### PR TITLE
Include bundled browser file for npm distribution

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,4 @@
 .idea
 npm-debug.log
 node_modules
-dist
 coverage


### PR DESCRIPTION
After looking at #24:

> I have excluded `sinon-chrome` bundle from git index last month, because it mess up git diffs.

I agree that the bundle should be in the `.gitignore` file, but why is it in `.npmignore`? The `prepublish` script looks like it's compiling the bundled file, but it's ignored from the npm release.

It would be nice to include the bundled file in npm so that it could be used by [projects that use sinon-chrome as a dependency](https://github.com/9joneg/karma-sinon-chrome) for browser tests. Currently you have to go into `node_modules/sinon-chrome` folder and manually build the bundle with webpack.