### PR TITLE
Introduce I18nPlugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,11 @@
       "name": "Vitaly Potapov",
       "email": "noginsk@rambler.ru",
       "url": "https://github.com/vitalets"
+    },
+    {
+      "name": "Sokratis Vidros",
+      "email": "sokratis.vidros@gmail.com",
+      "url": "https://github.com/SokratisVidros"
     }
   ],
   "repository": {

--- a/src/chrome-api/index.js
+++ b/src/chrome-api/index.js
@@ -9,6 +9,7 @@ import PropsFactory from '../factory/property';
 import Cache from '../factory/cache';
 
 import CookiePlugin from '../plugins/cookies';
+import I18nPlugin from '../plugins/i18n';
 
 /**
  * Create chrome api mock
@@ -51,6 +52,7 @@ const ChromeManager = {
      * plugin list
      */
     plugins: {
-        CookiePlugin
+        CookiePlugin,
+        I18nPlugin
     }
 };

--- a/src/plugins/i18n/index.js
+++ b/src/plugins/i18n/index.js
@@ -30,7 +30,9 @@ export default class ChromeI18n {
         function setPlaceholder(ignored, name) {
             const {content} = placeholders[name] || {};
 
-            if (!content) return undefined;
+            if (!content) {
+                return undefined;
+            }
 
             const index = Math.max(parseInt(content.replace('$', ''), 10) - 1, 0);
 

--- a/src/plugins/i18n/index.js
+++ b/src/plugins/i18n/index.js
@@ -1,0 +1,54 @@
+import {isEmpty} from 'lodash';
+
+export default class ChromeI18n {
+
+    constructor (translations = {}) {
+        this._translations = translations;
+    }
+
+    install (chrome) {
+        const plugin = this;
+        this.chrome = chrome;
+
+        Object.defineProperty(this.chrome, 'i18n', {
+            get: function () {
+                return plugin;
+            }
+        });
+    }
+
+    getMessage (messageName, ...substitutions) {
+        const {
+            message = undefined,
+            placeholders = {}
+        } = this._translations[messageName] || {};
+
+        if (isEmpty(substitutions) || isEmpty(placeholders)) {
+            return String(message);
+        }
+
+        function setPlaceholder(ignored, name) {
+            const {content} = placeholders[name] || {};
+
+            if (!content) return undefined;
+
+            const index = Math.max(parseInt(content.replace('$', ''), 10) - 1, 0);
+
+            return substitutions[index];
+        }
+
+        return message.replace(/\$([\w-]+)\$/g, setPlaceholder);
+    }
+
+    getAcceptLanguages (callback = () => {}) {
+        callback(['en-US', 'en', 'el', 'fr', 'it']);
+    }
+
+    getUILanguage () {
+        return 'en-US';
+    }
+
+    detectLanguage (text = '', callback = () => {}) {
+        callback('en-US');
+    }
+}

--- a/src/plugins/i18n/index.js
+++ b/src/plugins/i18n/index.js
@@ -1,11 +1,18 @@
 import {isEmpty} from 'lodash';
 
 export default class ChromeI18n {
-
+    /**
+     * @constructor
+     * @param {Object} translations
+     */
     constructor (translations = {}) {
         this._translations = translations;
     }
 
+    /**
+     * Install plugin
+     * @param {Object} chrome
+     */
     install (chrome) {
         const plugin = this;
         this.chrome = chrome;
@@ -17,6 +24,12 @@ export default class ChromeI18n {
         });
     }
 
+    /**
+     * Get message by name and apply provided substitutions
+     * @param {String} messageName
+     * @param {} substitutions
+     * @returns {String}
+     */
     getMessage (messageName, ...substitutions) {
         const {
             message = undefined,
@@ -27,7 +40,7 @@ export default class ChromeI18n {
             return String(message);
         }
 
-        function setPlaceholder(ignored, name) {
+        return message.replace(/\$([\w-]+)\$/g, (ignored, name) => {
             const {content} = placeholders[name] || {};
 
             if (!content) {
@@ -37,19 +50,30 @@ export default class ChromeI18n {
             const index = Math.max(parseInt(content.replace('$', ''), 10) - 1, 0);
 
             return substitutions[index];
-        }
-
-        return message.replace(/\$([\w-]+)\$/g, setPlaceholder);
+        });
     }
 
+    /**
+     * Get accept-languages from the browser
+     * @param {Function} callback
+     */
     getAcceptLanguages (callback = () => {}) {
         callback(['en-US', 'en', 'el', 'fr', 'it']);
     }
 
+    /**
+     * Get the browser UI language of the browser
+     * @returns {String}
+     */
     getUILanguage () {
         return 'en-US';
     }
 
+    /**
+     * Detect language from a given string
+     * @param {String} text
+     * @param {Function} callback
+     */
     detectLanguage (text = '', callback = () => {}) {
         callback('en-US');
     }

--- a/test/plugins/i18n/i18n.test.js
+++ b/test/plugins/i18n/i18n.test.js
@@ -44,8 +44,8 @@ describe('plugins/i18n', function () {
         });
 
         it('replaces message placeholders', function () {
-           assert.equal(chrome.i18n.getMessage('two', 'John', 'Doe'), 'Hi John Doe!');
-        })
+            assert.equal(chrome.i18n.getMessage('two', 'John', 'Doe'), 'Hi John Doe!');
+        });
 
         it('replace unknown message placeholders with "undefined', function () {
             assert.equal(chrome.i18n.getMessage('two', 'John'), 'Hi John undefined!');

--- a/test/plugins/i18n/i18n.test.js
+++ b/test/plugins/i18n/i18n.test.js
@@ -1,0 +1,76 @@
+import I18nPlugin from '../../../src/plugins/i18n';
+import createChromeApi from '../../../src/chrome-api';
+import * as is from '../../helpers/is';
+import mockTranslations from './translations.json';
+
+describe('plugins/i18n', function () {
+    const chrome = createChromeApi();
+
+    before(function () {
+        this.plugin = new I18nPlugin(mockTranslations);
+        chrome.registerPlugin(this.plugin);
+    });
+    after(function () {
+        delete this.plugin;
+        delete this.translations;
+    });
+
+    describe('install', function () {
+        it('should be defined', function () {
+            assert.isFunction(this.plugin.install);
+        });
+
+        it('should set i18n methods', function () {
+            assert.isFunction(chrome.i18n.install);
+            assert.isFunction(chrome.i18n.getMessage);
+            assert.isFunction(chrome.i18n.getAcceptLanguages);
+            assert.isFunction(chrome.i18n.getUILanguage);
+            assert.isFunction(chrome.i18n.detectLanguage);
+
+            assert.notOk(is.sinonStub(chrome.i18n.getMessage));
+            assert.notOk(is.sinonStub(chrome.i18n.getAcceptLanguages));
+            assert.notOk(is.sinonStub(chrome.i18n.getUILanguage));
+            assert.notOk(is.sinonStub(chrome.i18n.detectLanguage));
+        });
+    });
+
+    describe('getMessage', function () {
+        it('returns "undefined" for unknown messages', function () {
+            assert.equal(chrome.i18n.getMessage('unknown'), 'undefined');
+        });
+
+        it('returns the predefined message text', function () {
+            assert.equal(chrome.i18n.getMessage('one'), 'Hi!');
+        });
+
+        it('replaces message placeholders', function () {
+           assert.equal(chrome.i18n.getMessage('two', 'John', 'Doe'), 'Hi John Doe!');
+        })
+
+        it('replace unknown message placeholders with "undefined', function () {
+            assert.equal(chrome.i18n.getMessage('two', 'John'), 'Hi John undefined!');
+        });
+    });
+
+    describe('getAcceptLanguages', function () {
+        it('passes a mock array of accepted languages to callback', function () {
+            const spy = sinon.spy();
+            chrome.i18n.getAcceptLanguages(spy);
+            assert.ok(spy.calledWith(['en-US', 'en', 'el', 'fr', 'it']));
+        });
+    });
+
+    describe('getUILanguage', function () {
+        it('returns "en-US"', function () {
+            assert.equal(chrome.i18n.getUILanguage(), 'en-US');
+        });
+    });
+
+    describe('detectLanguage', function () {
+        it('passes "en-US" to callback', function () {
+            const spy = sinon.spy();
+            chrome.i18n.detectLanguage('test', spy);
+            assert.ok(spy.calledWith('en-US'));
+        });
+    });
+});

--- a/test/plugins/i18n/translations.json
+++ b/test/plugins/i18n/translations.json
@@ -1,0 +1,16 @@
+{
+    "one": {
+        "message": "Hi!"
+    },
+    "two": {
+        "message": "Hi $first_name$ $last_name$!",
+        "placeholders": {
+            "first_name": {
+                "content": "$1"
+            },
+            "last_name": {
+                "content": "$2"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hi there,

I've implemented a mock I18nPlugin in order to test Chrome extensions that rely heavily on i18n for their copywriting. As shown in the following snippet, the plugin can be used with the original translation file.

```
import translations from '../app/_locales/en/messages.json';
chrome = require('sinon-chrome');
chrome.registerPlugin(new global.chrome.plugins.I18nPlugin(translations));
```

Thanks in advance.