### PR TITLE
chai-as-promised is only used in tests, so it can be a devDependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
   },
   "license": "ISC",
   "dependencies": {
-    "chai-as-promised": "^6.0.0",
     "lodash": "^4.16.3",
     "sinon": "^1.17.6",
     "urijs": "^1.18.2"
@@ -73,6 +72,7 @@
     "babel-preset-es2015": "^6.16.0",
     "babel-register": "^6.16.3",
     "chai": "^3.5.0",
+    "chai-as-promised": "^6.0.0",
     "eslint": "^3.7.1",
     "eslint-plugin-import": "^2.0.0",
     "json-loader": "^0.5.4",


### PR DESCRIPTION
When I install the latest version of sinon-chrome (2.1.0), then I get:

```shell
- lodash@3.10.1 node_modules/sinon-chrome/node_modules/lodash
examplewebextension@0.0.1 /Users/mark/dev/example-webextension
└─┬ sinon-chrome@2.1.0 
  ├── UNMET PEER DEPENDENCY chai@>= 2.1.2 < 4
  └─┬ chai-as-promised@6.0.0 
    └── check-error@1.0.2 

npm WARN chai-as-promised@6.0.0 requires a peer of chai@>= 2.1.2 < 4 but none was installed.
```

`chai-as-promised` has a peer dependency of `chai` but `chai` isn't listed in the dependencies for `sinon-chrome`. However `chai-as-promised` appears to only be used for tests and not for the main library, so I think we can just move it to the devDependencies and installations should then be happy.