### PR TITLE
Make i18n.getMessage interoperable with message substitutions.

### DIFF
--- a/src/plugins/i18n/index.js
+++ b/src/plugins/i18n/index.js
@@ -1,4 +1,4 @@
-import {isEmpty} from 'lodash';
+import {isEmpty, flatten} from 'lodash';
 
 export default class ChromeI18n {
     /**
@@ -36,7 +36,9 @@ export default class ChromeI18n {
             placeholders = {}
         } = this._translations[messageName] || {};
 
-        if (isEmpty(substitutions) || isEmpty(placeholders)) {
+        const flattenSubstitutions = flatten(substitutions);
+
+        if (isEmpty(flattenSubstitutions) || isEmpty(placeholders)) {
             return String(message);
         }
 
@@ -49,7 +51,7 @@ export default class ChromeI18n {
 
             const index = Math.max(parseInt(content.replace('$', ''), 10) - 1, 0);
 
-            return substitutions[index];
+            return flattenSubstitutions[index];
         });
     }
 

--- a/test/plugins/i18n/i18n.test.js
+++ b/test/plugins/i18n/i18n.test.js
@@ -52,6 +52,10 @@ describe('plugins/i18n', function () {
         it('replace unknown message placeholders with "undefined', function () {
             assert.equal(chrome.i18n.getMessage('two', 'John'), 'Hi John undefined!');
         });
+
+        it('replace message placeholders after unfolding substitutions', function () {
+            assert.equal(chrome.i18n.getMessage('two', ['John'], 'Doe'), 'Hi John Doe!');
+        });
     });
 
     describe('getAcceptLanguages', function () {


### PR DESCRIPTION
That way, it will be able to replace message placeholders with array-folded substitutions.