### PR TITLE
Fixed package main

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "chrome api",
     "sinon"
   ],
-  "main": "out/index.js",
+  "main": "index.js",
   "scripts": {
     "clean": "rm -rf ./out/",
     "lint": "eslint ./src ./test",


### PR DESCRIPTION
@acvetkov This is actually a tricky bug.

Previous versions (<=v.2.2.1) worked because module resolver loaded the `index.js` after failing resolving `out/index.js` in `package.json` .

While v2.2.2 and v2.2.3 worked because you accidentally published the source repo. There is actually an `out/index.js`. But `require('sinon-chrome/extensions')` and `require('sinon-chrome/webextensions')` break because they are also in `./out`.

Perhaps you should `npm publish` within `./out`?