### PR TITLE
Update to sinon@4

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,12 +55,12 @@
     "predeploy": "npm run clean && npm run lint && npm test && npm run build && npm run copy2out",
     "bundle": "webpack",
     "bundle-dev": "webpack --watch --progress",
-    "copy2out": "cp ./README.md ./out/README.md && cp ./package.json ./out/package.json && cp -R ./dist out/bundle"
+    "copy2out": "cp ./readme.md ./out/readme.md && cp ./package.json ./out/package.json && cp -R ./dist out/bundle"
   },
   "license": "ISC",
   "dependencies": {
     "lodash": "^4.16.3",
-    "sinon": "^2.1.0",
+    "sinon": "^4.4.2",
     "urijs": "^1.18.2"
   },
   "devDependencies": {

--- a/src/api/events.js
+++ b/src/api/events.js
@@ -35,7 +35,8 @@ export default class EventsCache extends BaseCache {
      * Remove all listeners
      */
     reset() {
-        this.sandbox.reset();
+        this.sandbox.resetHistory();
+        this.sandbox.resetBehavior();
         forEach(this.events, event => {
             event.removeListeners();
         });

--- a/src/api/stub.js
+++ b/src/api/stub.js
@@ -69,6 +69,9 @@ export default class StubsCache extends BaseCache {
      * Reset sinon stubs
      */
     reset() {
-        Object.keys(this.stubs).forEach(key => this.stubs[key].reset());
+        Object.keys(this.stubs).forEach(key => {
+          this.stubs[key].resetHistory();
+          this.stubs[key].resetBehavior();
+        });
     }
 }

--- a/test/specs/chrome-extensions.test.js
+++ b/test/specs/chrome-extensions.test.js
@@ -22,12 +22,12 @@ describe('extensions', function () {
     describe('chrome.reset', function () {
 
         before(function () {
-            chrome.runtime.sendMessage.reset();
+            chrome.runtime.sendMessage.resetHistory();
             chrome.runtime.sendMessage.resetBehavior();
         });
 
         after(function () {
-            chrome.runtime.sendMessage.reset();
+            chrome.runtime.sendMessage.resetHistory();
             chrome.runtime.sendMessage.resetBehavior();
         });
 
@@ -74,14 +74,14 @@ describe('extensions', function () {
     describe('chrome.flush', function () {
 
         before(function () {
-            chrome.runtime.sendMessage.reset();
+            chrome.runtime.sendMessage.resetHistory();
             chrome.runtime.sendMessage.resetBehavior();
             chrome.runtime.getURL.resetBehavior();
-            chrome.runtime.getURL.reset();
+            chrome.runtime.getURL.resetHistory();
         });
 
         after(function () {
-            chrome.runtime.sendMessage.reset();
+            chrome.runtime.sendMessage.resetHistory();
             chrome.runtime.sendMessage.resetBehavior();
             chrome.runtime.getURL.resetBehavior();
         });

--- a/test/specs/chrome.methods.test.js
+++ b/test/specs/chrome.methods.test.js
@@ -39,7 +39,7 @@ function generateMethodSuite(chrome, method, namespace, prefix) {
         it('should have stub sync behaviour', function () {
             const stub = _.get(chrome, `${namespace}.${method}`);
             const a = 'a';
-            stub.reset();
+            stub.resetHistory();
             stub.resetBehavior();
             stub.returns(a);
             assert.equal(stub(), a);
@@ -50,7 +50,7 @@ function generateMethodSuite(chrome, method, namespace, prefix) {
             const spy = sinon.spy();
             assert.notCalled(spy);
 
-            stub.reset();
+            stub.resetHistory();
             stub.resetBehavior();
             stub.yields(spy);
             stub(spy);
@@ -59,7 +59,7 @@ function generateMethodSuite(chrome, method, namespace, prefix) {
 
         it('should flush stub', function () {
             let stub = _.get(chrome, `${namespace}.${method}`);
-            stub.reset();
+            stub.resetHistory();
             stub.resetBehavior();
             stub.yields([1, 2]);
             const spy1 = sinon.spy();

--- a/test/specs/chrome.test.js
+++ b/test/specs/chrome.test.js
@@ -8,12 +8,12 @@ import chrome from '../../src/index';
 describe('chrome/reset', function () {
 
     before(function () {
-        chrome.runtime.sendMessage.reset();
+        chrome.runtime.sendMessage.resetHistory();
         chrome.runtime.sendMessage.resetBehavior();
     });
 
     after(function () {
-        chrome.runtime.sendMessage.reset();
+        chrome.runtime.sendMessage.resetHistory();
         chrome.runtime.sendMessage.resetBehavior();
     });
 
@@ -60,14 +60,14 @@ describe('chrome/reset', function () {
 describe('chrome/flush', function () {
 
     before(function () {
-        chrome.runtime.sendMessage.reset();
+        chrome.runtime.sendMessage.resetHistory();
         chrome.runtime.sendMessage.resetBehavior();
         chrome.runtime.getURL.resetBehavior();
-        chrome.runtime.getURL.reset();
+        chrome.runtime.getURL.resetHistory();
     });
 
     after(function () {
-        chrome.runtime.sendMessage.reset();
+        chrome.runtime.sendMessage.resetHistory();
         chrome.runtime.sendMessage.resetBehavior();
         chrome.runtime.getURL.resetBehavior();
     });


### PR DESCRIPTION
Hi, thanks for your work on sinon-chrome.

sinon@4.4.0 got a [PR](https://github.com/sinonjs/sinon/pull/1689) merged which introduces to get the return values of callbacks when `yield`ing, which we rely on in our WebExtension tests. Would be awesome if you could update sinon.

However, sinon deprecated `.reset` in favor of explicitly calling `.resetBehavior` and `.resetHistory`. I've updated the code accordingly.

Best regards