### PR TITLE
Expose and allow to pass in sinon instance

### DIFF
--- a/src/api/events.js
+++ b/src/api/events.js
@@ -4,13 +4,12 @@
  */
 
 import {forEach} from 'lodash';
-import sinon from 'sinon';
 import ChromeEvent from '../events/index';
 import BaseCache from './cache';
 
 export default class EventsCache extends BaseCache {
 
-    constructor() {
+    constructor(sinon) {
         super();
         this.events = Object.create(null);
         this.sandbox = sinon.sandbox.create();

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -4,6 +4,7 @@
  */
 
 import {set, get, reduce, assign} from 'lodash';
+import sinon from 'sinon';
 import Stubs from './stub';
 import Events from './events';
 import Props from './props';
@@ -29,11 +30,12 @@ export default class Api {
     /**
      * @param {Array<Object>} config
      */
-    constructor(config) {
+    constructor(config, options = {}) {
+        this.sinon = options.sinon ? options.sinon : sinon;
         this.NS_RULE = /^(.+)\.(.+)$/;
         this.config = config;
-        this.stubs = new Stubs();
-        this.events = new Events();
+        this.stubs = new Stubs(this.sinon);
+        this.events = new Events(this.sinon);
         this.props = new Props();
         this.manager = new Manager(this.stubs, this.events, this.props);
     }

--- a/src/api/stub.js
+++ b/src/api/stub.js
@@ -3,14 +3,14 @@
  * @overview Subs cache
  */
 
-import sinon from 'sinon';
 import BaseCache from './cache';
 
 export default class StubsCache extends BaseCache {
 
-    constructor() {
+    constructor(sinon) {
         super();
         this.stubs = Object.create(null);
+        this.sinon = sinon;
     }
 
     /**
@@ -42,7 +42,7 @@ export default class StubsCache extends BaseCache {
      * @returns {Function}
      */
     create(key) {
-        const stub = sinon.stub();
+        const stub = this.sinon.stub();
         stub.flush = () => {
             this.deleteStub(key);
         };


### PR DESCRIPTION
Allows to work around #67 if one uses the API directly to create a sinon-chrome instance. [Here's an example how I'm doing it](https://github.com/stoically/webextensions-api-fake/blob/master/src/index.js#L14-L16).

Might be worth thinking about exposing that possibility to the default way of getting an instance too.