### PR TITLE
Set props and methods as enumerable and configurable

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -81,7 +81,9 @@ export default class Api {
             Object.defineProperty(result, func.name, {
                 get: function () {
                     return stubs.get(func.name, namespace);
-                }
+                },
+                enumerable: true,
+                configurable: true
             });
             return obj;
         }, obj);
@@ -99,7 +101,9 @@ export default class Api {
             Object.defineProperty(result, event.name, {
                 get: function () {
                     return ev.get(event.name, namespace);
-                }
+                },
+                enumerable: true,
+                configurable: true
             });
             return obj;
         }, obj);
@@ -155,7 +159,9 @@ export default class Api {
             return Object.defineProperty(obj, prop, {
                 get() {
                     return instance.get();
-                }
+                },
+                enumerable: true,
+                configurable: true
             });
         }
         const property = this.props.get(prop, `${namespace}`, value);
@@ -165,7 +171,9 @@ export default class Api {
             },
             set(newValue) {
                 property.current = newValue;
-            }
+            },
+            enumerable: true,
+            configurable: true
         });
     }
 }

--- a/test/specs/chrome.test.js
+++ b/test/specs/chrome.test.js
@@ -129,3 +129,45 @@ describe('chrome/flush', function () {
         assert.isNull(chrome.runtime.id);
     });
 });
+
+describe.only('chrome api', function () {
+
+    describe('functions', function () {
+
+        it('should be enumerable', function () {
+            const descriptor = Object.getOwnPropertyDescriptor(chrome.tabs, 'create');
+            assert(descriptor.enumerable);
+        });
+
+        it('should be configurable', function () {
+            const descriptor = Object.getOwnPropertyDescriptor(chrome.tabs, 'create');
+            assert(descriptor.configurable);
+        });
+    });
+
+    describe('props', function () {
+
+        it('should be enumerable', function () {
+            const descriptor = Object.getOwnPropertyDescriptor(chrome.runtime, 'id');
+            assert(descriptor.enumerable);
+        });
+
+        it('should be configurable', function () {
+            const descriptor = Object.getOwnPropertyDescriptor(chrome.runtime, 'id');
+            assert(descriptor.configurable);
+        });
+    });
+
+    describe('events', function () {
+
+        it('should be enumerable', function () {
+            const descriptor = Object.getOwnPropertyDescriptor(chrome.tabs, 'onCreated');
+            assert(descriptor.enumerable);
+        });
+
+        it('should be configurable', function () {
+            const descriptor = Object.getOwnPropertyDescriptor(chrome.tabs, 'onCreated');
+            assert(descriptor.configurable);
+        });
+    });
+});


### PR DESCRIPTION
When using the `chrome` API in the browser, the methods and props are enumerable:

```js
Object.getOwnPropertyDescriptor(chrome.tabs, 'create')
// {writable: true, enumerable: true, configurable: true, value: function}
```

When using `sinon-chrome`, the methods and props are not enumerable

```js
Object.getOwnPropertyDescriptor(chrome.tabs, 'create')
// {get: function, set: undefined, enumerable: false, configurable: false}
```

This PR creates methods, props and events as enumerable and configurable.