### PR TITLE
Sinon update and sandbox creation change to prevent deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "license": "ISC",
   "dependencies": {
     "lodash": "^4.16.3",
-    "sinon": "^4.4.2",
+    "sinon": "^7.2.3",
     "urijs": "^1.18.2"
   },
   "devDependencies": {

--- a/src/api/events.js
+++ b/src/api/events.js
@@ -12,7 +12,7 @@ export default class EventsCache extends BaseCache {
     constructor(sinon) {
         super();
         this.events = Object.create(null);
-        this.sandbox = sinon.sandbox.create();
+        this.sandbox = sinon.createSandbox();
     }
 
     /**


### PR DESCRIPTION
When using sinon-chrome with sinon versions 5 and later the following deprecation warning pops up:

> `sandbox.create()` is deprecated. Use default sandbox at `sinon.sandbox` or create new sandboxes with `sinon.createSandbox()`

According to the migration guide https://sinonjs.org/guides/migrating-to-5.0.html a change from `sinon.sandbox.create` to `sinon.createSandbox` is needed.