### PR TITLE
Reset sinon sandbox when flushing to prevent memory leak

### DIFF
--- a/src/api/stub.js
+++ b/src/api/stub.js
@@ -63,6 +63,7 @@ export default class StubsCache extends BaseCache {
      */
     flush() {
         this.stubs = Object.create(null);
+        this.sinon.restore();
     }
 
     /**
@@ -73,5 +74,6 @@ export default class StubsCache extends BaseCache {
           this.stubs[key].resetHistory();
           this.stubs[key].resetBehavior();
         });
+        this.sinon.restore();
     }
 }


### PR DESCRIPTION
Since version 5, [sinon is itself a sandbox](https://sinonjs.org/releases/latest/general-setup/). Creating stubs results in a [memory leak](https://github.com/sinonjs/sinon/issues/1866) if not restored properly, so we should do that when `flush` or `reset` is called.