### PR TITLE
Add update script and update Firefox schemas to 69

### DIFF
--- a/fetch-firefox-schemas.py
+++ b/fetch-firefox-schemas.py
@@ -1,0 +1,66 @@
+#!/usr/bin/python3
+
+import json
+import re
+import sys
+from http.client import HTTPSConnection
+from operator import itemgetter
+
+moz = 'hg.mozilla.org'
+# Find the revision for latest release
+# https://hg.mozilla.org/releases/mozilla-release/tags
+base_path = '/releases/mozilla-release/raw-file/'
+
+def main():
+    if len(sys.argv) != 2:
+        print("Needs revision as argument")
+        return
+    rev = sys.argv[1]
+    toolkit_path = base_path + rev + '/toolkit/components/extensions/schemas/'
+    browser_path = base_path + rev + '/browser/components/extensions/schemas/'
+
+    conn = HTTPSConnection(moz)
+    sch_items = fetch_json_links(conn, toolkit_path)
+    sch_items.extend(fetch_json_links(conn, browser_path))
+    # Sort items
+    sch_items.sort(key=itemgetter(0))
+
+    schemas = []
+    for file_name, path in sch_items:
+        fetch_json_schema(conn, path + file_name, schemas)
+    print(json.dumps(schemas, sort_keys=True, indent=2))
+
+
+def fetch_json_links(conn, path):
+    """
+    Given a directory path create a list of json files
+    """
+    conn.request('GET', path)
+    response = conn.getresponse()
+    links = []
+
+    for file_entry in response.read().decode('utf-8').strip().split('\n'):
+        if file_entry:
+            # File should be safe (that is, no spaces)
+            file_name = file_entry.split(' ')[2]
+            if '.json' == file_name[-5:]:
+                links.append((file_name, path))
+    return links
+
+
+def fetch_json_schema(conn, path, schemas):
+    """
+    Given a file path fetch the schema object
+    """
+    conn.request('GET', path)
+    response = conn.getresponse()
+    remove_comments = re.sub('(?m)^(//|/\*| \*).*$', '', response.read().decode('utf-8'))
+    for sch in json.loads(remove_comments):
+        # TODO: Figure out how to properly implement 'extend' properties
+        if 'native_manifest.json' in path or \
+            ('manifest.json' not in path and sch['namespace'] == 'manifest'):
+            continue
+        else:
+            schemas.append(sch)
+
+main()

--- a/src/config/stable-api-ff.json
+++ b/src/config/stable-api-ff.json
@@ -2,6183 +2,6816 @@
   {
     "events": [
       {
-        "description": "Fired when an alarm has expired. Useful for transient background pages.", 
-        "name": "onAlarm", 
+        "description": "Fired when an alarm has expired. Useful for transient background pages.",
+        "name": "onAlarm",
         "parameters": [
           {
-            "$ref": "Alarm", 
-            "description": "The alarm that has expired.", 
+            "$ref": "Alarm",
+            "description": "The alarm that has expired.",
             "name": "name"
           }
-        ], 
+        ],
         "type": "function"
       }
-    ], 
+    ],
     "functions": [
       {
-        "description": "Creates an alarm. After the delay is expired, the onAlarm event is fired. If there is another alarm with the same name (or no name if none is specified), it will be cancelled and replaced by this alarm.", 
-        "name": "create", 
+        "description": "Creates an alarm. After the delay is expired, the onAlarm event is fired. If there is another alarm with the same name (or no name if none is specified), it will be cancelled and replaced by this alarm.",
+        "name": "create",
         "parameters": [
           {
-            "description": "Optional name to identify this alarm. Defaults to the empty string.", 
-            "name": "name", 
-            "optional": true, 
+            "description": "Optional name to identify this alarm. Defaults to the empty string.",
+            "name": "name",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           {
-            "description": "Details about the alarm. The alarm first fires either at 'when' milliseconds past the epoch (if 'when' is provided), after 'delayInMinutes' minutes from the current time (if 'delayInMinutes' is provided instead), or after 'periodInMinutes' minutes from the current time (if only 'periodInMinutes' is provided). Users should never provide both 'when' and 'delayInMinutes'. If 'periodInMinutes' is provided, then the alarm recurs repeatedly after that many minutes.", 
-            "name": "alarmInfo", 
+            "description": "Details about the alarm. The alarm first fires either at 'when' milliseconds past the epoch (if 'when' is provided), after 'delayInMinutes' minutes from the current time (if 'delayInMinutes' is provided instead), or after 'periodInMinutes' minutes from the current time (if only 'periodInMinutes' is provided). Users should never provide both 'when' and 'delayInMinutes'. If 'periodInMinutes' is provided, then the alarm recurs repeatedly after that many minutes.",
+            "name": "alarmInfo",
             "properties": {
               "delayInMinutes": {
-                "description": "Number of minutes from the current time after which the alarm should first fire.", 
-                "optional": true, 
+                "description": "Number of minutes from the current time after which the alarm should first fire.",
+                "optional": true,
                 "type": "number"
-              }, 
+              },
               "periodInMinutes": {
-                "description": "Number of minutes after which the alarm should recur repeatedly.", 
-                "optional": true, 
+                "description": "Number of minutes after which the alarm should recur repeatedly.",
+                "optional": true,
                 "type": "number"
-              }, 
+              },
               "when": {
-                "description": "Time when the alarm is scheduled to first fire, in milliseconds past the epoch.", 
-                "optional": true, 
+                "description": "Time when the alarm is scheduled to first fire, in milliseconds past the epoch.",
+                "optional": true,
                 "type": "number"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Retrieves details about the specified alarm.", 
-        "name": "get", 
+        "async": "callback",
+        "description": "Retrieves details about the specified alarm.",
+        "name": "get",
         "parameters": [
           {
-            "description": "The name of the alarm to get. Defaults to the empty string.", 
-            "name": "name", 
-            "optional": true, 
+            "description": "The name of the alarm to get. Defaults to the empty string.",
+            "name": "name",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
-                "$ref": "Alarm", 
-                "name": "alarm", 
+                "$ref": "Alarm",
+                "name": "alarm",
                 "optional": true
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Gets an array of all the alarms.", 
-        "name": "getAll", 
+        "async": "callback",
+        "description": "Gets an array of all the alarms.",
+        "name": "getAll",
         "parameters": [
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
                 "items": {
                   "$ref": "Alarm"
-                }, 
-                "name": "alarms", 
+                },
+                "name": "alarms",
                 "type": "array"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Clears the alarm with the given name.", 
-        "name": "clear", 
+        "async": "callback",
+        "description": "Clears the alarm with the given name.",
+        "name": "clear",
         "parameters": [
           {
-            "description": "The name of the alarm to clear. Defaults to the empty string.", 
-            "name": "name", 
-            "optional": true, 
+            "description": "The name of the alarm to clear. Defaults to the empty string.",
+            "name": "name",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
-                "description": "Whether an alarm of the given name was found to clear.", 
-                "name": "wasCleared", 
+                "description": "Whether an alarm of the given name was found to clear.",
+                "name": "wasCleared",
                 "type": "boolean"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Clears all alarms.", 
-        "name": "clearAll", 
+        "async": "callback",
+        "description": "Clears all alarms.",
+        "name": "clearAll",
         "parameters": [
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
-                "description": "Whether any alarm was found to clear.", 
-                "name": "wasCleared", 
+                "description": "Whether any alarm was found to clear.",
+                "name": "wasCleared",
                 "type": "boolean"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
       }
-    ], 
-    "namespace": "alarms", 
+    ],
+    "namespace": "alarms",
     "permissions": [
       "alarms"
-    ], 
+    ],
     "types": [
       {
-        "id": "Alarm", 
+        "id": "Alarm",
         "properties": {
           "name": {
-            "description": "Name of this alarm.", 
+            "description": "Name of this alarm.",
             "type": "string"
-          }, 
+          },
           "periodInMinutes": {
-            "description": "When present, signals that the alarm triggers periodically after so many minutes.", 
-            "optional": true, 
+            "description": "When present, signals that the alarm triggers periodically after so many minutes.",
+            "optional": true,
             "type": "number"
-          }, 
+          },
           "scheduledTime": {
-            "description": "Time when the alarm is scheduled to fire, in milliseconds past the epoch.", 
+            "description": "Time when the alarm is scheduled to fire, in milliseconds past the epoch.",
             "type": "number"
           }
-        }, 
+        },
         "type": "object"
       }
     ]
-  }, 
+  },
   {
-    "description": "Use the <code>browser.bookmarks</code> API to create, organize, and otherwise manipulate bookmarks. Also see $(topic:override)[Override Pages], which you can use to create a custom Bookmark Manager page.", 
+    "description": "Use the <code>browser.bookmarks</code> API to create, organize, and otherwise manipulate bookmarks. Also see $(topic:override)[Override Pages], which you can use to create a custom Bookmark Manager page.",
     "events": [
       {
-        "description": "Fired when a bookmark or folder is created.", 
-        "name": "onCreated", 
+        "description": "Fired when a bookmark or folder is created.",
+        "name": "onCreated",
         "parameters": [
           {
-            "name": "id", 
+            "name": "id",
             "type": "string"
-          }, 
+          },
           {
-            "$ref": "BookmarkTreeNode", 
+            "$ref": "BookmarkTreeNode",
             "name": "bookmark"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Fired when a bookmark or folder is removed.  When a folder is removed recursively, a single notification is fired for the folder, and none for its contents.", 
-        "name": "onRemoved", 
+        "description": "Fired when a bookmark or folder is removed.  When a folder is removed recursively, a single notification is fired for the folder, and none for its contents.",
+        "name": "onRemoved",
         "parameters": [
           {
-            "name": "id", 
+            "name": "id",
             "type": "string"
-          }, 
+          },
           {
-            "name": "removeInfo", 
+            "name": "removeInfo",
             "properties": {
               "index": {
                 "type": "integer"
-              }, 
+              },
               "node": {
                 "$ref": "BookmarkTreeNode"
-              }, 
+              },
               "parentId": {
                 "type": "string"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Fired when a bookmark or folder changes.  <b>Note:</b> Currently, only title and url changes trigger this.", 
-        "name": "onChanged", 
+        "description": "Fired when a bookmark or folder changes.  <b>Note:</b> Currently, only title and url changes trigger this.",
+        "name": "onChanged",
         "parameters": [
           {
-            "name": "id", 
+            "name": "id",
             "type": "string"
-          }, 
+          },
           {
-            "name": "changeInfo", 
+            "name": "changeInfo",
             "properties": {
               "title": {
                 "type": "string"
-              }, 
+              },
               "url": {
-                "optional": true, 
+                "optional": true,
                 "type": "string"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Fired when a bookmark or folder is moved to a different parent folder.", 
-        "name": "onMoved", 
+        "description": "Fired when a bookmark or folder is moved to a different parent folder.",
+        "name": "onMoved",
         "parameters": [
           {
-            "name": "id", 
+            "name": "id",
             "type": "string"
-          }, 
+          },
           {
-            "name": "moveInfo", 
+            "name": "moveInfo",
             "properties": {
               "index": {
                 "type": "integer"
-              }, 
+              },
               "oldIndex": {
                 "type": "integer"
-              }, 
+              },
               "oldParentId": {
                 "type": "string"
-              }, 
+              },
               "parentId": {
                 "type": "string"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Fired when the children of a folder have changed their order due to the order being sorted in the UI.  This is not called as a result of a move().", 
-        "name": "onChildrenReordered", 
+        "description": "Fired when the children of a folder have changed their order due to the order being sorted in the UI.  This is not called as a result of a move().",
+        "name": "onChildrenReordered",
         "parameters": [
           {
-            "name": "id", 
+            "name": "id",
             "type": "string"
-          }, 
+          },
           {
-            "name": "reorderInfo", 
+            "name": "reorderInfo",
             "properties": {
               "childIds": {
                 "items": {
                   "type": "string"
-                }, 
+                },
                 "type": "array"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
-      }, 
+      },
       {
-        "description": "Fired when a bookmark import session is begun.  Expensive observers should ignore onCreated updates until onImportEnded is fired.  Observers should still handle other notifications immediately.", 
-        "name": "onImportBegan", 
-        "parameters": [], 
-        "type": "function", 
+        "description": "Fired when a bookmark import session is begun.  Expensive observers should ignore onCreated updates until onImportEnded is fired.  Observers should still handle other notifications immediately.",
+        "name": "onImportBegan",
+        "parameters": [],
+        "type": "function",
         "unsupported": true
-      }, 
+      },
       {
-        "description": "Fired when a bookmark import session is ended.", 
-        "name": "onImportEnded", 
-        "parameters": [], 
-        "type": "function", 
+        "description": "Fired when a bookmark import session is ended.",
+        "name": "onImportEnded",
+        "parameters": [],
+        "type": "function",
         "unsupported": true
       }
-    ], 
+    ],
     "functions": [
       {
-        "async": "callback", 
-        "description": "Retrieves the specified BookmarkTreeNode(s).", 
-        "name": "get", 
+        "async": "callback",
+        "description": "Retrieves the specified BookmarkTreeNode(s).",
+        "name": "get",
         "parameters": [
           {
             "choices": [
               {
                 "type": "string"
-              }, 
+              },
               {
                 "items": {
                   "type": "string"
-                }, 
-                "minItems": 1, 
+                },
+                "minItems": 1,
                 "type": "array"
               }
-            ], 
-            "description": "A single string-valued id, or an array of string-valued ids", 
+            ],
+            "description": "A single string-valued id, or an array of string-valued ids",
             "name": "idOrIdList"
-          }, 
+          },
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
                 "items": {
                   "$ref": "BookmarkTreeNode"
-                }, 
-                "name": "results", 
+                },
+                "name": "results",
                 "type": "array"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Retrieves the children of the specified BookmarkTreeNode id.", 
-        "name": "getChildren", 
+        "async": "callback",
+        "description": "Retrieves the children of the specified BookmarkTreeNode id.",
+        "name": "getChildren",
         "parameters": [
           {
-            "name": "id", 
+            "name": "id",
             "type": "string"
-          }, 
+          },
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
                 "items": {
                   "$ref": "BookmarkTreeNode"
-                }, 
-                "name": "results", 
+                },
+                "name": "results",
                 "type": "array"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Retrieves the recently added bookmarks.", 
-        "name": "getRecent", 
+        "async": "callback",
+        "description": "Retrieves the recently added bookmarks.",
+        "name": "getRecent",
         "parameters": [
           {
-            "description": "The maximum number of items to return.", 
-            "minimum": 1, 
-            "name": "numberOfItems", 
+            "description": "The maximum number of items to return.",
+            "minimum": 1,
+            "name": "numberOfItems",
             "type": "integer"
-          }, 
+          },
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
                 "items": {
                   "$ref": "BookmarkTreeNode"
-                }, 
-                "name": "results", 
+                },
+                "name": "results",
                 "type": "array"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Retrieves the entire Bookmarks hierarchy.", 
-        "name": "getTree", 
+        "async": "callback",
+        "description": "Retrieves the entire Bookmarks hierarchy.",
+        "name": "getTree",
         "parameters": [
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
                 "items": {
                   "$ref": "BookmarkTreeNode"
-                }, 
-                "name": "results", 
+                },
+                "name": "results",
                 "type": "array"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Retrieves part of the Bookmarks hierarchy, starting at the specified node.", 
-        "name": "getSubTree", 
+        "async": "callback",
+        "description": "Retrieves part of the Bookmarks hierarchy, starting at the specified node.",
+        "name": "getSubTree",
         "parameters": [
           {
-            "description": "The ID of the root of the subtree to retrieve.", 
-            "name": "id", 
+            "description": "The ID of the root of the subtree to retrieve.",
+            "name": "id",
             "type": "string"
-          }, 
+          },
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
                 "items": {
                   "$ref": "BookmarkTreeNode"
-                }, 
-                "name": "results", 
+                },
+                "name": "results",
                 "type": "array"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Searches for BookmarkTreeNodes matching the given query. Queries specified with an object produce BookmarkTreeNodes matching all specified properties.", 
-        "name": "search", 
+        "async": "callback",
+        "description": "Searches for BookmarkTreeNodes matching the given query. Queries specified with an object produce BookmarkTreeNodes matching all specified properties.",
+        "name": "search",
         "parameters": [
           {
             "choices": [
               {
-                "description": "A string of words and quoted phrases that are matched against bookmark URLs and titles.", 
+                "description": "A string of words and quoted phrases that are matched against bookmark URLs and titles.",
                 "type": "string"
-              }, 
+              },
               {
-                "description": "An object specifying properties and values to match when searching. Produces bookmarks matching all properties.", 
+                "description": "An object specifying properties and values to match when searching. Produces bookmarks matching all properties.",
                 "properties": {
                   "query": {
-                    "description": "A string of words and quoted phrases that are matched against bookmark URLs and titles.", 
-                    "optional": true, 
+                    "description": "A string of words and quoted phrases that are matched against bookmark URLs and titles.",
+                    "optional": true,
                     "type": "string"
-                  }, 
+                  },
                   "title": {
-                    "description": "The title of the bookmark; matches verbatim.", 
-                    "optional": true, 
+                    "description": "The title of the bookmark; matches verbatim.",
+                    "optional": true,
                     "type": "string"
-                  }, 
+                  },
                   "url": {
-                    "description": "The URL of the bookmark; matches verbatim. Note that folders have no URL.", 
-                    "format": "url", 
-                    "optional": true, 
+                    "description": "The URL of the bookmark; matches verbatim. Note that folders have no URL.",
+                    "format": "url",
+                    "optional": true,
                     "type": "string"
                   }
-                }, 
+                },
                 "type": "object"
               }
-            ], 
-            "description": "Either a string of words and quoted phrases that are matched against bookmark URLs and titles, or an object. If an object, the properties <code>query</code>, <code>url</code>, and <code>title</code> may be specified and bookmarks matching all specified properties will be produced.", 
+            ],
+            "description": "Either a string of words and quoted phrases that are matched against bookmark URLs and titles, or an object. If an object, the properties <code>query</code>, <code>url</code>, and <code>title</code> may be specified and bookmarks matching all specified properties will be produced.",
             "name": "query"
-          }, 
+          },
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
                 "items": {
                   "$ref": "BookmarkTreeNode"
-                }, 
-                "name": "results", 
+                },
+                "name": "results",
                 "type": "array"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Creates a bookmark or folder under the specified parentId.  If url is NULL or missing, it will be a folder.", 
-        "name": "create", 
+        "async": "callback",
+        "description": "Creates a bookmark or folder under the specified parentId.  If url is NULL or missing, it will be a folder.",
+        "name": "create",
         "parameters": [
           {
-            "$ref": "CreateDetails", 
+            "$ref": "CreateDetails",
             "name": "bookmark"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
+            "name": "callback",
+            "optional": true,
             "parameters": [
               {
-                "$ref": "BookmarkTreeNode", 
+                "$ref": "BookmarkTreeNode",
                 "name": "result"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Moves the specified BookmarkTreeNode to the provided location.", 
-        "name": "move", 
+        "async": "callback",
+        "description": "Moves the specified BookmarkTreeNode to the provided location.",
+        "name": "move",
         "parameters": [
           {
-            "name": "id", 
+            "name": "id",
             "type": "string"
-          }, 
+          },
           {
-            "name": "destination", 
+            "name": "destination",
             "properties": {
               "index": {
-                "minimum": 0, 
-                "optional": true, 
+                "minimum": 0,
+                "optional": true,
                 "type": "integer"
-              }, 
+              },
               "parentId": {
-                "optional": true, 
+                "optional": true,
                 "type": "string"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
+            "name": "callback",
+            "optional": true,
             "parameters": [
               {
-                "$ref": "BookmarkTreeNode", 
+                "$ref": "BookmarkTreeNode",
                 "name": "result"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Updates the properties of a bookmark or folder. Specify only the properties that you want to change; unspecified properties will be left unchanged.  <b>Note:</b> Currently, only 'title' and 'url' are supported.", 
-        "name": "update", 
+        "async": "callback",
+        "description": "Updates the properties of a bookmark or folder. Specify only the properties that you want to change; unspecified properties will be left unchanged.  <b>Note:</b> Currently, only 'title' and 'url' are supported.",
+        "name": "update",
         "parameters": [
           {
-            "name": "id", 
+            "name": "id",
             "type": "string"
-          }, 
+          },
           {
-            "name": "changes", 
+            "name": "changes",
             "properties": {
               "title": {
-                "optional": true, 
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "url": {
-                "optional": true, 
+                "optional": true,
                 "type": "string"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
+            "name": "callback",
+            "optional": true,
             "parameters": [
               {
-                "$ref": "BookmarkTreeNode", 
+                "$ref": "BookmarkTreeNode",
                 "name": "result"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Removes a bookmark or an empty bookmark folder.", 
-        "name": "remove", 
+        "async": "callback",
+        "description": "Removes a bookmark or an empty bookmark folder.",
+        "name": "remove",
         "parameters": [
           {
-            "name": "id", 
+            "name": "id",
             "type": "string"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Recursively removes a bookmark folder.", 
-        "name": "removeTree", 
+        "async": "callback",
+        "description": "Recursively removes a bookmark folder.",
+        "name": "removeTree",
         "parameters": [
           {
-            "name": "id", 
+            "name": "id",
             "type": "string"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Imports bookmarks from an html bookmark file", 
-        "name": "import", 
+        "async": "callback",
+        "description": "Imports bookmarks from an html bookmark file",
+        "name": "import",
         "parameters": [
           {
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Exports bookmarks to an html bookmark file", 
-        "name": "export", 
+        "async": "callback",
+        "description": "Exports bookmarks to an html bookmark file",
+        "name": "export",
         "parameters": [
           {
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
       }
-    ], 
-    "namespace": "bookmarks", 
+    ],
+    "namespace": "bookmarks",
     "permissions": [
       "bookmarks"
-    ], 
+    ],
     "types": [
       {
-        "description": "Indicates the reason why this node is unmodifiable. The <var>managed</var> value indicates that this node was configured by the system administrator or by the custodian of a supervised user. Omitted if the node can be modified by the user and the extension (default).", 
+        "description": "Indicates the reason why this node is unmodifiable. The <var>managed</var> value indicates that this node was configured by the system administrator or by the custodian of a supervised user. Omitted if the node can be modified by the user and the extension (default).",
         "enum": [
           "managed"
-        ], 
-        "id": "BookmarkTreeNodeUnmodifiable", 
+        ],
+        "id": "BookmarkTreeNodeUnmodifiable",
         "type": "string"
-      }, 
+      },
       {
-        "description": "Indicates the type of a BookmarkTreeNode, which can be one of bookmark, folder or separator.", 
+        "description": "Indicates the type of a BookmarkTreeNode, which can be one of bookmark, folder or separator.",
         "enum": [
-          "bookmark", 
-          "folder", 
+          "bookmark",
+          "folder",
           "separator"
-        ], 
-        "id": "BookmarkTreeNodeType", 
+        ],
+        "id": "BookmarkTreeNodeType",
         "type": "string"
-      }, 
+      },
       {
-        "description": "A node (either a bookmark or a folder) in the bookmark tree.  Child nodes are ordered within their parent folder.", 
-        "id": "BookmarkTreeNode", 
+        "description": "A node (either a bookmark or a folder) in the bookmark tree.  Child nodes are ordered within their parent folder.",
+        "id": "BookmarkTreeNode",
         "properties": {
           "children": {
-            "description": "An ordered list of children of this node.", 
+            "description": "An ordered list of children of this node.",
             "items": {
               "$ref": "BookmarkTreeNode"
-            }, 
-            "optional": true, 
+            },
+            "optional": true,
             "type": "array"
-          }, 
+          },
           "dateAdded": {
-            "description": "When this node was created, in milliseconds since the epoch (<code>new Date(dateAdded)</code>).", 
-            "optional": true, 
+            "description": "When this node was created, in milliseconds since the epoch (<code>new Date(dateAdded)</code>).",
+            "optional": true,
             "type": "number"
-          }, 
+          },
           "dateGroupModified": {
-            "description": "When the contents of this folder last changed, in milliseconds since the epoch.", 
-            "optional": true, 
+            "description": "When the contents of this folder last changed, in milliseconds since the epoch.",
+            "optional": true,
             "type": "number"
-          }, 
+          },
           "id": {
-            "description": "The unique identifier for the node. IDs are unique within the current profile, and they remain valid even after the browser is restarted.", 
+            "description": "The unique identifier for the node. IDs are unique within the current profile, and they remain valid even after the browser is restarted.",
             "type": "string"
-          }, 
+          },
           "index": {
-            "description": "The 0-based position of this node within its parent folder.", 
-            "optional": true, 
+            "description": "The 0-based position of this node within its parent folder.",
+            "optional": true,
             "type": "integer"
-          }, 
+          },
           "parentId": {
-            "description": "The <code>id</code> of the parent folder.  Omitted for the root node.", 
-            "optional": true, 
+            "description": "The <code>id</code> of the parent folder.  Omitted for the root node.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "title": {
-            "description": "The text displayed for the node.", 
+            "description": "The text displayed for the node.",
             "type": "string"
-          }, 
+          },
           "type": {
-            "$ref": "BookmarkTreeNodeType", 
-            "description": "Indicates the type of the BookmarkTreeNode, which can be one of bookmark, folder or separator.", 
+            "$ref": "BookmarkTreeNodeType",
+            "description": "Indicates the type of the BookmarkTreeNode, which can be one of bookmark, folder or separator.",
             "optional": true
-          }, 
+          },
           "unmodifiable": {
-            "$ref": "BookmarkTreeNodeUnmodifiable", 
-            "description": "Indicates the reason why this node is unmodifiable. The <var>managed</var> value indicates that this node was configured by the system administrator or by the custodian of a supervised user. Omitted if the node can be modified by the user and the extension (default).", 
+            "$ref": "BookmarkTreeNodeUnmodifiable",
+            "description": "Indicates the reason why this node is unmodifiable. The <var>managed</var> value indicates that this node was configured by the system administrator or by the custodian of a supervised user. Omitted if the node can be modified by the user and the extension (default).",
             "optional": true
-          }, 
+          },
           "url": {
-            "description": "The URL navigated to when a user clicks the bookmark. Omitted for folders.", 
-            "optional": true, 
+            "description": "The URL navigated to when a user clicks the bookmark. Omitted for folders.",
+            "optional": true,
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       {
-        "description": "Object passed to the create() function.", 
-        "id": "CreateDetails", 
+        "description": "Object passed to the create() function.",
+        "id": "CreateDetails",
         "properties": {
           "index": {
-            "minimum": 0, 
-            "optional": true, 
+            "minimum": 0,
+            "optional": true,
             "type": "integer"
-          }, 
+          },
           "parentId": {
-            "description": "Defaults to the Other Bookmarks folder.", 
-            "optional": true, 
+            "description": "Defaults to the Other Bookmarks folder.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "title": {
-            "optional": true, 
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "type": {
-            "$ref": "BookmarkTreeNodeType", 
-            "description": "Indicates the type of BookmarkTreeNode to create, which can be one of bookmark, folder or separator.", 
+            "$ref": "BookmarkTreeNodeType",
+            "description": "Indicates the type of BookmarkTreeNode to create, which can be one of bookmark, folder or separator.",
             "optional": true
-          }, 
+          },
           "url": {
-            "optional": true, 
+            "optional": true,
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
       }
     ]
-  }, 
+  },
   {
-    "description": "Use browser actions to put icons in the main browser toolbar, to the right of the address bar. In addition to its icon, a browser action can also have a tooltip, a badge, and a popup.", 
+    "description": "Use browser actions to put icons in the main browser toolbar, to the right of the address bar. In addition to its icon, a browser action can also have a tooltip, a badge, and a popup.",
     "events": [
       {
-        "description": "Fired when a browser action icon is clicked.  This event will not fire if the browser action has a popup.", 
-        "name": "onClicked", 
+        "description": "Fired when a browser action icon is clicked.  This event will not fire if the browser action has a popup.",
+        "name": "onClicked",
         "parameters": [
           {
-            "$ref": "tabs.Tab", 
+            "$ref": "tabs.Tab",
             "name": "tab"
           }
-        ], 
+        ],
         "type": "function"
       }
-    ], 
+    ],
     "functions": [
       {
-        "async": "callback", 
-        "description": "Sets the title of the browser action. This shows up in the tooltip.", 
-        "name": "setTitle", 
+        "async": "callback",
+        "description": "Sets the title of the browser action. This shows up in the tooltip.",
+        "name": "setTitle",
         "parameters": [
           {
-            "name": "details", 
+            "$import": "Details",
+            "name": "details",
             "properties": {
-              "tabId": {
-                "description": "Limits the change to when a particular tab is selected. Automatically resets when the tab is closed.", 
-                "optional": true, 
-                "type": "integer"
-              }, 
               "title": {
-                "description": "The string the browser action should display when moused over.", 
-                "type": "string"
+                "choices": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "The string the browser action should display when moused over."
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Gets the title of the browser action.", 
-        "name": "getTitle", 
+        "async": "callback",
+        "description": "Gets the title of the browser action.",
+        "name": "getTitle",
         "parameters": [
           {
-            "name": "details", 
-            "properties": {
-              "tabId": {
-                "description": "Specify the tab to get the title from. If no tab is specified, the non-tab-specific title is returned.", 
-                "optional": true, 
-                "type": "integer"
-              }
-            }, 
-            "type": "object"
-          }, 
+            "$ref": "Details",
+            "name": "details"
+          },
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
-                "name": "result", 
+                "name": "result",
                 "type": "string"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Sets the icon for the browser action. The icon can be specified either as the path to an image file or as the pixel data from a canvas element, or as dictionary of either one of those. Either the <b>path</b> or the <b>imageData</b> property must be specified.", 
-        "name": "setIcon", 
+        "async": "callback",
+        "description": "Sets the icon for the browser action. The icon can be specified either as the path to an image file or as the pixel data from a canvas element, or as dictionary of either one of those. Either the <b>path</b> or the <b>imageData</b> property must be specified.",
+        "name": "setIcon",
         "parameters": [
           {
-            "name": "details", 
+            "$import": "Details",
+            "name": "details",
             "properties": {
               "imageData": {
                 "choices": [
                   {
                     "$ref": "ImageDataType"
-                  }, 
+                  },
                   {
                     "patternProperties": {
                       "^[1-9]\\d*$": {
                         "$ref": "ImageDataType"
                       }
-                    }, 
+                    },
                     "type": "object"
                   }
-                ], 
-                "description": "Either an ImageData object or a dictionary {size -> ImageData} representing icon to be set. If the icon is specified as a dictionary, the actual image to be used is chosen depending on screen's pixel density. If the number of image pixels that fit into one screen space unit equals <code>scale</code>, then image with size <code>scale</code> * 19 will be selected. Initially only scales 1 and 2 will be supported. At least one image must be specified. Note that 'details.imageData = foo' is equivalent to 'details.imageData = {'19': foo}'", 
+                ],
+                "description": "Either an ImageData object or a dictionary {size -> ImageData} representing icon to be set. If the icon is specified as a dictionary, the actual image to be used is chosen depending on screen's pixel density. If the number of image pixels that fit into one screen space unit equals <code>scale</code>, then image with size <code>scale</code> * 19 will be selected. Initially only scales 1 and 2 will be supported. At least one image must be specified. Note that 'details.imageData = foo' is equivalent to 'details.imageData = {'19': foo}'",
                 "optional": true
-              }, 
+              },
               "path": {
                 "choices": [
                   {
                     "type": "string"
-                  }, 
+                  },
                   {
                     "patternProperties": {
                       "^[1-9]\\d*$": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "type": "object"
                   }
-                ], 
-                "description": "Either a relative image path or a dictionary {size -> relative image path} pointing to icon to be set. If the icon is specified as a dictionary, the actual image to be used is chosen depending on screen's pixel density. If the number of image pixels that fit into one screen space unit equals <code>scale</code>, then image with size <code>scale</code> * 19 will be selected. Initially only scales 1 and 2 will be supported. At least one image must be specified. Note that 'details.path = foo' is equivalent to 'details.imageData = {'19': foo}'", 
+                ],
+                "description": "Either a relative image path or a dictionary {size -> relative image path} pointing to icon to be set. If the icon is specified as a dictionary, the actual image to be used is chosen depending on screen's pixel density. If the number of image pixels that fit into one screen space unit equals <code>scale</code>, then image with size <code>scale</code> * 19 will be selected. Initially only scales 1 and 2 will be supported. At least one image must be specified. Note that 'details.path = foo' is equivalent to 'details.imageData = {'19': foo}'",
                 "optional": true
-              }, 
-              "tabId": {
-                "description": "Limits the change to when a particular tab is selected. Automatically resets when the tab is closed.", 
-                "optional": true, 
-                "type": "integer"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Sets the html document to be opened as a popup when the user clicks on the browser action's icon.", 
-        "name": "setPopup", 
+        "async": "callback",
+        "description": "Sets the html document to be opened as a popup when the user clicks on the browser action's icon.",
+        "name": "setPopup",
         "parameters": [
           {
-            "name": "details", 
+            "$import": "Details",
+            "name": "details",
             "properties": {
               "popup": {
-                "description": "The html file to show in a popup.  If set to the empty string (''), no popup is shown.", 
-                "type": "string"
-              }, 
-              "tabId": {
-                "description": "Limits the change to when a particular tab is selected. Automatically resets when the tab is closed.", 
-                "minimum": 0, 
-                "optional": true, 
-                "type": "integer"
-              }
-            }, 
-            "type": "object"
-          }, 
-          {
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
-            "type": "function"
-          }
-        ], 
-        "type": "function"
-      }, 
-      {
-        "async": "callback", 
-        "description": "Gets the html document set as the popup for this browser action.", 
-        "name": "getPopup", 
-        "parameters": [
-          {
-            "name": "details", 
-            "properties": {
-              "tabId": {
-                "description": "Specify the tab to get the popup from. If no tab is specified, the non-tab-specific popup is returned.", 
-                "optional": true, 
-                "type": "integer"
-              }
-            }, 
-            "type": "object"
-          }, 
-          {
-            "name": "callback", 
-            "parameters": [
-              {
-                "name": "result", 
-                "type": "string"
-              }
-            ], 
-            "type": "function"
-          }
-        ], 
-        "type": "function"
-      }, 
-      {
-        "async": "callback", 
-        "description": "Sets the badge text for the browser action. The badge is displayed on top of the icon.", 
-        "name": "setBadgeText", 
-        "parameters": [
-          {
-            "name": "details", 
-            "properties": {
-              "tabId": {
-                "description": "Limits the change to when a particular tab is selected. Automatically resets when the tab is closed.", 
-                "optional": true, 
-                "type": "integer"
-              }, 
-              "text": {
-                "description": "Any number of characters can be passed, but only about four can fit in the space.", 
-                "type": "string"
-              }
-            }, 
-            "type": "object"
-          }, 
-          {
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
-            "type": "function"
-          }
-        ], 
-        "type": "function"
-      }, 
-      {
-        "async": "callback", 
-        "description": "Gets the badge text of the browser action. If no tab is specified, the non-tab-specific badge text is returned.", 
-        "name": "getBadgeText", 
-        "parameters": [
-          {
-            "name": "details", 
-            "properties": {
-              "tabId": {
-                "description": "Specify the tab to get the badge text from. If no tab is specified, the non-tab-specific badge text is returned.", 
-                "optional": true, 
-                "type": "integer"
-              }
-            }, 
-            "type": "object"
-          }, 
-          {
-            "name": "callback", 
-            "parameters": [
-              {
-                "name": "result", 
-                "type": "string"
-              }
-            ], 
-            "type": "function"
-          }
-        ], 
-        "type": "function"
-      }, 
-      {
-        "async": "callback", 
-        "description": "Sets the background color for the badge.", 
-        "name": "setBadgeBackgroundColor", 
-        "parameters": [
-          {
-            "name": "details", 
-            "properties": {
-              "color": {
                 "choices": [
                   {
                     "type": "string"
-                  }, 
+                  },
                   {
-                    "$ref": "ColorArray"
+                    "type": "null"
                   }
-                ], 
-                "description": "An array of four integers in the range [0,255] that make up the RGBA color of the badge. For example, opaque red is <code>[255, 0, 0, 255]</code>. Can also be a string with a CSS value, with opaque red being <code>#FF0000</code> or <code>#F00</code>."
-              }, 
-              "tabId": {
-                "description": "Limits the change to when a particular tab is selected. Automatically resets when the tab is closed.", 
-                "optional": true, 
-                "type": "integer"
+                ],
+                "description": "The html file to show in a popup.  If set to the empty string (''), no popup is shown."
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Gets the background color of the browser action.", 
-        "name": "getBadgeBackgroundColor", 
+        "async": "callback",
+        "description": "Gets the html document set as the popup for this browser action.",
+        "name": "getPopup",
         "parameters": [
           {
-            "name": "details", 
-            "properties": {
-              "tabId": {
-                "description": "Specify the tab to get the badge background color from. If no tab is specified, the non-tab-specific badge background color is returned.", 
-                "optional": true, 
-                "type": "integer"
-              }
-            }, 
-            "type": "object"
-          }, 
+            "$ref": "Details",
+            "name": "details"
+          },
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
-                "$ref": "ColorArray", 
+                "name": "result",
+                "type": "string"
+              }
+            ],
+            "type": "function"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": "callback",
+        "description": "Sets the badge text for the browser action. The badge is displayed on top of the icon.",
+        "name": "setBadgeText",
+        "parameters": [
+          {
+            "$import": "Details",
+            "name": "details",
+            "properties": {
+              "text": {
+                "choices": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "Any number of characters can be passed, but only about four can fit in the space."
+              }
+            },
+            "type": "object"
+          },
+          {
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
+            "type": "function"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": "callback",
+        "description": "Gets the badge text of the browser action. If no tab nor window is specified is specified, the global badge text is returned.",
+        "name": "getBadgeText",
+        "parameters": [
+          {
+            "$ref": "Details",
+            "name": "details"
+          },
+          {
+            "name": "callback",
+            "parameters": [
+              {
+                "name": "result",
+                "type": "string"
+              }
+            ],
+            "type": "function"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": "callback",
+        "description": "Sets the background color for the badge.",
+        "name": "setBadgeBackgroundColor",
+        "parameters": [
+          {
+            "$import": "Details",
+            "name": "details",
+            "properties": {
+              "color": {
+                "$ref": "ColorValue"
+              }
+            },
+            "type": "object"
+          },
+          {
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
+            "type": "function"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": "callback",
+        "description": "Gets the background color of the browser action badge.",
+        "name": "getBadgeBackgroundColor",
+        "parameters": [
+          {
+            "$ref": "Details",
+            "name": "details"
+          },
+          {
+            "name": "callback",
+            "parameters": [
+              {
+                "$ref": "ColorArray",
                 "name": "result"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Enables the browser action for a tab. By default, browser actions are enabled.", 
-        "name": "enable", 
+        "async": true,
+        "description": "Sets the text color for the badge.",
+        "name": "setBadgeTextColor",
         "parameters": [
           {
-            "description": "The id of the tab for which you want to modify the browser action.", 
-            "minimum": 0, 
-            "name": "tabId", 
-            "optional": true, 
-            "type": "integer"
-          }, 
-          {
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
-            "type": "function"
+            "$import": "Details",
+            "name": "details",
+            "properties": {
+              "color": {
+                "$ref": "ColorValue"
+              }
+            },
+            "type": "object"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Disables the browser action for a tab.", 
-        "name": "disable", 
+        "async": true,
+        "description": "Gets the text color of the browser action badge.",
+        "name": "getBadgeTextColor",
         "parameters": [
           {
-            "description": "The id of the tab for which you want to modify the browser action.", 
-            "minimum": 0, 
-            "name": "tabId", 
-            "optional": true, 
-            "type": "integer"
-          }, 
+            "$ref": "Details",
+            "name": "details"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": "callback",
+        "description": "Enables the browser action for a tab. By default, browser actions are enabled.",
+        "name": "enable",
+        "parameters": [
           {
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "description": "The id of the tab for which you want to modify the browser action.",
+            "minimum": 0,
+            "name": "tabId",
+            "optional": true,
+            "type": "integer"
+          },
+          {
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": true, 
-        "description": "Opens the extension popup window in the active window.", 
-        "name": "openPopup", 
-        "parameters": [], 
-        "requireUserInput": true, 
+        "async": "callback",
+        "description": "Disables the browser action for a tab.",
+        "name": "disable",
+        "parameters": [
+          {
+            "description": "The id of the tab for which you want to modify the browser action.",
+            "minimum": 0,
+            "name": "tabId",
+            "optional": true,
+            "type": "integer"
+          },
+          {
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
+            "type": "function"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": true,
+        "description": "Checks whether the browser action is enabled.",
+        "name": "isEnabled",
+        "parameters": [
+          {
+            "$ref": "Details",
+            "name": "details"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": true,
+        "description": "Opens the extension popup window in the active window.",
+        "name": "openPopup",
+        "parameters": [],
+        "requireUserInput": true,
         "type": "function"
       }
-    ], 
-    "namespace": "browserAction", 
+    ],
+    "namespace": "browserAction",
     "permissions": [
       "manifest:browser_action"
-    ], 
+    ],
     "types": [
       {
-        "id": "ColorArray", 
+        "description": "Specifies to which tab or window the value should be set, or from which one it should be retrieved. If no tab nor window is specified, the global value is set or retrieved.",
+        "id": "Details",
+        "properties": {
+          "tabId": {
+            "description": "When setting a value, it will be specific to the specified tab, and will automatically reset when the tab navigates. When getting, specifies the tab to get the value from; if there is no tab-specific value, the window one will be inherited.",
+            "minimum": 0,
+            "optional": true,
+            "type": "integer"
+          },
+          "windowId": {
+            "description": "When setting a value, it will be specific to the specified window. When getting, specifies the window to get the value from; if there is no window-specific value, the global one will be inherited.",
+            "minimum": -2,
+            "optional": true,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      {
+        "id": "ColorArray",
         "items": {
-          "maximum": 255, 
-          "minimum": 0, 
+          "maximum": 255,
+          "minimum": 0,
           "type": "integer"
-        }, 
-        "maxItems": 4, 
-        "minItems": 4, 
+        },
+        "maxItems": 4,
+        "minItems": 4,
         "type": "array"
-      }, 
+      },
       {
         "additionalProperties": {
           "type": "any"
-        }, 
-        "description": "Pixel data for an image. Must be an ImageData object (for example, from a <code>canvas</code> element).", 
-        "id": "ImageDataType", 
-        "isInstanceOf": "ImageData", 
-        "postprocess": "convertImageDataToURL", 
+        },
+        "description": "Pixel data for an image. Must be an ImageData object (for example, from a <code>canvas</code> element).",
+        "id": "ImageDataType",
+        "isInstanceOf": "ImageData",
+        "postprocess": "convertImageDataToURL",
         "type": "object"
+      },
+      {
+        "choices": [
+          {
+            "type": "string"
+          },
+          {
+            "$ref": "ColorArray"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "description": "An array of four integers in the range [0,255] that make up the RGBA color of the badge. For example, opaque red is <code>[255, 0, 0, 255]</code>. Can also be a string with a CSS value, with opaque red being <code>#FF0000</code> or <code>#F00</code>.",
+        "id": "ColorValue"
       }
     ]
-  }, 
+  },
   {
-    "description": "Use the <code>browser.browserSettings</code> API to control global settings of the browser.", 
-    "namespace": "browserSettings", 
+    "description": "Use the <code>browser.browserSettings</code> API to control global settings of the browser.",
+    "namespace": "browserSettings",
     "permissions": [
       "browserSettings"
-    ], 
+    ],
     "properties": {
       "allowPopupsForUserEvents": {
-        "$ref": "types.Setting", 
+        "$ref": "types.Setting",
         "description": "Allows or disallows pop-up windows from opening in response to user events."
-      }, 
+      },
       "cacheEnabled": {
-        "$ref": "types.Setting", 
+        "$ref": "types.Setting",
         "description": "Enables or disables the browser cache."
-      }, 
+      },
+      "closeTabsByDoubleClick": {
+        "$ref": "types.Setting",
+        "description": "This boolean setting controls whether the selected tab can be closed with a double click."
+      },
       "contextMenuShowEvent": {
-        "$ref": "types.Setting", 
+        "$ref": "types.Setting",
         "description": "Controls after which mouse event context menus popup. This setting's value is of type ContextMenuMouseEvent, which has possible values of <code>mouseup</code> and <code>mousedown</code>."
-      }, 
+      },
       "homepageOverride": {
-        "$ref": "types.Setting", 
+        "$ref": "types.Setting",
         "description": "Returns the value of the overridden home page. Read-only."
-      }, 
+      },
       "imageAnimationBehavior": {
-        "$ref": "types.Setting", 
+        "$ref": "types.Setting",
         "description": "Controls the behaviour of image animation in the browser. This setting's value is of type ImageAnimationBehavior, defaulting to <code>normal</code>."
-      }, 
+      },
       "newTabPageOverride": {
-        "$ref": "types.Setting", 
+        "$ref": "types.Setting",
         "description": "Returns the value of the overridden new tab page. Read-only."
-      }, 
+      },
+      "newTabPosition": {
+        "$ref": "types.Setting",
+        "description": "Controls where new tabs are opened. `afterCurrent` will open all new tabs next to the current tab, `relatedAfterCurrent` will open only related tabs next to the current tab, and `atEnd` will open all tabs at the end of the tab strip. The default is `relatedAfterCurrent`."
+      },
+      "openBookmarksInNewTabs": {
+        "$ref": "types.Setting",
+        "description": "This boolean setting controls whether bookmarks are opened in the current tab or in a new tab."
+      },
+      "openSearchResultsInNewTabs": {
+        "$ref": "types.Setting",
+        "description": "This boolean setting controls whether search results are opened in the current tab or in a new tab."
+      },
+      "openUrlbarResultsInNewTabs": {
+        "$ref": "types.Setting",
+        "description": "This boolean setting controls whether urlbar results are opened in the current tab or in a new tab."
+      },
+      "overrideDocumentColors": {
+        "$ref": "types.Setting",
+        "description": "This setting controls whether the user-chosen colors override the page's colors."
+      },
+      "useDocumentFonts": {
+        "$ref": "types.Setting",
+        "description": "This setting controls whether the document's fonts are used."
+      },
       "webNotificationsDisabled": {
-        "$ref": "types.Setting", 
+        "$ref": "types.Setting",
         "description": "Disables webAPI notifications."
       }
-    }, 
+    },
     "types": [
       {
-        "description": "How images should be animated in the browser.", 
+        "description": "How images should be animated in the browser.",
         "enum": [
-          "normal", 
-          "none", 
+          "normal",
+          "none",
           "once"
-        ], 
-        "id": "ImageAnimationBehavior", 
+        ],
+        "id": "ImageAnimationBehavior",
         "type": "string"
-      }, 
+      },
       {
-        "description": "After which mouse event context menus should popup.", 
+        "description": "After which mouse event context menus should popup.",
         "enum": [
-          "mouseup", 
+          "mouseup",
           "mousedown"
-        ], 
-        "id": "ContextMenuMouseEvent", 
+        ],
+        "id": "ContextMenuMouseEvent",
         "type": "string"
       }
     ]
-  }, 
+  },
   {
-    "description": "Use the <code>chrome.browsingData</code> API to remove browsing data from a user's local profile.", 
+    "description": "Use the <code>chrome.browsingData</code> API to remove browsing data from a user's local profile.",
     "functions": [
       {
-        "async": "callback", 
-        "description": "Reports which types of data are currently selected in the 'Clear browsing data' settings UI.  Note: some of the data types included in this API are not available in the settings UI, and some UI settings control more than one data type listed here.", 
-        "name": "settings", 
+        "async": "callback",
+        "description": "Reports which types of data are currently selected in the 'Clear browsing data' settings UI.  Note: some of the data types included in this API are not available in the settings UI, and some UI settings control more than one data type listed here.",
+        "name": "settings",
         "parameters": [
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
-                "name": "result", 
+                "name": "result",
                 "properties": {
                   "dataRemovalPermitted": {
-                    "$ref": "DataTypeSet", 
+                    "$ref": "DataTypeSet",
                     "description": "All of the types will be present in the result, with values of <code>true</code> if they are permitted to be removed (e.g., by enterprise policy) and <code>false</code> if not."
-                  }, 
+                  },
                   "dataToRemove": {
-                    "$ref": "DataTypeSet", 
+                    "$ref": "DataTypeSet",
                     "description": "All of the types will be present in the result, with values of <code>true</code> if they are both selected to be removed and permitted to be removed, otherwise <code>false</code>."
-                  }, 
+                  },
                   "options": {
                     "$ref": "RemovalOptions"
                   }
-                }, 
+                },
                 "type": "object"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Clears various types of browsing data stored in a user's profile.", 
-        "name": "remove", 
+        "async": "callback",
+        "description": "Clears various types of browsing data stored in a user's profile.",
+        "name": "remove",
         "parameters": [
           {
-            "$ref": "RemovalOptions", 
+            "$ref": "RemovalOptions",
             "name": "options"
-          }, 
+          },
           {
-            "$ref": "DataTypeSet", 
-            "description": "The set of data types to remove.", 
+            "$ref": "DataTypeSet",
+            "description": "The set of data types to remove.",
             "name": "dataToRemove"
-          }, 
+          },
           {
-            "description": "Called when deletion has completed.", 
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "description": "Called when deletion has completed.",
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Clears websites' appcache data.", 
-        "name": "removeAppcache", 
+        "async": "callback",
+        "description": "Clears websites' appcache data.",
+        "name": "removeAppcache",
         "parameters": [
           {
-            "$ref": "RemovalOptions", 
+            "$ref": "RemovalOptions",
             "name": "options"
-          }, 
+          },
           {
-            "description": "Called when websites' appcache data has been cleared.", 
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "description": "Called when websites' appcache data has been cleared.",
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Clears the browser's cache.", 
-        "name": "removeCache", 
+        "async": "callback",
+        "description": "Clears the browser's cache.",
+        "name": "removeCache",
         "parameters": [
           {
-            "$ref": "RemovalOptions", 
+            "$ref": "RemovalOptions",
             "name": "options"
-          }, 
+          },
           {
-            "description": "Called when the browser's cache has been cleared.", 
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "description": "Called when the browser's cache has been cleared.",
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Clears the browser's cookies and server-bound certificates modified within a particular timeframe.", 
-        "name": "removeCookies", 
+        "async": "callback",
+        "description": "Clears the browser's cookies and server-bound certificates modified within a particular timeframe.",
+        "name": "removeCookies",
         "parameters": [
           {
-            "$ref": "RemovalOptions", 
+            "$ref": "RemovalOptions",
             "name": "options"
-          }, 
+          },
           {
-            "description": "Called when the browser's cookies and server-bound certificates have been cleared.", 
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "description": "Called when the browser's cookies and server-bound certificates have been cleared.",
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Clears the browser's list of downloaded files (<em>not</em> the downloaded files themselves).", 
-        "name": "removeDownloads", 
+        "async": "callback",
+        "description": "Clears the browser's list of downloaded files (<em>not</em> the downloaded files themselves).",
+        "name": "removeDownloads",
         "parameters": [
           {
-            "$ref": "RemovalOptions", 
+            "$ref": "RemovalOptions",
             "name": "options"
-          }, 
+          },
           {
-            "description": "Called when the browser's list of downloaded files has been cleared.", 
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "description": "Called when the browser's list of downloaded files has been cleared.",
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Clears websites' file system data.", 
-        "name": "removeFileSystems", 
+        "async": "callback",
+        "description": "Clears websites' file system data.",
+        "name": "removeFileSystems",
         "parameters": [
           {
-            "$ref": "RemovalOptions", 
+            "$ref": "RemovalOptions",
             "name": "options"
-          }, 
+          },
           {
-            "description": "Called when websites' file systems have been cleared.", 
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "description": "Called when websites' file systems have been cleared.",
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Clears the browser's stored form data (autofill).", 
-        "name": "removeFormData", 
+        "async": "callback",
+        "description": "Clears the browser's stored form data (autofill).",
+        "name": "removeFormData",
         "parameters": [
           {
-            "$ref": "RemovalOptions", 
+            "$ref": "RemovalOptions",
             "name": "options"
-          }, 
+          },
           {
-            "description": "Called when the browser's form data has been cleared.", 
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "description": "Called when the browser's form data has been cleared.",
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Clears the browser's history.", 
-        "name": "removeHistory", 
+        "async": "callback",
+        "description": "Clears the browser's history.",
+        "name": "removeHistory",
         "parameters": [
           {
-            "$ref": "RemovalOptions", 
+            "$ref": "RemovalOptions",
             "name": "options"
-          }, 
+          },
           {
-            "description": "Called when the browser's history has cleared.", 
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "description": "Called when the browser's history has cleared.",
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Clears websites' IndexedDB data.", 
-        "name": "removeIndexedDB", 
+        "async": "callback",
+        "description": "Clears websites' IndexedDB data.",
+        "name": "removeIndexedDB",
         "parameters": [
           {
-            "$ref": "RemovalOptions", 
+            "$ref": "RemovalOptions",
             "name": "options"
-          }, 
+          },
           {
-            "description": "Called when websites' IndexedDB data has been cleared.", 
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "description": "Called when websites' IndexedDB data has been cleared.",
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Clears websites' local storage data.", 
-        "name": "removeLocalStorage", 
+        "async": "callback",
+        "description": "Clears websites' local storage data.",
+        "name": "removeLocalStorage",
         "parameters": [
           {
-            "$ref": "RemovalOptions", 
+            "$ref": "RemovalOptions",
             "name": "options"
-          }, 
+          },
           {
-            "description": "Called when websites' local storage has been cleared.", 
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "description": "Called when websites' local storage has been cleared.",
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Clears plugins' data.", 
-        "name": "removePluginData", 
+        "async": "callback",
+        "description": "Clears plugins' data.",
+        "name": "removePluginData",
         "parameters": [
           {
-            "$ref": "RemovalOptions", 
+            "$ref": "RemovalOptions",
             "name": "options"
-          }, 
+          },
           {
-            "description": "Called when plugins' data has been cleared.", 
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "description": "Called when plugins' data has been cleared.",
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Clears the browser's stored passwords.", 
-        "name": "removePasswords", 
+        "async": "callback",
+        "description": "Clears the browser's stored passwords.",
+        "name": "removePasswords",
         "parameters": [
           {
-            "$ref": "RemovalOptions", 
+            "$ref": "RemovalOptions",
             "name": "options"
-          }, 
+          },
           {
-            "description": "Called when the browser's passwords have been cleared.", 
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "description": "Called when the browser's passwords have been cleared.",
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Clears websites' WebSQL data.", 
-        "name": "removeWebSQL", 
+        "async": "callback",
+        "description": "Clears websites' WebSQL data.",
+        "name": "removeWebSQL",
         "parameters": [
           {
-            "$ref": "RemovalOptions", 
+            "$ref": "RemovalOptions",
             "name": "options"
-          }, 
+          },
           {
-            "description": "Called when websites' WebSQL databases have been cleared.", 
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "description": "Called when websites' WebSQL databases have been cleared.",
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
       }
-    ], 
-    "namespace": "browsingData", 
+    ],
+    "namespace": "browsingData",
     "permissions": [
       "browsingData"
-    ], 
+    ],
     "types": [
       {
-        "description": "Options that determine exactly what data will be removed.", 
-        "id": "RemovalOptions", 
+        "description": "Options that determine exactly what data will be removed.",
+        "id": "RemovalOptions",
         "properties": {
           "hostnames": {
-            "description": "Only remove data associated with these hostnames (only applies to cookies and localStorage).", 
+            "description": "Only remove data associated with these hostnames (only applies to cookies and localStorage).",
             "items": {
-              "format": "hostname", 
+              "format": "hostname",
               "type": "string"
-            }, 
-            "optional": true, 
+            },
+            "optional": true,
             "type": "array"
-          }, 
+          },
           "originTypes": {
-            "description": "An object whose properties specify which origin types ought to be cleared. If this object isn't specified, it defaults to clearing only \"unprotected\" origins. Please ensure that you <em>really</em> want to remove application data before adding 'protectedWeb' or 'extensions'.", 
-            "optional": true, 
+            "description": "An object whose properties specify which origin types ought to be cleared. If this object isn't specified, it defaults to clearing only \"unprotected\" origins. Please ensure that you <em>really</em> want to remove application data before adding 'protectedWeb' or 'extensions'.",
+            "optional": true,
             "properties": {
               "extension": {
-                "description": "Extensions and packaged applications a user has installed (be _really_ careful!).", 
-                "optional": true, 
+                "description": "Extensions and packaged applications a user has installed (be _really_ careful!).",
+                "optional": true,
                 "type": "boolean"
-              }, 
+              },
               "protectedWeb": {
-                "description": "Websites that have been installed as hosted applications (be careful!).", 
-                "optional": true, 
+                "description": "Websites that have been installed as hosted applications (be careful!).",
+                "optional": true,
                 "type": "boolean"
-              }, 
+              },
               "unprotectedWeb": {
-                "description": "Normal websites.", 
-                "optional": true, 
+                "description": "Normal websites.",
+                "optional": true,
                 "type": "boolean"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           "since": {
-            "$ref": "extensionTypes.Date", 
-            "description": "Remove data accumulated on or after this date, represented in milliseconds since the epoch (accessible via the <code>getTime</code> method of the JavaScript <code>Date</code> object). If absent, defaults to 0 (which would remove all browsing data).", 
+            "$ref": "extensionTypes.Date",
+            "description": "Remove data accumulated on or after this date, represented in milliseconds since the epoch (accessible via the <code>getTime</code> method of the JavaScript <code>Date</code> object). If absent, defaults to 0 (which would remove all browsing data).",
             "optional": true
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       {
-        "description": "A set of data types. Missing data types are interpreted as <code>false</code>.", 
-        "id": "DataTypeSet", 
+        "description": "A set of data types. Missing data types are interpreted as <code>false</code>.",
+        "id": "DataTypeSet",
         "properties": {
           "cache": {
-            "description": "The browser's cache. Note: when removing data, this clears the <em>entire</em> cache: it is not limited to the range you specify.", 
-            "optional": true, 
+            "description": "The browser's cache. Note: when removing data, this clears the <em>entire</em> cache: it is not limited to the range you specify.",
+            "optional": true,
             "type": "boolean"
-          }, 
+          },
           "cookies": {
-            "description": "The browser's cookies.", 
-            "optional": true, 
+            "description": "The browser's cookies.",
+            "optional": true,
             "type": "boolean"
-          }, 
+          },
           "downloads": {
-            "description": "The browser's download list.", 
-            "optional": true, 
+            "description": "The browser's download list.",
+            "optional": true,
             "type": "boolean"
-          }, 
+          },
           "formData": {
-            "description": "The browser's stored form data.", 
-            "optional": true, 
+            "description": "The browser's stored form data.",
+            "optional": true,
             "type": "boolean"
-          }, 
+          },
           "history": {
-            "description": "The browser's history.", 
-            "optional": true, 
+            "description": "The browser's history.",
+            "optional": true,
             "type": "boolean"
-          }, 
+          },
           "indexedDB": {
-            "description": "Websites' IndexedDB data.", 
-            "optional": true, 
+            "description": "Websites' IndexedDB data.",
+            "optional": true,
             "type": "boolean"
-          }, 
+          },
           "localStorage": {
-            "description": "Websites' local storage data.", 
-            "optional": true, 
+            "description": "Websites' local storage data.",
+            "optional": true,
             "type": "boolean"
-          }, 
+          },
           "passwords": {
-            "description": "Stored passwords.", 
-            "optional": true, 
+            "description": "Stored passwords.",
+            "optional": true,
             "type": "boolean"
-          }, 
+          },
           "pluginData": {
-            "description": "Plugins' data.", 
-            "optional": true, 
+            "description": "Plugins' data.",
+            "optional": true,
             "type": "boolean"
-          }, 
+          },
           "serverBoundCertificates": {
-            "description": "Server-bound certificates.", 
-            "optional": true, 
+            "description": "Server-bound certificates.",
+            "optional": true,
             "type": "boolean"
-          }, 
+          },
           "serviceWorkers": {
-            "description": "Service Workers.", 
-            "optional": true, 
+            "description": "Service Workers.",
+            "optional": true,
             "type": "boolean"
           }
-        }, 
+        },
         "type": "object"
       }
     ]
-  }, 
+  },
   {
-    "description": "Offers the ability to write to the clipboard. Reading is not supported because the clipboard can already be read through the standard web platform APIs.", 
-    "functions": [
+    "description": "This API provides the ability detect the captive portal state of the users connection.",
+    "events": [
       {
-        "async": true, 
-        "description": "Copy an image to the clipboard. The image is re-encoded before it is written to the clipboard. If the image is invalid, the clipboard is not modified.", 
-        "name": "setImageData", 
+        "description": "Fired when the captive portal state changes.",
+        "name": "onStateChanged",
         "parameters": [
           {
-            "additionalProperties": true, 
-            "description": "The image data to be copied.", 
-            "isInstanceOf": "ArrayBuffer", 
-            "name": "imageData", 
+            "name": "details",
+            "properties": {
+              "state": {
+                "description": "The current captive portal state.",
+                "enum": [
+                  "unknown",
+                  "not_captive",
+                  "unlocked_portal",
+                  "locked_portal"
+                ],
+                "type": "string"
+              }
+            },
             "type": "object"
-          }, 
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "description": "This notification will be emitted when the captive portal service has determined that we can connect to the internet. The service will pass either `captive` if there is an unlocked captive portal present, or `clear` if no captive portal was detected.",
+        "name": "onConnectivityAvailable",
+        "parameters": [
           {
-            "description": "The type of imageData.", 
             "enum": [
-              "jpeg", 
-              "png"
-            ], 
-            "name": "imageType", 
+              "captive",
+              "clear"
+            ],
+            "name": "status",
             "type": "string"
           }
-        ], 
+        ],
         "type": "function"
       }
-    ], 
-    "namespace": "clipboard", 
+    ],
+    "functions": [
+      {
+        "async": true,
+        "description": "Returns the current portal state, one of `unknown`, `not_captive`, `unlocked_portal`, `locked_portal`.",
+        "name": "getState",
+        "parameters": [],
+        "type": "function"
+      },
+      {
+        "async": true,
+        "description": "Returns the time difference between NOW and the last time a request was completed in milliseconds.",
+        "name": "getLastChecked",
+        "parameters": [],
+        "type": "function"
+      }
+    ],
+    "namespace": "captivePortal",
+    "permissions": [
+      "captivePortal"
+    ]
+  },
+  {
+    "description": "Offers the ability to write to the clipboard. Reading is not supported because the clipboard can already be read through the standard web platform APIs.",
+    "functions": [
+      {
+        "async": true,
+        "description": "Copy an image to the clipboard. The image is re-encoded before it is written to the clipboard. If the image is invalid, the clipboard is not modified.",
+        "name": "setImageData",
+        "parameters": [
+          {
+            "additionalProperties": true,
+            "description": "The image data to be copied.",
+            "isInstanceOf": "ArrayBuffer",
+            "name": "imageData",
+            "type": "object"
+          },
+          {
+            "description": "The type of imageData.",
+            "enum": [
+              "jpeg",
+              "png"
+            ],
+            "name": "imageType",
+            "type": "string"
+          }
+        ],
+        "type": "function"
+      }
+    ],
+    "namespace": "clipboard",
     "permissions": [
       "clipboardWrite"
     ]
-  }, 
+  },
   {
-    "description": "Use the commands API to add keyboard shortcuts that trigger actions in your extension, for example, an action to open the browser action or send a command to the xtension.", 
+    "description": "Use the commands API to add keyboard shortcuts that trigger actions in your extension, for example, an action to open the browser action or send a command to the xtension.",
     "events": [
       {
-        "description": "Fired when a registered command is activated using a keyboard shortcut.", 
-        "name": "onCommand", 
+        "description": "Fired when a registered command is activated using a keyboard shortcut.",
+        "name": "onCommand",
         "parameters": [
           {
-            "name": "command", 
+            "name": "command",
             "type": "string"
           }
-        ], 
+        ],
         "type": "function"
       }
-    ], 
+    ],
     "functions": [
       {
-        "async": "callback", 
-        "description": "Returns all the registered extension commands for this extension and their shortcut (if active).", 
-        "name": "getAll", 
+        "async": true,
+        "description": "Update the details of an already defined command.",
+        "name": "update",
         "parameters": [
           {
-            "description": "Called to return the registered commands.", 
-            "name": "callback", 
-            "optional": true, 
+            "description": "The new description for the command.",
+            "name": "detail",
+            "properties": {
+              "description": {
+                "description": "The new description for the command.",
+                "optional": true,
+                "type": "string"
+              },
+              "name": {
+                "description": "The name of the command.",
+                "type": "string"
+              },
+              "shortcut": {
+                "$ref": "manifest.KeyName",
+                "optional": true
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": true,
+        "description": "Reset a command's details to what is specified in the manifest.",
+        "name": "reset",
+        "parameters": [
+          {
+            "description": "The name of the command.",
+            "name": "name",
+            "type": "string"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": "callback",
+        "description": "Returns all the registered extension commands for this extension and their shortcut (if active).",
+        "name": "getAll",
+        "parameters": [
+          {
+            "description": "Called to return the registered commands.",
+            "name": "callback",
+            "optional": true,
             "parameters": [
               {
                 "items": {
                   "$ref": "Command"
-                }, 
-                "name": "commands", 
+                },
+                "name": "commands",
                 "type": "array"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
       }
-    ], 
-    "namespace": "commands", 
+    ],
+    "namespace": "commands",
     "permissions": [
       "manifest:commands"
-    ], 
+    ],
     "types": [
       {
-        "id": "Command", 
+        "id": "Command",
         "properties": {
           "description": {
-            "description": "The Extension Command description", 
-            "optional": true, 
+            "description": "The Extension Command description",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "name": {
-            "description": "The name of the Extension Command", 
-            "optional": true, 
+            "description": "The name of the Extension Command",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "shortcut": {
-            "description": "The shortcut active for this command, or blank if not active.", 
-            "optional": true, 
+            "description": "The shortcut active for this command, or blank if not active.",
+            "optional": true,
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
       }
     ]
-  }, 
+  },
   {
-    "description": "Use the <code>browser.contextualIdentities</code> API to query and modify contextual identity, also called as containers.", 
-    "events": [
+    "functions": [
       {
-        "description": "Fired when a container is updated.", 
-        "name": "onUpdated", 
+        "async": true,
+        "description": "Register a content script programmatically",
+        "name": "register",
         "parameters": [
           {
-            "name": "changeInfo", 
+            "$ref": "RegisteredContentScriptOptions",
+            "name": "contentScriptOptions"
+          }
+        ],
+        "type": "function"
+      }
+    ],
+    "namespace": "contentScripts",
+    "types": [
+      {
+        "description": "Details of a content script registered programmatically",
+        "id": "RegisteredContentScriptOptions",
+        "properties": {
+          "allFrames": {
+            "description": "If allFrames is <code>true</code>, implies that the JavaScript or CSS should be injected into all frames of current page. By default, it's <code>false</code> and is only injected into the top frame.",
+            "optional": true,
+            "type": "boolean"
+          },
+          "css": {
+            "description": "The list of CSS files to inject",
+            "items": {
+              "$ref": "extensionTypes.ExtensionFileOrCode"
+            },
+            "optional": true,
+            "type": "array"
+          },
+          "excludeGlobs": {
+            "items": {
+              "type": "string"
+            },
+            "optional": true,
+            "type": "array"
+          },
+          "excludeMatches": {
+            "items": {
+              "$ref": "manifest.MatchPattern"
+            },
+            "minItems": 1,
+            "optional": true,
+            "type": "array"
+          },
+          "includeGlobs": {
+            "items": {
+              "type": "string"
+            },
+            "optional": true,
+            "type": "array"
+          },
+          "js": {
+            "description": "The list of JS files to inject",
+            "items": {
+              "$ref": "extensionTypes.ExtensionFileOrCode"
+            },
+            "optional": true,
+            "type": "array"
+          },
+          "matchAboutBlank": {
+            "description": "If matchAboutBlank is true, then the code is also injected in about:blank and about:srcdoc frames if your extension has access to its parent document. Code cannot be inserted in top-level about:-frames. By default it is <code>false</code>.",
+            "optional": true,
+            "type": "boolean"
+          },
+          "matches": {
+            "items": {
+              "$ref": "manifest.MatchPattern"
+            },
+            "minItems": 1,
+            "optional": false,
+            "type": "array"
+          },
+          "runAt": {
+            "$ref": "extensionTypes.RunAt",
+            "description": "The soonest that the JavaScript or CSS will be injected into the tab. Defaults to \"document_idle\".",
+            "optional": true
+          }
+        },
+        "type": "object"
+      },
+      {
+        "description": "An object that represents a content script registered programmatically",
+        "functions": [
+          {
+            "async": true,
+            "description": "Unregister a content script registered programmatically",
+            "name": "unregister",
+            "parameters": [],
+            "type": "function"
+          }
+        ],
+        "id": "RegisteredContentScript",
+        "type": "object"
+      }
+    ]
+  },
+  {
+    "description": "Use the <code>browser.contextualIdentities</code> API to query and modify contextual identity, also called as containers.",
+    "events": [
+      {
+        "description": "Fired when a container is updated.",
+        "name": "onUpdated",
+        "parameters": [
+          {
+            "name": "changeInfo",
             "properties": {
               "contextualIdentity": {
-                "$ref": "ContextualIdentity", 
+                "$ref": "ContextualIdentity",
                 "description": "Contextual identity that has been updated"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Fired when a new container is created.", 
-        "name": "onCreated", 
+        "description": "Fired when a new container is created.",
+        "name": "onCreated",
         "parameters": [
           {
-            "name": "changeInfo", 
+            "name": "changeInfo",
             "properties": {
               "contextualIdentity": {
-                "$ref": "ContextualIdentity", 
+                "$ref": "ContextualIdentity",
                 "description": "Contextual identity that has been created"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Fired when a container is removed.", 
-        "name": "onRemoved", 
+        "description": "Fired when a container is removed.",
+        "name": "onRemoved",
         "parameters": [
           {
-            "name": "changeInfo", 
+            "name": "changeInfo",
             "properties": {
               "contextualIdentity": {
-                "$ref": "ContextualIdentity", 
+                "$ref": "ContextualIdentity",
                 "description": "Contextual identity that has been removed"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "type": "function"
       }
-    ], 
+    ],
     "functions": [
       {
-        "async": true, 
-        "description": "Retrieves information about a single contextual identity.", 
-        "name": "get", 
+        "async": true,
+        "description": "Retrieves information about a single contextual identity.",
+        "name": "get",
         "parameters": [
           {
-            "description": "The ID of the contextual identity cookie store. ", 
-            "name": "cookieStoreId", 
+            "description": "The ID of the contextual identity cookie store. ",
+            "name": "cookieStoreId",
             "type": "string"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": true, 
-        "description": "Retrieves all contextual identities", 
-        "name": "query", 
+        "async": true,
+        "description": "Retrieves all contextual identities",
+        "name": "query",
         "parameters": [
           {
-            "description": "Information to filter the contextual identities being retrieved.", 
-            "name": "details", 
+            "description": "Information to filter the contextual identities being retrieved.",
+            "name": "details",
             "properties": {
               "name": {
-                "description": "Filters the contextual identity by name.", 
-                "optional": true, 
+                "description": "Filters the contextual identity by name.",
+                "optional": true,
                 "type": "string"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": true, 
-        "description": "Creates a contextual identity with the given data.", 
-        "name": "create", 
+        "async": true,
+        "description": "Creates a contextual identity with the given data.",
+        "name": "create",
         "parameters": [
           {
-            "description": "Details about the contextual identity being created.", 
-            "name": "details", 
-            "properties": {
-              "color": {
-                "description": "The color of the contextual identity.", 
-                "optional": false, 
-                "type": "string"
-              }, 
-              "icon": {
-                "description": "The icon of the contextual identity.", 
-                "optional": false, 
-                "type": "string"
-              }, 
-              "name": {
-                "description": "The name of the contextual identity.", 
-                "optional": false, 
-                "type": "string"
-              }
-            }, 
-            "type": "object"
-          }
-        ], 
-        "type": "function"
-      }, 
-      {
-        "async": true, 
-        "description": "Updates a contextual identity with the given data.", 
-        "name": "update", 
-        "parameters": [
-          {
-            "description": "The ID of the contextual identity cookie store. ", 
-            "name": "cookieStoreId", 
-            "type": "string"
-          }, 
-          {
-            "description": "Details about the contextual identity being created.", 
-            "name": "details", 
+            "description": "Details about the contextual identity being created.",
+            "name": "details",
             "properties": {
               "color": {
-                "description": "The color of the contextual identity.", 
-                "optional": true, 
+                "description": "The color of the contextual identity.",
+                "optional": false,
                 "type": "string"
-              }, 
+              },
               "icon": {
-                "description": "The icon of the contextual identity.", 
-                "optional": true, 
+                "description": "The icon of the contextual identity.",
+                "optional": false,
                 "type": "string"
-              }, 
+              },
               "name": {
-                "description": "The name of the contextual identity.", 
-                "optional": true, 
+                "description": "The name of the contextual identity.",
+                "optional": false,
                 "type": "string"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": true, 
-        "description": "Deletes a contetual identity by its cookie Store ID.", 
-        "name": "remove", 
+        "async": true,
+        "description": "Updates a contextual identity with the given data.",
+        "name": "update",
         "parameters": [
           {
-            "description": "The ID of the contextual identity cookie store. ", 
-            "name": "cookieStoreId", 
+            "description": "The ID of the contextual identity cookie store. ",
+            "name": "cookieStoreId",
+            "type": "string"
+          },
+          {
+            "description": "Details about the contextual identity being created.",
+            "name": "details",
+            "properties": {
+              "color": {
+                "description": "The color of the contextual identity.",
+                "optional": true,
+                "type": "string"
+              },
+              "icon": {
+                "description": "The icon of the contextual identity.",
+                "optional": true,
+                "type": "string"
+              },
+              "name": {
+                "description": "The name of the contextual identity.",
+                "optional": true,
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": true,
+        "description": "Deletes a contetual identity by its cookie Store ID.",
+        "name": "remove",
+        "parameters": [
+          {
+            "description": "The ID of the contextual identity cookie store. ",
+            "name": "cookieStoreId",
             "type": "string"
           }
-        ], 
+        ],
         "type": "function"
       }
-    ], 
-    "namespace": "contextualIdentities", 
+    ],
+    "namespace": "contextualIdentities",
     "permissions": [
       "contextualIdentities"
-    ], 
+    ],
     "types": [
       {
-        "description": "Represents information about a contextual identity.", 
-        "id": "ContextualIdentity", 
+        "description": "Represents information about a contextual identity.",
+        "id": "ContextualIdentity",
         "properties": {
           "color": {
-            "description": "The color name of the contextual identity.", 
+            "description": "The color name of the contextual identity.",
             "type": "string"
-          }, 
+          },
           "colorCode": {
-            "description": "The color hash of the contextual identity.", 
+            "description": "The color hash of the contextual identity.",
             "type": "string"
-          }, 
+          },
           "cookieStoreId": {
-            "description": "The cookie store ID of the contextual identity.", 
+            "description": "The cookie store ID of the contextual identity.",
             "type": "string"
-          }, 
+          },
           "icon": {
-            "description": "The icon name of the contextual identity.", 
+            "description": "The icon name of the contextual identity.",
             "type": "string"
-          }, 
+          },
           "iconUrl": {
-            "description": "The icon url of the contextual identity.", 
+            "description": "The icon url of the contextual identity.",
             "type": "string"
-          }, 
+          },
           "name": {
-            "description": "The name of the contextual identity.", 
+            "description": "The name of the contextual identity.",
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
       }
     ]
-  }, 
+  },
   {
-    "description": "Use the <code>browser.cookies</code> API to query and modify cookies, and to be notified when they change.", 
+    "description": "Use the <code>browser.cookies</code> API to query and modify cookies, and to be notified when they change.",
     "events": [
       {
-        "description": "Fired when a cookie is set or removed. As a special case, note that updating a cookie's properties is implemented as a two step process: the cookie to be updated is first removed entirely, generating a notification with \"cause\" of \"overwrite\" .  Afterwards, a new cookie is written with the updated values, generating a second notification with \"cause\" \"explicit\".", 
-        "name": "onChanged", 
+        "description": "Fired when a cookie is set or removed. As a special case, note that updating a cookie's properties is implemented as a two step process: the cookie to be updated is first removed entirely, generating a notification with \"cause\" of \"overwrite\" .  Afterwards, a new cookie is written with the updated values, generating a second notification with \"cause\" \"explicit\".",
+        "name": "onChanged",
         "parameters": [
           {
-            "name": "changeInfo", 
+            "name": "changeInfo",
             "properties": {
               "cause": {
-                "$ref": "OnChangedCause", 
+                "$ref": "OnChangedCause",
                 "description": "The underlying reason behind the cookie's change."
-              }, 
+              },
               "cookie": {
-                "$ref": "Cookie", 
+                "$ref": "Cookie",
                 "description": "Information about the cookie that was set or removed."
-              }, 
+              },
               "removed": {
-                "description": "True if a cookie was removed.", 
+                "description": "True if a cookie was removed.",
                 "type": "boolean"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "type": "function"
       }
-    ], 
+    ],
     "functions": [
       {
-        "async": "callback", 
-        "description": "Retrieves information about a single cookie. If more than one cookie of the same name exists for the given URL, the one with the longest path will be returned. For cookies with the same path length, the cookie with the earliest creation time will be returned.", 
-        "name": "get", 
+        "async": "callback",
+        "description": "Retrieves information about a single cookie. If more than one cookie of the same name exists for the given URL, the one with the longest path will be returned. For cookies with the same path length, the cookie with the earliest creation time will be returned.",
+        "name": "get",
         "parameters": [
           {
-            "description": "Details to identify the cookie being retrieved.", 
-            "name": "details", 
+            "description": "Details to identify the cookie being retrieved.",
+            "name": "details",
             "properties": {
+              "firstPartyDomain": {
+                "description": "The first-party domain which the cookie to retrieve is associated. This attribute is required if First-Party Isolation is enabled.",
+                "optional": true,
+                "type": "string"
+              },
               "name": {
-                "description": "The name of the cookie to retrieve.", 
+                "description": "The name of the cookie to retrieve.",
                 "type": "string"
-              }, 
+              },
               "storeId": {
-                "description": "The ID of the cookie store in which to look for the cookie. By default, the current execution context's cookie store will be used.", 
-                "optional": true, 
+                "description": "The ID of the cookie store in which to look for the cookie. By default, the current execution context's cookie store will be used.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "url": {
-                "description": "The URL with which the cookie to retrieve is associated. This argument may be a full URL, in which case any data following the URL path (e.g. the query string) is simply ignored. If host permissions for this URL are not specified in the manifest file, the API call will fail.", 
+                "description": "The URL with which the cookie to retrieve is associated. This argument may be a full URL, in which case any data following the URL path (e.g. the query string) is simply ignored. If host permissions for this URL are not specified in the manifest file, the API call will fail.",
                 "type": "string"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
-                "$ref": "Cookie", 
-                "description": "Contains details about the cookie. This parameter is null if no such cookie was found.", 
-                "name": "cookie", 
+                "$ref": "Cookie",
+                "description": "Contains details about the cookie. This parameter is null if no such cookie was found.",
+                "name": "cookie",
                 "optional": true
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Retrieves all cookies from a single cookie store that match the given information.  The cookies returned will be sorted, with those with the longest path first.  If multiple cookies have the same path length, those with the earliest creation time will be first.", 
-        "name": "getAll", 
+        "async": "callback",
+        "description": "Retrieves all cookies from a single cookie store that match the given information.  The cookies returned will be sorted, with those with the longest path first.  If multiple cookies have the same path length, those with the earliest creation time will be first.",
+        "name": "getAll",
         "parameters": [
           {
-            "description": "Information to filter the cookies being retrieved.", 
-            "name": "details", 
+            "description": "Information to filter the cookies being retrieved.",
+            "name": "details",
             "properties": {
               "domain": {
-                "description": "Restricts the retrieved cookies to those whose domains match or are subdomains of this one.", 
-                "optional": true, 
+                "description": "Restricts the retrieved cookies to those whose domains match or are subdomains of this one.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
+              "firstPartyDomain": {
+                "description": "Restricts the retrieved cookies to those whose first-party domains match this one. This attribute is required if First-Party Isolation is enabled. To not filter by a specific first-party domain, use `null` or `undefined`.",
+                "optional": "omit-key-if-missing",
+                "type": "string"
+              },
               "name": {
-                "description": "Filters the cookies by name.", 
-                "optional": true, 
+                "description": "Filters the cookies by name.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "path": {
-                "description": "Restricts the retrieved cookies to those whose path exactly matches this string.", 
-                "optional": true, 
+                "description": "Restricts the retrieved cookies to those whose path exactly matches this string.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "secure": {
-                "description": "Filters the cookies by their Secure property.", 
-                "optional": true, 
+                "description": "Filters the cookies by their Secure property.",
+                "optional": true,
                 "type": "boolean"
-              }, 
+              },
               "session": {
-                "description": "Filters out session vs. persistent cookies.", 
-                "optional": true, 
+                "description": "Filters out session vs. persistent cookies.",
+                "optional": true,
                 "type": "boolean"
-              }, 
+              },
               "storeId": {
-                "description": "The cookie store to retrieve cookies from. If omitted, the current execution context's cookie store will be used.", 
-                "optional": true, 
+                "description": "The cookie store to retrieve cookies from. If omitted, the current execution context's cookie store will be used.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "url": {
-                "description": "Restricts the retrieved cookies to those that would match the given URL.", 
-                "optional": true, 
+                "description": "Restricts the retrieved cookies to those that would match the given URL.",
+                "optional": true,
                 "type": "string"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
-                "description": "All the existing, unexpired cookies that match the given cookie info.", 
+                "description": "All the existing, unexpired cookies that match the given cookie info.",
                 "items": {
                   "$ref": "Cookie"
-                }, 
-                "name": "cookies", 
+                },
+                "name": "cookies",
                 "type": "array"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Sets a cookie with the given cookie data; may overwrite equivalent cookies if they exist.", 
-        "name": "set", 
+        "async": "callback",
+        "description": "Sets a cookie with the given cookie data; may overwrite equivalent cookies if they exist.",
+        "name": "set",
         "parameters": [
           {
-            "description": "Details about the cookie being set.", 
-            "name": "details", 
+            "description": "Details about the cookie being set.",
+            "name": "details",
             "properties": {
               "domain": {
-                "description": "The domain of the cookie. If omitted, the cookie becomes a host-only cookie.", 
-                "optional": true, 
+                "description": "The domain of the cookie. If omitted, the cookie becomes a host-only cookie.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "expirationDate": {
-                "description": "The expiration date of the cookie as the number of seconds since the UNIX epoch. If omitted, the cookie becomes a session cookie.", 
-                "optional": true, 
+                "description": "The expiration date of the cookie as the number of seconds since the UNIX epoch. If omitted, the cookie becomes a session cookie.",
+                "optional": true,
                 "type": "number"
-              }, 
+              },
+              "firstPartyDomain": {
+                "description": "The first-party domain of the cookie. This attribute is required if First-Party Isolation is enabled.",
+                "optional": true,
+                "type": "string"
+              },
               "httpOnly": {
-                "description": "Whether the cookie should be marked as HttpOnly. Defaults to false.", 
-                "optional": true, 
+                "description": "Whether the cookie should be marked as HttpOnly. Defaults to false.",
+                "optional": true,
                 "type": "boolean"
-              }, 
+              },
               "name": {
-                "description": "The name of the cookie. Empty by default if omitted.", 
-                "optional": true, 
+                "description": "The name of the cookie. Empty by default if omitted.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "path": {
-                "description": "The path of the cookie. Defaults to the path portion of the url parameter.", 
-                "optional": true, 
+                "description": "The path of the cookie. Defaults to the path portion of the url parameter.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
+              "sameSite": {
+                "$ref": "SameSiteStatus",
+                "default": "no_restriction",
+                "description": "The cookie's same-site status.",
+                "optional": true
+              },
               "secure": {
-                "description": "Whether the cookie should be marked as Secure. Defaults to false.", 
-                "optional": true, 
+                "description": "Whether the cookie should be marked as Secure. Defaults to false.",
+                "optional": true,
                 "type": "boolean"
-              }, 
+              },
               "storeId": {
-                "description": "The ID of the cookie store in which to set the cookie. By default, the cookie is set in the current execution context's cookie store.", 
-                "optional": true, 
+                "description": "The ID of the cookie store in which to set the cookie. By default, the cookie is set in the current execution context's cookie store.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "url": {
-                "description": "The request-URI to associate with the setting of the cookie. This value can affect the default domain and path values of the created cookie. If host permissions for this URL are not specified in the manifest file, the API call will fail.", 
+                "description": "The request-URI to associate with the setting of the cookie. This value can affect the default domain and path values of the created cookie. If host permissions for this URL are not specified in the manifest file, the API call will fail.",
                 "type": "string"
-              }, 
+              },
               "value": {
-                "description": "The value of the cookie. Empty by default if omitted.", 
-                "optional": true, 
+                "description": "The value of the cookie. Empty by default if omitted.",
+                "optional": true,
                 "type": "string"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
+            "name": "callback",
+            "optional": true,
             "parameters": [
               {
-                "$ref": "Cookie", 
-                "description": "Contains details about the cookie that's been set.  If setting failed for any reason, this will be \"null\", and $(ref:runtime.lastError) will be set.", 
-                "name": "cookie", 
+                "$ref": "Cookie",
+                "description": "Contains details about the cookie that's been set.  If setting failed for any reason, this will be \"null\", and $(ref:runtime.lastError) will be set.",
+                "name": "cookie",
                 "optional": true
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Deletes a cookie by name.", 
-        "name": "remove", 
+        "async": "callback",
+        "description": "Deletes a cookie by name.",
+        "name": "remove",
         "parameters": [
           {
-            "description": "Information to identify the cookie to remove.", 
-            "name": "details", 
+            "description": "Information to identify the cookie to remove.",
+            "name": "details",
             "properties": {
+              "firstPartyDomain": {
+                "description": "The first-party domain associated with the cookie. This attribute is required if First-Party Isolation is enabled.",
+                "optional": true,
+                "type": "string"
+              },
               "name": {
-                "description": "The name of the cookie to remove.", 
+                "description": "The name of the cookie to remove.",
                 "type": "string"
-              }, 
+              },
               "storeId": {
-                "description": "The ID of the cookie store to look in for the cookie. If unspecified, the cookie is looked for by default in the current execution context's cookie store.", 
-                "optional": true, 
+                "description": "The ID of the cookie store to look in for the cookie. If unspecified, the cookie is looked for by default in the current execution context's cookie store.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "url": {
-                "description": "The URL associated with the cookie. If host permissions for this URL are not specified in the manifest file, the API call will fail.", 
+                "description": "The URL associated with the cookie. If host permissions for this URL are not specified in the manifest file, the API call will fail.",
                 "type": "string"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
+            "name": "callback",
+            "optional": true,
             "parameters": [
               {
-                "description": "Contains details about the cookie that's been removed.  If removal failed for any reason, this will be \"null\", and $(ref:runtime.lastError) will be set.", 
-                "name": "details", 
-                "optional": true, 
+                "description": "Contains details about the cookie that's been removed.  If removal failed for any reason, this will be \"null\", and $(ref:runtime.lastError) will be set.",
+                "name": "details",
+                "optional": true,
                 "properties": {
+                  "firstPartyDomain": {
+                    "description": "The first-party domain associated with the cookie that's been removed.",
+                    "type": "string"
+                  },
                   "name": {
-                    "description": "The name of the cookie that's been removed.", 
+                    "description": "The name of the cookie that's been removed.",
                     "type": "string"
-                  }, 
+                  },
                   "storeId": {
-                    "description": "The ID of the cookie store from which the cookie was removed.", 
+                    "description": "The ID of the cookie store from which the cookie was removed.",
                     "type": "string"
-                  }, 
+                  },
                   "url": {
-                    "description": "The URL associated with the cookie that's been removed.", 
+                    "description": "The URL associated with the cookie that's been removed.",
                     "type": "string"
                   }
-                }, 
+                },
                 "type": "object"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Lists all existing cookie stores.", 
-        "name": "getAllCookieStores", 
+        "async": "callback",
+        "description": "Lists all existing cookie stores.",
+        "name": "getAllCookieStores",
         "parameters": [
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
-                "description": "All the existing cookie stores.", 
+                "description": "All the existing cookie stores.",
                 "items": {
                   "$ref": "CookieStore"
-                }, 
-                "name": "cookieStores", 
+                },
+                "name": "cookieStores",
                 "type": "array"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
       }
-    ], 
-    "namespace": "cookies", 
+    ],
+    "namespace": "cookies",
     "permissions": [
       "cookies"
-    ], 
+    ],
     "types": [
       {
-        "description": "Represents information about an HTTP cookie.", 
-        "id": "Cookie", 
+        "description": "A cookie's 'SameSite' state (https://tools.ietf.org/html/draft-west-first-party-cookies). 'no_restriction' corresponds to a cookie set without a 'SameSite' attribute, 'lax' to 'SameSite=Lax', and 'strict' to 'SameSite=Strict'.",
+        "enum": [
+          "no_restriction",
+          "lax",
+          "strict"
+        ],
+        "id": "SameSiteStatus",
+        "type": "string"
+      },
+      {
+        "description": "Represents information about an HTTP cookie.",
+        "id": "Cookie",
         "properties": {
           "domain": {
-            "description": "The domain of the cookie (e.g. \"www.google.com\", \"example.com\").", 
+            "description": "The domain of the cookie (e.g. \"www.google.com\", \"example.com\").",
             "type": "string"
-          }, 
+          },
           "expirationDate": {
-            "description": "The expiration date of the cookie as the number of seconds since the UNIX epoch. Not provided for session cookies.", 
-            "optional": true, 
+            "description": "The expiration date of the cookie as the number of seconds since the UNIX epoch. Not provided for session cookies.",
+            "optional": true,
             "type": "number"
-          }, 
+          },
+          "firstPartyDomain": {
+            "description": "The first-party domain of the cookie.",
+            "type": "string"
+          },
           "hostOnly": {
-            "description": "True if the cookie is a host-only cookie (i.e. a request's host must exactly match the domain of the cookie).", 
+            "description": "True if the cookie is a host-only cookie (i.e. a request's host must exactly match the domain of the cookie).",
             "type": "boolean"
-          }, 
+          },
           "httpOnly": {
-            "description": "True if the cookie is marked as HttpOnly (i.e. the cookie is inaccessible to client-side scripts).", 
+            "description": "True if the cookie is marked as HttpOnly (i.e. the cookie is inaccessible to client-side scripts).",
             "type": "boolean"
-          }, 
+          },
           "name": {
-            "description": "The name of the cookie.", 
+            "description": "The name of the cookie.",
             "type": "string"
-          }, 
+          },
           "path": {
-            "description": "The path of the cookie.", 
+            "description": "The path of the cookie.",
             "type": "string"
-          }, 
+          },
+          "sameSite": {
+            "$ref": "SameSiteStatus",
+            "description": "The cookie's same-site status (i.e. whether the cookie is sent with cross-site requests)."
+          },
           "secure": {
-            "description": "True if the cookie is marked as Secure (i.e. its scope is limited to secure channels, typically HTTPS).", 
+            "description": "True if the cookie is marked as Secure (i.e. its scope is limited to secure channels, typically HTTPS).",
             "type": "boolean"
-          }, 
+          },
           "session": {
-            "description": "True if the cookie is a session cookie, as opposed to a persistent cookie with an expiration date.", 
+            "description": "True if the cookie is a session cookie, as opposed to a persistent cookie with an expiration date.",
             "type": "boolean"
-          }, 
+          },
           "storeId": {
-            "description": "The ID of the cookie store containing this cookie, as provided in getAllCookieStores().", 
+            "description": "The ID of the cookie store containing this cookie, as provided in getAllCookieStores().",
             "type": "string"
-          }, 
+          },
           "value": {
-            "description": "The value of the cookie.", 
+            "description": "The value of the cookie.",
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       {
-        "description": "Represents a cookie store in the browser. An incognito mode window, for instance, uses a separate cookie store from a non-incognito window.", 
-        "id": "CookieStore", 
+        "description": "Represents a cookie store in the browser. An incognito mode window, for instance, uses a separate cookie store from a non-incognito window.",
+        "id": "CookieStore",
         "properties": {
           "id": {
-            "description": "The unique identifier for the cookie store.", 
+            "description": "The unique identifier for the cookie store.",
             "type": "string"
-          }, 
+          },
           "incognito": {
-            "description": "Indicates if this is an incognito cookie store", 
+            "description": "Indicates if this is an incognito cookie store",
             "type": "boolean"
-          }, 
+          },
           "tabIds": {
-            "description": "Identifiers of all the browser tabs that share this cookie store.", 
+            "description": "Identifiers of all the browser tabs that share this cookie store.",
             "items": {
               "type": "integer"
-            }, 
+            },
             "type": "array"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       {
-        "description": "The underlying reason behind the cookie's change. If a cookie was inserted, or removed via an explicit call to $(ref:cookies.remove), \"cause\" will be \"explicit\". If a cookie was automatically removed due to expiry, \"cause\" will be \"expired\". If a cookie was removed due to being overwritten with an already-expired expiration date, \"cause\" will be set to \"expired_overwrite\".  If a cookie was automatically removed due to garbage collection, \"cause\" will be \"evicted\".  If a cookie was automatically removed due to a \"set\" call that overwrote it, \"cause\" will be \"overwrite\". Plan your response accordingly.", 
+        "description": "The underlying reason behind the cookie's change. If a cookie was inserted, or removed via an explicit call to $(ref:cookies.remove), \"cause\" will be \"explicit\". If a cookie was automatically removed due to expiry, \"cause\" will be \"expired\". If a cookie was removed due to being overwritten with an already-expired expiration date, \"cause\" will be set to \"expired_overwrite\".  If a cookie was automatically removed due to garbage collection, \"cause\" will be \"evicted\".  If a cookie was automatically removed due to a \"set\" call that overwrote it, \"cause\" will be \"overwrite\". Plan your response accordingly.",
         "enum": [
-          "evicted", 
-          "expired", 
-          "explicit", 
-          "expired_overwrite", 
+          "evicted",
+          "expired",
+          "explicit",
+          "expired_overwrite",
           "overwrite"
-        ], 
-        "id": "OnChangedCause", 
+        ],
+        "id": "OnChangedCause",
         "type": "string"
       }
     ]
-  }, 
+  },
   {
     "allowedContexts": [
-      "devtools", 
+      "devtools",
       "devtools_only"
-    ], 
+    ],
     "defaultContexts": [
-      "devtools", 
+      "devtools",
       "devtools_only"
-    ], 
-    "namespace": "devtools", 
+    ],
+    "namespace": "devtools",
     "permissions": [
-      "devtools"
+      "manifest:devtools_page"
     ]
-  }, 
+  },
   {
     "allowedContexts": [
-      "devtools", 
+      "devtools",
       "devtools_only"
-    ], 
+    ],
     "defaultContexts": [
-      "devtools", 
+      "devtools",
       "devtools_only"
-    ], 
-    "description": "Use the <code>chrome.devtools.inspectedWindow</code> API to interact with the inspected window: obtain the tab ID for the inspected page, evaluate the code in the context of the inspected window, reload the page, or obtain the list of resources within the page.", 
+    ],
+    "description": "Use the <code>chrome.devtools.inspectedWindow</code> API to interact with the inspected window: obtain the tab ID for the inspected page, evaluate the code in the context of the inspected window, reload the page, or obtain the list of resources within the page.",
     "events": [
       {
-        "description": "Fired when a new resource is added to the inspected page.", 
-        "name": "onResourceAdded", 
+        "description": "Fired when a new resource is added to the inspected page.",
+        "name": "onResourceAdded",
         "parameters": [
           {
-            "$ref": "Resource", 
+            "$ref": "Resource",
             "name": "resource"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
-      }, 
+      },
       {
-        "description": "Fired when a new revision of the resource is committed (e.g. user saves an edited version of the resource in the Developer Tools).", 
-        "name": "onResourceContentCommitted", 
+        "description": "Fired when a new revision of the resource is committed (e.g. user saves an edited version of the resource in the Developer Tools).",
+        "name": "onResourceContentCommitted",
         "parameters": [
           {
-            "$ref": "Resource", 
+            "$ref": "Resource",
             "name": "resource"
-          }, 
+          },
           {
-            "description": "New content of the resource.", 
-            "name": "content", 
+            "description": "New content of the resource.",
+            "name": "content",
             "type": "string"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
       }
-    ], 
+    ],
     "functions": [
       {
-        "async": "callback", 
-        "description": "Evaluates a JavaScript expression in the context of the main frame of the inspected page. The expression must evaluate to a JSON-compliant object, otherwise an exception is thrown. The eval function can report either a DevTools-side error or a JavaScript exception that occurs during evaluation. In either case, the <code>result</code> parameter of the callback is <code>undefined</code>. In the case of a DevTools-side error, the <code>isException</code> parameter is non-null and has <code>isError</code> set to true and <code>code</code> set to an error code. In the case of a JavaScript error, <code>isException</code> is set to true and <code>value</code> is set to the string value of thrown object.", 
-        "name": "eval", 
+        "async": "callback",
+        "description": "Evaluates a JavaScript expression in the context of the main frame of the inspected page. The expression must evaluate to a JSON-compliant object, otherwise an exception is thrown. The eval function can report either a DevTools-side error or a JavaScript exception that occurs during evaluation. In either case, the <code>result</code> parameter of the callback is <code>undefined</code>. In the case of a DevTools-side error, the <code>isException</code> parameter is non-null and has <code>isError</code> set to true and <code>code</code> set to an error code. In the case of a JavaScript error, <code>isException</code> is set to true and <code>value</code> is set to the string value of thrown object.",
+        "name": "eval",
         "parameters": [
           {
-            "description": "An expression to evaluate.", 
-            "name": "expression", 
+            "description": "An expression to evaluate.",
+            "name": "expression",
             "type": "string"
-          }, 
+          },
           {
-            "description": "The options parameter can contain one or more options.", 
-            "name": "options", 
-            "optional": true, 
+            "description": "The options parameter can contain one or more options.",
+            "name": "options",
+            "optional": true,
             "properties": {
               "contextSecurityOrigin": {
-                "description": "Evaluate the expression in the context of a content script of an extension that matches the specified origin. If given, contextSecurityOrigin overrides the 'true' setting on userContentScriptContext.", 
-                "optional": true, 
-                "type": "string", 
+                "description": "Evaluate the expression in the context of a content script of an extension that matches the specified origin. If given, contextSecurityOrigin overrides the 'true' setting on userContentScriptContext.",
+                "optional": true,
+                "type": "string",
                 "unsupported": true
-              }, 
+              },
               "frameURL": {
-                "description": "If specified, the expression is evaluated on the iframe whose URL matches the one specified. By default, the expression is evaluated in the top frame of the inspected page.", 
-                "optional": true, 
-                "type": "string", 
+                "description": "If specified, the expression is evaluated on the iframe whose URL matches the one specified. By default, the expression is evaluated in the top frame of the inspected page.",
+                "optional": true,
+                "type": "string",
                 "unsupported": true
-              }, 
+              },
               "useContentScriptContext": {
-                "description": "Evaluate the expression in the context of the content script of the calling extension, provided that the content script is already injected into the inspected page. If not, the expression is not evaluated and the callback is invoked with the exception parameter set to an object that has the <code>isError</code> field set to true and the <code>code</code> field set to <code>E_NOTFOUND</code>.", 
-                "optional": true, 
-                "type": "boolean", 
+                "description": "Evaluate the expression in the context of the content script of the calling extension, provided that the content script is already injected into the inspected page. If not, the expression is not evaluated and the callback is invoked with the exception parameter set to an object that has the <code>isError</code> field set to true and the <code>code</code> field set to <code>E_NOTFOUND</code>.",
+                "optional": true,
+                "type": "boolean",
                 "unsupported": true
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "description": "A function called when evaluation completes.", 
-            "name": "callback", 
-            "optional": true, 
+            "description": "A function called when evaluation completes.",
+            "name": "callback",
+            "optional": true,
             "parameters": [
               {
-                "description": "The result of evaluation.", 
-                "name": "result", 
+                "description": "The result of evaluation.",
+                "name": "result",
                 "type": "any"
-              }, 
+              },
               {
-                "description": "An object providing details if an exception occurred while evaluating the expression.", 
-                "name": "exceptionInfo", 
-                "optional": true, 
+                "description": "An object providing details if an exception occurred while evaluating the expression.",
+                "name": "exceptionInfo",
+                "optional": true,
                 "properties": {
                   "code": {
-                    "description": "Set if the error occurred on the DevTools side before the expression is evaluated.", 
+                    "description": "Set if the error occurred on the DevTools side before the expression is evaluated.",
                     "type": "string"
-                  }, 
+                  },
                   "description": {
-                    "description": "Set if the error occurred on the DevTools side before the expression is evaluated.", 
+                    "description": "Set if the error occurred on the DevTools side before the expression is evaluated.",
                     "type": "string"
-                  }, 
+                  },
                   "details": {
-                    "description": "Set if the error occurred on the DevTools side before the expression is evaluated, contains the array of the values that may be substituted into the description string to provide more information about the cause of the error.", 
+                    "description": "Set if the error occurred on the DevTools side before the expression is evaluated, contains the array of the values that may be substituted into the description string to provide more information about the cause of the error.",
                     "items": {
                       "type": "any"
-                    }, 
+                    },
                     "type": "array"
-                  }, 
+                  },
                   "isError": {
-                    "description": "Set if the error occurred on the DevTools side before the expression is evaluated.", 
+                    "description": "Set if the error occurred on the DevTools side before the expression is evaluated.",
                     "type": "boolean"
-                  }, 
+                  },
                   "isException": {
-                    "description": "Set if the evaluated code produces an unhandled exception.", 
+                    "description": "Set if the evaluated code produces an unhandled exception.",
                     "type": "boolean"
-                  }, 
+                  },
                   "value": {
-                    "description": "Set if the evaluated code produces an unhandled exception.", 
+                    "description": "Set if the evaluated code produces an unhandled exception.",
                     "type": "string"
                   }
-                }, 
+                },
                 "type": "object"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Reloads the inspected page.", 
-        "name": "reload", 
+        "description": "Reloads the inspected page.",
+        "name": "reload",
         "parameters": [
           {
-            "name": "reloadOptions", 
-            "optional": true, 
+            "name": "reloadOptions",
+            "optional": true,
             "properties": {
               "ignoreCache": {
-                "description": "When true, the loader will bypass the cache for all inspected page resources loaded before the <code>load</code> event is fired. The effect is similar to pressing Ctrl+Shift+R in the inspected window or within the Developer Tools window.", 
-                "optional": true, 
+                "description": "When true, the loader will bypass the cache for all inspected page resources loaded before the <code>load</code> event is fired. The effect is similar to pressing Ctrl+Shift+R in the inspected window or within the Developer Tools window.",
+                "optional": true,
                 "type": "boolean"
-              }, 
+              },
               "injectedScript": {
-                "description": "If specified, the script will be injected into every frame of the inspected page immediately upon load, before any of the frame's scripts. The script will not be injected after subsequent reloads&mdash;for example, if the user presses Ctrl+R.", 
-                "optional": true, 
+                "description": "If specified, the script will be injected into every frame of the inspected page immediately upon load, before any of the frame's scripts. The script will not be injected after subsequent reloads&mdash;for example, if the user presses Ctrl+R.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "preprocessorScript": {
-                "deprecated": "Please avoid using this parameter, it will be removed soon.", 
-                "description": "If specified, this script evaluates into a function that accepts three string arguments: the source to preprocess, the URL of the source, and a function name if the source is an DOM event handler. The preprocessorerScript function should return a string to be compiled by Chrome in place of the input source. In the case that the source is a DOM event handler, the returned source must compile to a single JS function.", 
-                "optional": true, 
-                "type": "string", 
+                "deprecated": "Please avoid using this parameter, it will be removed soon.",
+                "description": "If specified, this script evaluates into a function that accepts three string arguments: the source to preprocess, the URL of the source, and a function name if the source is an DOM event handler. The preprocessorerScript function should return a string to be compiled by Chrome in place of the input source. In the case that the source is a DOM event handler, the returned source must compile to a single JS function.",
+                "optional": true,
+                "type": "string",
                 "unsupported": true
-              }, 
+              },
               "userAgent": {
-                "description": "If specified, the string will override the value of the <code>User-Agent</code> HTTP header that's sent while loading the resources of the inspected page. The string will also override the value of the <code>navigator.userAgent</code> property that's returned to any scripts that are running within the inspected page.", 
-                "optional": true, 
+                "description": "If specified, the string will override the value of the <code>User-Agent</code> HTTP header that's sent while loading the resources of the inspected page. The string will also override the value of the <code>navigator.userAgent</code> property that's returned to any scripts that are running within the inspected page.",
+                "optional": true,
                 "type": "string"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Retrieves the list of resources from the inspected page.", 
-        "name": "getResources", 
+        "async": "callback",
+        "description": "Retrieves the list of resources from the inspected page.",
+        "name": "getResources",
         "parameters": [
           {
-            "description": "A function that receives the list of resources when the request completes.", 
-            "name": "callback", 
+            "description": "A function that receives the list of resources when the request completes.",
+            "name": "callback",
             "parameters": [
               {
-                "description": "The resources within the page.", 
+                "description": "The resources within the page.",
                 "items": {
                   "$ref": "Resource"
-                }, 
-                "name": "resources", 
+                },
+                "name": "resources",
                 "type": "array"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
       }
-    ], 
-    "namespace": "devtools.inspectedWindow", 
-    "nocompile": true, 
+    ],
+    "namespace": "devtools.inspectedWindow",
+    "nocompile": true,
     "properties": {
       "tabId": {
-        "description": "The ID of the tab being inspected. This ID may be used with chrome.tabs.* API.", 
+        "description": "The ID of the tab being inspected. This ID may be used with chrome.tabs.* API.",
         "type": "integer"
       }
-    }, 
+    },
     "types": [
       {
-        "description": "A resource within the inspected page, such as a document, a script, or an image.", 
+        "description": "A resource within the inspected page, such as a document, a script, or an image.",
         "functions": [
           {
-            "async": "callback", 
-            "description": "Gets the content of the resource.", 
-            "name": "getContent", 
+            "async": "callback",
+            "description": "Gets the content of the resource.",
+            "name": "getContent",
             "parameters": [
               {
-                "description": "A function that receives resource content when the request completes.", 
-                "name": "callback", 
+                "description": "A function that receives resource content when the request completes.",
+                "name": "callback",
                 "parameters": [
                   {
-                    "description": "Content of the resource (potentially encoded).", 
-                    "name": "content", 
+                    "description": "Content of the resource (potentially encoded).",
+                    "name": "content",
                     "type": "string"
-                  }, 
+                  },
                   {
-                    "description": "Empty if content is not encoded, encoding name otherwise. Currently, only base64 is supported.", 
-                    "name": "encoding", 
+                    "description": "Empty if content is not encoded, encoding name otherwise. Currently, only base64 is supported.",
+                    "name": "encoding",
                     "type": "string"
                   }
-                ], 
+                ],
                 "type": "function"
               }
-            ], 
-            "type": "function", 
+            ],
+            "type": "function",
             "unsupported": true
-          }, 
+          },
           {
-            "async": "callback", 
-            "description": "Sets the content of the resource.", 
-            "name": "setContent", 
+            "async": "callback",
+            "description": "Sets the content of the resource.",
+            "name": "setContent",
             "parameters": [
               {
-                "description": "New content of the resource. Only resources with the text type are currently supported.", 
-                "name": "content", 
+                "description": "New content of the resource. Only resources with the text type are currently supported.",
+                "name": "content",
                 "type": "string"
-              }, 
+              },
               {
-                "description": "True if the user has finished editing the resource, and the new content of the resource should be persisted; false if this is a minor change sent in progress of the user editing the resource.", 
-                "name": "commit", 
+                "description": "True if the user has finished editing the resource, and the new content of the resource should be persisted; false if this is a minor change sent in progress of the user editing the resource.",
+                "name": "commit",
                 "type": "boolean"
-              }, 
+              },
               {
-                "description": "A function called upon request completion.", 
-                "name": "callback", 
-                "optional": true, 
+                "description": "A function called upon request completion.",
+                "name": "callback",
+                "optional": true,
                 "parameters": [
                   {
                     "additionalProperties": {
                       "type": "any"
-                    }, 
-                    "description": "Set to undefined if the resource content was set successfully; describes error otherwise.", 
-                    "name": "error", 
-                    "optional": true, 
+                    },
+                    "description": "Set to undefined if the resource content was set successfully; describes error otherwise.",
+                    "name": "error",
+                    "optional": true,
                     "type": "object"
                   }
-                ], 
+                ],
                 "type": "function"
               }
-            ], 
-            "type": "function", 
+            ],
+            "type": "function",
             "unsupported": true
           }
-        ], 
-        "id": "Resource", 
+        ],
+        "id": "Resource",
         "properties": {
           "url": {
-            "description": "The URL of the resource.", 
+            "description": "The URL of the resource.",
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
       }
     ]
-  }, 
+  },
   {
     "allowedContexts": [
-      "devtools", 
+      "devtools",
       "devtools_only"
-    ], 
+    ],
     "defaultContexts": [
-      "devtools", 
+      "devtools",
       "devtools_only"
-    ], 
-    "description": "Use the <code>chrome.devtools.network</code> API to retrieve the information about network requests displayed by the Developer Tools in the Network panel.", 
+    ],
+    "description": "Use the <code>chrome.devtools.network</code> API to retrieve the information about network requests displayed by the Developer Tools in the Network panel.",
     "events": [
       {
-        "description": "Fired when a network request is finished and all request data are available.", 
-        "name": "onRequestFinished", 
+        "description": "Fired when a network request is finished and all request data are available.",
+        "name": "onRequestFinished",
         "parameters": [
           {
-            "$ref": "Request", 
-            "description": "Description of a network request in the form of a HAR entry. See HAR specification for details.", 
+            "$ref": "Request",
+            "description": "Description of a network request in the form of a HAR entry. See HAR specification for details.",
             "name": "request"
           }
-        ], 
-        "type": "function", 
-        "unsupported": true
-      }, 
+        ],
+        "type": "function"
+      },
       {
-        "description": "Fired when the inspected window navigates to a new page.", 
-        "name": "onNavigated", 
+        "description": "Fired when the inspected window navigates to a new page.",
+        "name": "onNavigated",
         "parameters": [
           {
-            "description": "URL of the new page.", 
-            "name": "url", 
+            "description": "URL of the new page.",
+            "name": "url",
             "type": "string"
           }
-        ], 
+        ],
         "type": "function"
       }
-    ], 
+    ],
     "functions": [
       {
-        "async": "callback", 
-        "description": "Returns HAR log that contains all known network requests.", 
-        "name": "getHAR", 
+        "async": "callback",
+        "description": "Returns HAR log that contains all known network requests.",
+        "name": "getHAR",
         "parameters": [
           {
-            "description": "A function that receives the HAR log when the request completes.", 
-            "name": "callback", 
+            "description": "A function that receives the HAR log when the request completes.",
+            "name": "callback",
             "parameters": [
               {
                 "additionalProperties": {
                   "type": "any"
-                }, 
-                "description": "A HAR log. See HAR specification for details.", 
-                "name": "harLog", 
+                },
+                "description": "A HAR log. See HAR specification for details.",
+                "name": "harLog",
                 "type": "object"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
-        "type": "function", 
-        "unsupported": true
+        ],
+        "type": "function"
       }
-    ], 
-    "namespace": "devtools.network", 
+    ],
+    "namespace": "devtools.network",
     "types": [
       {
-        "description": "Represents a network request for a document resource (script, image and so on). See HAR Specification for reference.", 
+        "description": "Represents a network request for a document resource (script, image and so on). See HAR Specification for reference.",
         "functions": [
           {
-            "async": "callback", 
-            "description": "Returns content of the response body.", 
-            "name": "getContent", 
+            "async": "callback",
+            "description": "Returns content of the response body.",
+            "name": "getContent",
             "parameters": [
               {
-                "description": "A function that receives the response body when the request completes.", 
-                "name": "callback", 
+                "description": "A function that receives the response body when the request completes.",
+                "name": "callback",
                 "parameters": [
                   {
-                    "description": "Content of the response body (potentially encoded).", 
-                    "name": "content", 
+                    "description": "Content of the response body (potentially encoded).",
+                    "name": "content",
                     "type": "string"
-                  }, 
+                  },
                   {
-                    "description": "Empty if content is not encoded, encoding name otherwise. Currently, only base64 is supported.", 
-                    "name": "encoding", 
+                    "description": "Empty if content is not encoded, encoding name otherwise. Currently, only base64 is supported.",
+                    "name": "encoding",
                     "type": "string"
                   }
-                ], 
+                ],
                 "type": "function"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
-        "id": "Request", 
+        ],
+        "id": "Request",
         "type": "object"
       }
     ]
-  }, 
+  },
   {
     "allowedContexts": [
-      "devtools", 
+      "devtools",
       "devtools_only"
-    ], 
+    ],
     "defaultContexts": [
-      "devtools", 
+      "devtools",
       "devtools_only"
-    ], 
-    "description": "Use the <code>chrome.devtools.panels</code> API to integrate your extension into Developer Tools window UI: create your own panels, access existing panels, and add sidebars.", 
+    ],
+    "description": "Use the <code>chrome.devtools.panels</code> API to integrate your extension into Developer Tools window UI: create your own panels, access existing panels, and add sidebars.",
     "events": [
       {
-        "description": "Fired when the devtools theme changes.", 
-        "name": "onThemeChanged", 
+        "description": "Fired when the devtools theme changes.",
+        "name": "onThemeChanged",
         "parameters": [
           {
-            "description": "The name of the current devtools theme.", 
-            "name": "themeName", 
+            "description": "The name of the current devtools theme.",
+            "name": "themeName",
             "type": "string"
           }
-        ], 
+        ],
         "type": "function"
       }
-    ], 
+    ],
     "functions": [
       {
-        "async": "callback", 
-        "description": "Creates an extension panel.", 
-        "name": "create", 
+        "async": "callback",
+        "description": "Creates an extension panel.",
+        "name": "create",
         "parameters": [
           {
-            "description": "Title that is displayed next to the extension icon in the Developer Tools toolbar.", 
-            "name": "title", 
+            "description": "Title that is displayed next to the extension icon in the Developer Tools toolbar.",
+            "name": "title",
             "type": "string"
-          }, 
+          },
           {
             "choices": [
               {
                 "enum": [
                   ""
-                ], 
+                ],
                 "type": "string"
-              }, 
+              },
               {
                 "$ref": "manifest.ExtensionURL"
               }
-            ], 
-            "description": "Path of the panel's icon relative to the extension directory, or an empty string to use the default extension icon as the panel icon.", 
+            ],
+            "description": "Path of the panel's icon relative to the extension directory, or an empty string to use the default extension icon as the panel icon.",
             "name": "iconPath"
-          }, 
+          },
           {
-            "$ref": "manifest.ExtensionURL", 
-            "description": "Path of the panel's HTML page relative to the extension directory.", 
+            "$ref": "manifest.ExtensionURL",
+            "description": "Path of the panel's HTML page relative to the extension directory.",
             "name": "pagePath"
-          }, 
+          },
           {
-            "description": "A function that is called when the panel is created.", 
-            "name": "callback", 
-            "optional": true, 
+            "description": "A function that is called when the panel is created.",
+            "name": "callback",
+            "optional": true,
             "parameters": [
               {
-                "$ref": "ExtensionPanel", 
-                "description": "An ExtensionPanel object representing the created panel.", 
+                "$ref": "ExtensionPanel",
+                "description": "An ExtensionPanel object representing the created panel.",
                 "name": "panel"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Specifies the function to be called when the user clicks a resource link in the Developer Tools window. To unset the handler, either call the method with no parameters or pass null as the parameter.", 
-        "name": "setOpenResourceHandler", 
+        "async": "callback",
+        "description": "Specifies the function to be called when the user clicks a resource link in the Developer Tools window. To unset the handler, either call the method with no parameters or pass null as the parameter.",
+        "name": "setOpenResourceHandler",
         "parameters": [
           {
-            "description": "A function that is called when the user clicks on a valid resource link in Developer Tools window. Note that if the user clicks an invalid URL or an XHR, this function is not called.", 
-            "name": "callback", 
-            "optional": true, 
+            "description": "A function that is called when the user clicks on a valid resource link in Developer Tools window. Note that if the user clicks an invalid URL or an XHR, this function is not called.",
+            "name": "callback",
+            "optional": true,
             "parameters": [
               {
-                "$ref": "devtools.inspectedWindow.Resource", 
-                "description": "A $(ref:devtools.inspectedWindow.Resource) object for the resource that was clicked.", 
+                "$ref": "devtools.inspectedWindow.Resource",
+                "description": "A $(ref:devtools.inspectedWindow.Resource) object for the resource that was clicked.",
                 "name": "resource"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Requests DevTools to open a URL in a Developer Tools panel.", 
-        "name": "openResource", 
+        "async": "callback",
+        "description": "Requests DevTools to open a URL in a Developer Tools panel.",
+        "name": "openResource",
         "parameters": [
           {
-            "description": "The URL of the resource to open.", 
-            "name": "url", 
+            "description": "The URL of the resource to open.",
+            "name": "url",
             "type": "string"
-          }, 
+          },
           {
-            "description": "Specifies the line number to scroll to when the resource is loaded.", 
-            "name": "lineNumber", 
+            "description": "Specifies the line number to scroll to when the resource is loaded.",
+            "name": "lineNumber",
             "type": "integer"
-          }, 
+          },
           {
-            "description": "A function that is called when the resource has been successfully loaded.", 
-            "name": "callback", 
-            "optional": true, 
+            "description": "A function that is called when the resource has been successfully loaded.",
+            "name": "callback",
+            "optional": true,
             "type": "function"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
       }
-    ], 
-    "namespace": "devtools.panels", 
-    "nocompile": true, 
+    ],
+    "namespace": "devtools.panels",
+    "nocompile": true,
     "properties": {
       "elements": {
-        "$ref": "ElementsPanel", 
+        "$ref": "ElementsPanel",
         "description": "Elements panel."
-      }, 
+      },
       "sources": {
-        "$ref": "SourcesPanel", 
+        "$ref": "SourcesPanel",
         "description": "Sources panel."
-      }, 
+      },
       "themeName": {
-        "description": "The name of the current devtools theme.", 
+        "description": "The name of the current devtools theme.",
         "type": "string"
       }
-    }, 
+    },
     "types": [
       {
-        "description": "Represents the Elements panel.", 
+        "description": "Represents the Elements panel.",
         "events": [
           {
-            "description": "Fired when an object is selected in the panel.", 
-            "name": "onSelectionChanged", 
+            "description": "Fired when an object is selected in the panel.",
+            "name": "onSelectionChanged",
             "type": "function"
           }
-        ], 
+        ],
         "functions": [
           {
-            "async": "callback", 
-            "description": "Creates a pane within panel's sidebar.", 
-            "name": "createSidebarPane", 
+            "async": "callback",
+            "description": "Creates a pane within panel's sidebar.",
+            "name": "createSidebarPane",
             "parameters": [
               {
-                "description": "Text that is displayed in sidebar caption.", 
-                "name": "title", 
+                "description": "Text that is displayed in sidebar caption.",
+                "name": "title",
                 "type": "string"
-              }, 
+              },
               {
-                "description": "A callback invoked when the sidebar is created.", 
-                "name": "callback", 
-                "optional": true, 
+                "description": "A callback invoked when the sidebar is created.",
+                "name": "callback",
+                "optional": true,
                 "parameters": [
                   {
-                    "$ref": "ExtensionSidebarPane", 
-                    "description": "An ExtensionSidebarPane object for created sidebar pane.", 
+                    "$ref": "ExtensionSidebarPane",
+                    "description": "An ExtensionSidebarPane object for created sidebar pane.",
                     "name": "result"
                   }
-                ], 
+                ],
                 "type": "function"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
-        "id": "ElementsPanel", 
+        ],
+        "id": "ElementsPanel",
         "type": "object"
-      }, 
+      },
       {
-        "description": "Represents the Sources panel.", 
+        "description": "Represents the Sources panel.",
         "events": [
           {
-            "description": "Fired when an object is selected in the panel.", 
-            "name": "onSelectionChanged", 
+            "description": "Fired when an object is selected in the panel.",
+            "name": "onSelectionChanged",
             "unsupported": true
           }
-        ], 
+        ],
         "functions": [
           {
-            "description": "Creates a pane within panel's sidebar.", 
-            "name": "createSidebarPane", 
+            "description": "Creates a pane within panel's sidebar.",
+            "name": "createSidebarPane",
             "parameters": [
               {
-                "description": "Text that is displayed in sidebar caption.", 
-                "name": "title", 
+                "description": "Text that is displayed in sidebar caption.",
+                "name": "title",
                 "type": "string"
-              }, 
+              },
               {
-                "description": "A callback invoked when the sidebar is created.", 
-                "name": "callback", 
-                "optional": true, 
+                "description": "A callback invoked when the sidebar is created.",
+                "name": "callback",
+                "optional": true,
                 "parameters": [
                   {
-                    "$ref": "ExtensionSidebarPane", 
-                    "description": "An ExtensionSidebarPane object for created sidebar pane.", 
+                    "$ref": "ExtensionSidebarPane",
+                    "description": "An ExtensionSidebarPane object for created sidebar pane.",
                     "name": "result"
                   }
-                ], 
+                ],
                 "type": "function"
               }
-            ], 
-            "type": "function", 
+            ],
+            "type": "function",
             "unsupported": true
           }
-        ], 
-        "id": "SourcesPanel", 
+        ],
+        "id": "SourcesPanel",
         "type": "object"
-      }, 
+      },
       {
-        "description": "Represents a panel created by extension.", 
+        "description": "Represents a panel created by extension.",
         "events": [
           {
-            "description": "Fired upon a search action (start of a new search, search result navigation, or search being canceled).", 
-            "name": "onSearch", 
+            "description": "Fired upon a search action (start of a new search, search result navigation, or search being canceled).",
+            "name": "onSearch",
             "parameters": [
               {
-                "description": "Type of search action being performed.", 
-                "name": "action", 
+                "description": "Type of search action being performed.",
+                "name": "action",
                 "type": "string"
-              }, 
+              },
               {
-                "description": "Query string (only for 'performSearch').", 
-                "name": "queryString", 
-                "optional": true, 
+                "description": "Query string (only for 'performSearch').",
+                "name": "queryString",
+                "optional": true,
                 "type": "string"
               }
-            ], 
+            ],
             "unsupported": true
-          }, 
+          },
           {
-            "description": "Fired when the user switches to the panel.", 
-            "name": "onShown", 
+            "description": "Fired when the user switches to the panel.",
+            "name": "onShown",
             "parameters": [
               {
                 "additionalProperties": {
                   "type": "any"
-                }, 
-                "description": "The JavaScript <code>window</code> object of panel's page.", 
-                "isInstanceOf": "global", 
-                "name": "window", 
+                },
+                "description": "The JavaScript <code>window</code> object of panel's page.",
+                "isInstanceOf": "global",
+                "name": "window",
                 "type": "object"
               }
-            ], 
+            ],
             "type": "function"
-          }, 
+          },
           {
-            "description": "Fired when the user switches away from the panel.", 
-            "name": "onHidden", 
+            "description": "Fired when the user switches away from the panel.",
+            "name": "onHidden",
             "type": "function"
           }
-        ], 
+        ],
         "functions": [
           {
-            "description": "Appends a button to the status bar of the panel.", 
-            "name": "createStatusBarButton", 
+            "description": "Appends a button to the status bar of the panel.",
+            "name": "createStatusBarButton",
             "parameters": [
               {
-                "description": "Path to the icon of the button. The file should contain a 64x24-pixel image composed of two 32x24 icons. The left icon is used when the button is inactive; the right icon is displayed when the button is pressed.", 
-                "name": "iconPath", 
+                "description": "Path to the icon of the button. The file should contain a 64x24-pixel image composed of two 32x24 icons. The left icon is used when the button is inactive; the right icon is displayed when the button is pressed.",
+                "name": "iconPath",
                 "type": "string"
-              }, 
+              },
               {
-                "description": "Text shown as a tooltip when user hovers the mouse over the button.", 
-                "name": "tooltipText", 
+                "description": "Text shown as a tooltip when user hovers the mouse over the button.",
+                "name": "tooltipText",
                 "type": "string"
-              }, 
+              },
               {
-                "description": "Whether the button is disabled.", 
-                "name": "disabled", 
+                "description": "Whether the button is disabled.",
+                "name": "disabled",
                 "type": "boolean"
               }
-            ], 
+            ],
             "returns": {
               "$ref": "Button"
-            }, 
-            "type": "function", 
+            },
+            "type": "function",
             "unsupported": true
           }
-        ], 
-        "id": "ExtensionPanel", 
+        ],
+        "id": "ExtensionPanel",
         "type": "object"
-      }, 
+      },
       {
-        "description": "A sidebar created by the extension.", 
+        "description": "A sidebar created by the extension.",
         "events": [
           {
-            "description": "Fired when the sidebar pane becomes visible as a result of user switching to the panel that hosts it.", 
-            "name": "onShown", 
+            "description": "Fired when the sidebar pane becomes visible as a result of user switching to the panel that hosts it.",
+            "name": "onShown",
             "parameters": [
               {
                 "additionalProperties": {
                   "type": "any"
-                }, 
-                "description": "The JavaScript <code>window</code> object of the sidebar page, if one was set with the <code>setPage()</code> method.", 
-                "isInstanceOf": "global", 
-                "name": "window", 
+                },
+                "description": "The JavaScript <code>window</code> object of the sidebar page, if one was set with the <code>setPage()</code> method.",
+                "isInstanceOf": "global",
+                "name": "window",
                 "type": "object"
               }
-            ], 
+            ],
             "type": "function"
-          }, 
+          },
           {
-            "description": "Fired when the sidebar pane becomes hidden as a result of the user switching away from the panel that hosts the sidebar pane.", 
-            "name": "onHidden", 
+            "description": "Fired when the sidebar pane becomes hidden as a result of the user switching away from the panel that hosts the sidebar pane.",
+            "name": "onHidden",
             "type": "function"
           }
-        ], 
+        ],
         "functions": [
           {
-            "description": "Sets the height of the sidebar.", 
-            "name": "setHeight", 
+            "description": "Sets the height of the sidebar.",
+            "name": "setHeight",
             "parameters": [
               {
-                "description": "A CSS-like size specification, such as <code>'100px'</code> or <code>'12ex'</code>.", 
-                "name": "height", 
+                "description": "A CSS-like size specification, such as <code>'100px'</code> or <code>'12ex'</code>.",
+                "name": "height",
                 "type": "string"
               }
-            ], 
-            "type": "function", 
+            ],
+            "type": "function",
             "unsupported": true
-          }, 
+          },
           {
-            "async": "callback", 
-            "description": "Sets an expression that is evaluated within the inspected page. The result is displayed in the sidebar pane.", 
-            "name": "setExpression", 
+            "async": "callback",
+            "description": "Sets an expression that is evaluated within the inspected page. The result is displayed in the sidebar pane.",
+            "name": "setExpression",
             "parameters": [
               {
-                "description": "An expression to be evaluated in context of the inspected page. JavaScript objects and DOM nodes are displayed in an expandable tree similar to the console/watch.", 
-                "name": "expression", 
+                "description": "An expression to be evaluated in context of the inspected page. JavaScript objects and DOM nodes are displayed in an expandable tree similar to the console/watch.",
+                "name": "expression",
                 "type": "string"
-              }, 
+              },
               {
-                "description": "An optional title for the root of the expression tree.", 
-                "name": "rootTitle", 
-                "optional": true, 
+                "description": "An optional title for the root of the expression tree.",
+                "name": "rootTitle",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               {
-                "description": "A callback invoked after the sidebar pane is updated with the expression evaluation results.", 
-                "name": "callback", 
-                "optional": true, 
+                "description": "A callback invoked after the sidebar pane is updated with the expression evaluation results.",
+                "name": "callback",
+                "optional": true,
                 "type": "function"
               }
-            ], 
+            ],
             "type": "function"
-          }, 
+          },
           {
-            "async": "callback", 
-            "description": "Sets a JSON-compliant object to be displayed in the sidebar pane.", 
-            "name": "setObject", 
+            "async": "callback",
+            "description": "Sets a JSON-compliant object to be displayed in the sidebar pane.",
+            "name": "setObject",
             "parameters": [
               {
-                "description": "An object to be displayed in context of the inspected page. Evaluated in the context of the caller (API client).", 
-                "name": "jsonObject", 
+                "description": "An object to be displayed in context of the inspected page. Evaluated in the context of the caller (API client).",
+                "name": "jsonObject",
                 "type": "string"
-              }, 
+              },
               {
-                "description": "An optional title for the root of the expression tree.", 
-                "name": "rootTitle", 
-                "optional": true, 
+                "description": "An optional title for the root of the expression tree.",
+                "name": "rootTitle",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               {
-                "description": "A callback invoked after the sidebar is updated with the object.", 
-                "name": "callback", 
-                "optional": true, 
+                "description": "A callback invoked after the sidebar is updated with the object.",
+                "name": "callback",
+                "optional": true,
                 "type": "function"
               }
-            ], 
+            ],
             "type": "function"
-          }, 
+          },
           {
-            "description": "Sets an HTML page to be displayed in the sidebar pane.", 
-            "name": "setPage", 
+            "async": true,
+            "description": "Sets an HTML page to be displayed in the sidebar pane.",
+            "name": "setPage",
             "parameters": [
               {
-                "description": "Relative path of an extension page to display within the sidebar.", 
-                "name": "path", 
-                "type": "string"
+                "$ref": "manifest.ExtensionURL",
+                "description": "Relative path of an extension page to display within the sidebar.",
+                "name": "path"
               }
-            ], 
-            "type": "function", 
-            "unsupported": true
+            ],
+            "type": "function"
           }
-        ], 
-        "id": "ExtensionSidebarPane", 
+        ],
+        "id": "ExtensionSidebarPane",
         "type": "object"
-      }, 
+      },
       {
-        "description": "A button created by the extension.", 
+        "description": "A button created by the extension.",
         "events": [
           {
-            "description": "Fired when the button is clicked.", 
-            "name": "onClicked", 
-            "type": "function", 
+            "description": "Fired when the button is clicked.",
+            "name": "onClicked",
+            "type": "function",
             "unsupported": true
           }
-        ], 
+        ],
         "functions": [
           {
-            "description": "Updates the attributes of the button. If some of the arguments are omitted or <code>null</code>, the corresponding attributes are not updated.", 
-            "name": "update", 
+            "description": "Updates the attributes of the button. If some of the arguments are omitted or <code>null</code>, the corresponding attributes are not updated.",
+            "name": "update",
             "parameters": [
               {
-                "description": "Path to the new icon of the button.", 
-                "name": "iconPath", 
-                "optional": true, 
+                "description": "Path to the new icon of the button.",
+                "name": "iconPath",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               {
-                "description": "Text shown as a tooltip when user hovers the mouse over the button.", 
-                "name": "tooltipText", 
-                "optional": true, 
+                "description": "Text shown as a tooltip when user hovers the mouse over the button.",
+                "name": "tooltipText",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               {
-                "description": "Whether the button is disabled.", 
-                "name": "disabled", 
-                "optional": true, 
+                "description": "Whether the button is disabled.",
+                "name": "disabled",
+                "optional": true,
                 "type": "boolean"
               }
-            ], 
-            "type": "function", 
+            ],
+            "type": "function",
             "unsupported": true
           }
-        ], 
-        "id": "Button", 
+        ],
+        "id": "Button",
         "type": "object"
       }
     ]
-  }, 
+  },
+  {
+    "description": "Asynchronous DNS API",
+    "functions": [
+      {
+        "async": true,
+        "description": "Resolves a hostname to a DNS record.",
+        "name": "resolve",
+        "parameters": [
+          {
+            "name": "hostname",
+            "type": "string"
+          },
+          {
+            "$ref": "ResolveFlags",
+            "default": [],
+            "name": "flags",
+            "optional": true
+          }
+        ],
+        "type": "function"
+      }
+    ],
+    "namespace": "dns",
+    "permissions": [
+      "dns"
+    ],
+    "types": [
+      {
+        "description": "An object encapsulating a DNS Record.",
+        "id": "DNSRecord",
+        "properties": {
+          "addresses": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "canonicalName": {
+            "description": "The canonical hostname for this record.  this value is empty if the record was not fetched with the 'canonical_name' flag.",
+            "optional": true,
+            "type": "string"
+          },
+          "isTRR": {
+            "description": "Record retreived with TRR.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      {
+        "id": "ResolveFlags",
+        "items": {
+          "enum": [
+            "allow_name_collisions",
+            "bypass_cache",
+            "canonical_name",
+            "disable_ipv4",
+            "disable_ipv6",
+            "disable_trr",
+            "offline",
+            "priority_low",
+            "priority_medium",
+            "speculate"
+          ],
+          "type": "string"
+        },
+        "type": "array"
+      }
+    ]
+  },
   {
     "events": [
       {
-        "description": "This event fires with the <a href='#type-DownloadItem'>DownloadItem</a> object when a download begins.", 
-        "name": "onCreated", 
+        "description": "This event fires with the <a href='#type-DownloadItem'>DownloadItem</a> object when a download begins.",
+        "name": "onCreated",
         "parameters": [
           {
-            "$ref": "DownloadItem", 
+            "$ref": "DownloadItem",
             "name": "downloadItem"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Fires with the <code>downloadId</code> when a download is erased from history.", 
-        "name": "onErased", 
+        "description": "Fires with the <code>downloadId</code> when a download is erased from history.",
+        "name": "onErased",
         "parameters": [
           {
-            "description": "The <code>id</code> of the <a href='#type-DownloadItem'>DownloadItem</a> that was erased.", 
-            "name": "downloadId", 
+            "description": "The <code>id</code> of the <a href='#type-DownloadItem'>DownloadItem</a> that was erased.",
+            "name": "downloadId",
             "type": "integer"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "When any of a <a href='#type-DownloadItem'>DownloadItem</a>'s properties except <code>bytesReceived</code> changes, this event fires with the <code>downloadId</code> and an object containing the properties that changed.", 
-        "name": "onChanged", 
+        "description": "When any of a <a href='#type-DownloadItem'>DownloadItem</a>'s properties except <code>bytesReceived</code> changes, this event fires with the <code>downloadId</code> and an object containing the properties that changed.",
+        "name": "onChanged",
         "parameters": [
           {
-            "name": "downloadDelta", 
+            "name": "downloadDelta",
             "properties": {
               "canResume": {
-                "$ref": "BooleanDelta", 
+                "$ref": "BooleanDelta",
                 "optional": true
-              }, 
+              },
               "danger": {
-                "$ref": "StringDelta", 
-                "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>danger</code>.", 
+                "$ref": "StringDelta",
+                "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>danger</code>.",
                 "optional": true
-              }, 
+              },
               "endTime": {
-                "$ref": "StringDelta", 
-                "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>endTime</code>.", 
+                "$ref": "StringDelta",
+                "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>endTime</code>.",
                 "optional": true
-              }, 
+              },
               "error": {
-                "$ref": "StringDelta", 
-                "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>error</code>.", 
+                "$ref": "StringDelta",
+                "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>error</code>.",
                 "optional": true
-              }, 
+              },
               "exists": {
-                "$ref": "BooleanDelta", 
+                "$ref": "BooleanDelta",
                 "optional": true
-              }, 
+              },
               "fileSize": {
-                "$ref": "DoubleDelta", 
-                "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>fileSize</code>.", 
+                "$ref": "DoubleDelta",
+                "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>fileSize</code>.",
                 "optional": true
-              }, 
+              },
               "filename": {
-                "$ref": "StringDelta", 
-                "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>filename</code>.", 
+                "$ref": "StringDelta",
+                "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>filename</code>.",
                 "optional": true
-              }, 
+              },
               "id": {
-                "description": "The <code>id</code> of the <a href='#type-DownloadItem'>DownloadItem</a> that changed.", 
+                "description": "The <code>id</code> of the <a href='#type-DownloadItem'>DownloadItem</a> that changed.",
                 "type": "integer"
-              }, 
+              },
               "mime": {
-                "$ref": "StringDelta", 
-                "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>mime</code>.", 
+                "$ref": "StringDelta",
+                "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>mime</code>.",
                 "optional": true
-              }, 
+              },
               "paused": {
-                "$ref": "BooleanDelta", 
-                "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>paused</code>.", 
+                "$ref": "BooleanDelta",
+                "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>paused</code>.",
                 "optional": true
-              }, 
+              },
               "startTime": {
-                "$ref": "StringDelta", 
-                "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>startTime</code>.", 
+                "$ref": "StringDelta",
+                "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>startTime</code>.",
                 "optional": true
-              }, 
+              },
               "state": {
-                "$ref": "StringDelta", 
-                "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>state</code>.", 
+                "$ref": "StringDelta",
+                "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>state</code>.",
                 "optional": true
-              }, 
+              },
               "totalBytes": {
-                "$ref": "DoubleDelta", 
-                "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>totalBytes</code>.", 
+                "$ref": "DoubleDelta",
+                "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>totalBytes</code>.",
                 "optional": true
-              }, 
+              },
               "url": {
-                "$ref": "StringDelta", 
-                "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>url</code>.", 
+                "$ref": "StringDelta",
+                "description": "Describes a change in a <a href='#type-DownloadItem'>DownloadItem</a>'s <code>url</code>.",
                 "optional": true
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "type": "function"
       }
-    ], 
+    ],
     "functions": [
       {
-        "async": "callback", 
-        "description": "Download a URL. If the URL uses the HTTP[S] protocol, then the request will include all cookies currently set for its hostname. If both <code>filename</code> and <code>saveAs</code> are specified, then the Save As dialog will be displayed, pre-populated with the specified <code>filename</code>. If the download started successfully, <code>callback</code> will be called with the new <a href='#type-DownloadItem'>DownloadItem</a>'s <code>downloadId</code>. If there was an error starting the download, then <code>callback</code> will be called with <code>downloadId=undefined</code> and <a href='extension.html#property-lastError'>chrome.extension.lastError</a> will contain a descriptive string. The error strings are not guaranteed to remain backwards compatible between releases. You must not parse it.", 
-        "name": "download", 
+        "async": "callback",
+        "description": "Download a URL. If the URL uses the HTTP[S] protocol, then the request will include all cookies currently set for its hostname. If both <code>filename</code> and <code>saveAs</code> are specified, then the Save As dialog will be displayed, pre-populated with the specified <code>filename</code>. If the download started successfully, <code>callback</code> will be called with the new <a href='#type-DownloadItem'>DownloadItem</a>'s <code>downloadId</code>. If there was an error starting the download, then <code>callback</code> will be called with <code>downloadId=undefined</code> and <a href='extension.html#property-lastError'>chrome.extension.lastError</a> will contain a descriptive string. The error strings are not guaranteed to remain backwards compatible between releases. You must not parse it.",
+        "name": "download",
         "parameters": [
           {
-            "description": "What to download and how.", 
-            "name": "options", 
+            "description": "What to download and how.",
+            "name": "options",
             "properties": {
               "body": {
-                "description": "Post body.", 
-                "optional": true, 
+                "description": "Post body.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "conflictAction": {
-                "$ref": "FilenameConflictAction", 
+                "$ref": "FilenameConflictAction",
                 "optional": true
-              }, 
+              },
               "filename": {
-                "description": "A file path relative to the Downloads directory to contain the downloaded file.", 
-                "optional": true, 
+                "description": "A file path relative to the Downloads directory to contain the downloaded file.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "headers": {
-                "description": "Extra HTTP headers to send with the request if the URL uses the HTTP[s] protocol. Each header is represented as a dictionary containing the keys <code>name</code> and either <code>value</code> or <code>binaryValue</code>, restricted to those allowed by XMLHttpRequest.", 
+                "description": "Extra HTTP headers to send with the request if the URL uses the HTTP[s] protocol. Each header is represented as a dictionary containing the keys <code>name</code> and either <code>value</code> or <code>binaryValue</code>, restricted to those allowed by XMLHttpRequest.",
                 "items": {
                   "properties": {
                     "name": {
-                      "description": "Name of the HTTP header.", 
+                      "description": "Name of the HTTP header.",
                       "type": "string"
-                    }, 
+                    },
                     "value": {
-                      "description": "Value of the HTTP header.", 
+                      "description": "Value of the HTTP header.",
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
-                }, 
-                "optional": true, 
+                },
+                "optional": true,
                 "type": "array"
-              }, 
+              },
               "incognito": {
-                "default": false, 
-                "description": "Whether to associate the download with a private browsing session.", 
-                "optional": true, 
+                "default": false,
+                "description": "Whether to associate the download with a private browsing session.",
+                "optional": true,
                 "type": "boolean"
-              }, 
+              },
               "method": {
-                "description": "The HTTP method to use if the URL uses the HTTP[S] protocol.", 
+                "description": "The HTTP method to use if the URL uses the HTTP[S] protocol.",
                 "enum": [
-                  "GET", 
+                  "GET",
                   "POST"
-                ], 
-                "optional": true, 
+                ],
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "saveAs": {
-                "description": "Use a file-chooser to allow the user to select a filename. If the option is not specified, the file chooser will be shown only if the Firefox \"Always ask you where to save files\" option is enabled (i.e. the pref <code>browser.download.useDownloadDir</code> is set to <code>false</code>).", 
-                "optional": true, 
+                "description": "Use a file-chooser to allow the user to select a filename. If the option is not specified, the file chooser will be shown only if the Firefox \"Always ask you where to save files\" option is enabled (i.e. the pref <code>browser.download.useDownloadDir</code> is set to <code>false</code>).",
+                "optional": true,
                 "type": "boolean"
-              }, 
+              },
               "url": {
-                "description": "The URL to download.", 
-                "format": "url", 
+                "description": "The URL to download.",
+                "format": "url",
                 "type": "string"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
+            "name": "callback",
+            "optional": true,
             "parameters": [
               {
-                "name": "downloadId", 
+                "name": "downloadId",
                 "type": "integer"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Find <a href='#type-DownloadItem'>DownloadItems</a>. Set <code>query</code> to the empty object to get all <a href='#type-DownloadItem'>DownloadItems</a>. To get a specific <a href='#type-DownloadItem'>DownloadItem</a>, set only the <code>id</code> field.", 
-        "name": "search", 
+        "async": "callback",
+        "description": "Find <a href='#type-DownloadItem'>DownloadItems</a>. Set <code>query</code> to the empty object to get all <a href='#type-DownloadItem'>DownloadItems</a>. To get a specific <a href='#type-DownloadItem'>DownloadItem</a>, set only the <code>id</code> field.",
+        "name": "search",
         "parameters": [
           {
-            "$ref": "DownloadQuery", 
+            "$ref": "DownloadQuery",
             "name": "query"
-          }, 
+          },
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
                 "items": {
                   "$ref": "DownloadItem"
-                }, 
-                "name": "results", 
+                },
+                "name": "results",
                 "type": "array"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Pause the download. If the request was successful the download is in a paused state. Otherwise <a href='extension.html#property-lastError'>chrome.extension.lastError</a> contains an error message. The request will fail if the download is not active.", 
-        "name": "pause", 
+        "async": "callback",
+        "description": "Pause the download. If the request was successful the download is in a paused state. Otherwise <a href='extension.html#property-lastError'>chrome.extension.lastError</a> contains an error message. The request will fail if the download is not active.",
+        "name": "pause",
         "parameters": [
           {
-            "description": "The id of the download to pause.", 
-            "name": "downloadId", 
+            "description": "The id of the download to pause.",
+            "name": "downloadId",
             "type": "integer"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Resume a paused download. If the request was successful the download is in progress and unpaused. Otherwise <a href='extension.html#property-lastError'>chrome.extension.lastError</a> contains an error message. The request will fail if the download is not active.", 
-        "name": "resume", 
+        "async": "callback",
+        "description": "Resume a paused download. If the request was successful the download is in progress and unpaused. Otherwise <a href='extension.html#property-lastError'>chrome.extension.lastError</a> contains an error message. The request will fail if the download is not active.",
+        "name": "resume",
         "parameters": [
           {
-            "description": "The id of the download to resume.", 
-            "name": "downloadId", 
+            "description": "The id of the download to resume.",
+            "name": "downloadId",
             "type": "integer"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Cancel a download. When <code>callback</code> is run, the download is cancelled, completed, interrupted or doesn't exist anymore.", 
-        "name": "cancel", 
+        "async": "callback",
+        "description": "Cancel a download. When <code>callback</code> is run, the download is cancelled, completed, interrupted or doesn't exist anymore.",
+        "name": "cancel",
         "parameters": [
           {
-            "description": "The id of the download to cancel.", 
-            "name": "downloadId", 
+            "description": "The id of the download to cancel.",
+            "name": "downloadId",
             "type": "integer"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Retrieve an icon for the specified download. For new downloads, file icons are available after the <a href='#event-onCreated'>onCreated</a> event has been received. The image returned by this function while a download is in progress may be different from the image returned after the download is complete. Icon retrieval is done by querying the underlying operating system or toolkit depending on the platform. The icon that is returned will therefore depend on a number of factors including state of the download, platform, registered file types and visual theme. If a file icon cannot be determined, <a href='extension.html#property-lastError'>chrome.extension.lastError</a> will contain an error message.", 
-        "name": "getFileIcon", 
+        "async": "callback",
+        "description": "Retrieve an icon for the specified download. For new downloads, file icons are available after the <a href='#event-onCreated'>onCreated</a> event has been received. The image returned by this function while a download is in progress may be different from the image returned after the download is complete. Icon retrieval is done by querying the underlying operating system or toolkit depending on the platform. The icon that is returned will therefore depend on a number of factors including state of the download, platform, registered file types and visual theme. If a file icon cannot be determined, <a href='extension.html#property-lastError'>chrome.extension.lastError</a> will contain an error message.",
+        "name": "getFileIcon",
         "parameters": [
           {
-            "description": "The identifier for the download.", 
-            "name": "downloadId", 
+            "description": "The identifier for the download.",
+            "name": "downloadId",
             "type": "integer"
-          }, 
+          },
           {
-            "name": "options", 
-            "optional": true, 
+            "name": "options",
+            "optional": true,
             "properties": {
               "size": {
-                "description": "The size of the icon.  The returned icon will be square with dimensions size * size pixels.  The default size for the icon is 32x32 pixels.", 
-                "maximum": 127, 
-                "minimum": 1, 
-                "optional": true, 
+                "description": "The size of the icon.  The returned icon will be square with dimensions size * size pixels.  The default size for the icon is 32x32 pixels.",
+                "maximum": 127,
+                "minimum": 1,
+                "optional": true,
                 "type": "integer"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
-                "name": "iconURL", 
-                "optional": true, 
+                "name": "iconURL",
+                "optional": true,
                 "type": "string"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Open the downloaded file.", 
-        "name": "open", 
+        "async": "callback",
+        "description": "Open the downloaded file.",
+        "name": "open",
         "parameters": [
           {
-            "name": "downloadId", 
+            "name": "downloadId",
             "type": "integer"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
         "permissions": [
           "downloads.open"
-        ], 
-        "requireUserInput": true, 
+        ],
+        "requireUserInput": true,
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Show the downloaded file in its folder in a file manager.", 
-        "name": "show", 
+        "async": "callback",
+        "description": "Show the downloaded file in its folder in a file manager.",
+        "name": "show",
         "parameters": [
           {
-            "name": "downloadId", 
+            "name": "downloadId",
             "type": "integer"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
+            "name": "callback",
+            "optional": true,
             "parameters": [
               {
-                "name": "success", 
+                "name": "success",
                 "type": "boolean"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "name": "showDefaultFolder", 
-        "parameters": [], 
+        "name": "showDefaultFolder",
+        "parameters": [],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Erase matching <a href='#type-DownloadItem'>DownloadItems</a> from history", 
-        "name": "erase", 
+        "async": "callback",
+        "description": "Erase matching <a href='#type-DownloadItem'>DownloadItems</a> from history",
+        "name": "erase",
         "parameters": [
           {
-            "$ref": "DownloadQuery", 
+            "$ref": "DownloadQuery",
             "name": "query"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
+            "name": "callback",
+            "optional": true,
             "parameters": [
               {
                 "items": {
                   "type": "integer"
-                }, 
-                "name": "erasedIds", 
+                },
+                "name": "erasedIds",
                 "type": "array"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "name": "removeFile", 
+        "async": "callback",
+        "name": "removeFile",
         "parameters": [
           {
-            "name": "downloadId", 
+            "name": "downloadId",
             "type": "integer"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Prompt the user to either accept or cancel a dangerous download. <code>acceptDanger()</code> does not automatically accept dangerous downloads.", 
-        "name": "acceptDanger", 
+        "description": "Prompt the user to either accept or cancel a dangerous download. <code>acceptDanger()</code> does not automatically accept dangerous downloads.",
+        "name": "acceptDanger",
         "parameters": [
           {
-            "name": "downloadId", 
+            "name": "downloadId",
             "type": "integer"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
-      }, 
+      },
       {
-        "description": "Initiate dragging the file to another application.", 
-        "name": "drag", 
+        "description": "Initiate dragging the file to another application.",
+        "name": "drag",
         "parameters": [
           {
-            "name": "downloadId", 
+            "name": "downloadId",
             "type": "integer"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
-      }, 
+      },
       {
-        "name": "setShelfEnabled", 
+        "name": "setShelfEnabled",
         "parameters": [
           {
-            "name": "enabled", 
+            "name": "enabled",
             "type": "boolean"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
       }
-    ], 
-    "namespace": "downloads", 
+    ],
+    "namespace": "downloads",
     "permissions": [
       "downloads"
-    ], 
+    ],
     "types": [
       {
         "enum": [
-          "uniquify", 
-          "overwrite", 
+          "uniquify",
+          "overwrite",
           "prompt"
-        ], 
-        "id": "FilenameConflictAction", 
+        ],
+        "id": "FilenameConflictAction",
         "type": "string"
-      }, 
+      },
       {
         "enum": [
-          "FILE_FAILED", 
-          "FILE_ACCESS_DENIED", 
-          "FILE_NO_SPACE", 
-          "FILE_NAME_TOO_LONG", 
-          "FILE_TOO_LARGE", 
-          "FILE_VIRUS_INFECTED", 
-          "FILE_TRANSIENT_ERROR", 
-          "FILE_BLOCKED", 
-          "FILE_SECURITY_CHECK_FAILED", 
-          "FILE_TOO_SHORT", 
-          "NETWORK_FAILED", 
-          "NETWORK_TIMEOUT", 
-          "NETWORK_DISCONNECTED", 
-          "NETWORK_SERVER_DOWN", 
-          "NETWORK_INVALID_REQUEST", 
-          "SERVER_FAILED", 
-          "SERVER_NO_RANGE", 
-          "SERVER_BAD_CONTENT", 
-          "SERVER_UNAUTHORIZED", 
-          "SERVER_CERT_PROBLEM", 
-          "SERVER_FORBIDDEN", 
-          "USER_CANCELED", 
-          "USER_SHUTDOWN", 
+          "FILE_FAILED",
+          "FILE_ACCESS_DENIED",
+          "FILE_NO_SPACE",
+          "FILE_NAME_TOO_LONG",
+          "FILE_TOO_LARGE",
+          "FILE_VIRUS_INFECTED",
+          "FILE_TRANSIENT_ERROR",
+          "FILE_BLOCKED",
+          "FILE_SECURITY_CHECK_FAILED",
+          "FILE_TOO_SHORT",
+          "NETWORK_FAILED",
+          "NETWORK_TIMEOUT",
+          "NETWORK_DISCONNECTED",
+          "NETWORK_SERVER_DOWN",
+          "NETWORK_INVALID_REQUEST",
+          "SERVER_FAILED",
+          "SERVER_NO_RANGE",
+          "SERVER_BAD_CONTENT",
+          "SERVER_UNAUTHORIZED",
+          "SERVER_CERT_PROBLEM",
+          "SERVER_FORBIDDEN",
+          "USER_CANCELED",
+          "USER_SHUTDOWN",
           "CRASH"
-        ], 
-        "id": "InterruptReason", 
+        ],
+        "id": "InterruptReason",
         "type": "string"
-      }, 
+      },
       {
-        "description": "<dl><dt>file</dt><dd>The download's filename is suspicious.</dd><dt>url</dt><dd>The download's URL is known to be malicious.</dd><dt>content</dt><dd>The downloaded file is known to be malicious.</dd><dt>uncommon</dt><dd>The download's URL is not commonly downloaded and could be dangerous.</dd><dt>safe</dt><dd>The download presents no known danger to the user's computer.</dd></dl>These string constants will never change, however the set of DangerTypes may change.", 
+        "description": "<dl><dt>file</dt><dd>The download's filename is suspicious.</dd><dt>url</dt><dd>The download's URL is known to be malicious.</dd><dt>content</dt><dd>The downloaded file is known to be malicious.</dd><dt>uncommon</dt><dd>The download's URL is not commonly downloaded and could be dangerous.</dd><dt>safe</dt><dd>The download presents no known danger to the user's computer.</dd></dl>These string constants will never change, however the set of DangerTypes may change.",
         "enum": [
-          "file", 
-          "url", 
-          "content", 
-          "uncommon", 
-          "host", 
-          "unwanted", 
-          "safe", 
+          "file",
+          "url",
+          "content",
+          "uncommon",
+          "host",
+          "unwanted",
+          "safe",
           "accepted"
-        ], 
-        "id": "DangerType", 
+        ],
+        "id": "DangerType",
         "type": "string"
-      }, 
+      },
       {
-        "description": "<dl><dt>in_progress</dt><dd>The download is currently receiving data from the server.</dd><dt>interrupted</dt><dd>An error broke the connection with the file host.</dd><dt>complete</dt><dd>The download completed successfully.</dd></dl>These string constants will never change, however the set of States may change.", 
+        "description": "<dl><dt>in_progress</dt><dd>The download is currently receiving data from the server.</dd><dt>interrupted</dt><dd>An error broke the connection with the file host.</dd><dt>complete</dt><dd>The download completed successfully.</dd></dl>These string constants will never change, however the set of States may change.",
         "enum": [
-          "in_progress", 
-          "interrupted", 
+          "in_progress",
+          "interrupted",
           "complete"
-        ], 
-        "id": "State", 
+        ],
+        "id": "State",
         "type": "string"
-      }, 
+      },
       {
-        "id": "DownloadItem", 
+        "id": "DownloadItem",
         "properties": {
           "byExtensionId": {
-            "optional": true, 
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "byExtensionName": {
-            "optional": true, 
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "bytesReceived": {
-            "description": "Number of bytes received so far from the host, without considering file compression.", 
+            "description": "Number of bytes received so far from the host, without considering file compression.",
             "type": "number"
-          }, 
+          },
           "canResume": {
             "type": "boolean"
-          }, 
+          },
           "danger": {
-            "$ref": "DangerType", 
+            "$ref": "DangerType",
             "description": "Indication of whether this download is thought to be safe or known to be suspicious."
-          }, 
+          },
           "endTime": {
-            "description": "Number of milliseconds between the unix epoch and when this download ended.", 
-            "optional": true, 
+            "description": "Number of milliseconds between the unix epoch and when this download ended.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "error": {
-            "$ref": "InterruptReason", 
-            "description": "Number indicating why a download was interrupted.", 
+            "$ref": "InterruptReason",
+            "description": "Number indicating why a download was interrupted.",
             "optional": true
-          }, 
+          },
           "estimatedEndTime": {
-            "optional": true, 
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "exists": {
             "type": "boolean"
-          }, 
+          },
           "fileSize": {
-            "description": "Number of bytes in the whole file post-decompression, or -1 if unknown.", 
+            "description": "Number of bytes in the whole file post-decompression, or -1 if unknown.",
             "type": "number"
-          }, 
+          },
           "filename": {
-            "description": "Absolute local path.", 
+            "description": "Absolute local path.",
             "type": "string"
-          }, 
+          },
           "id": {
-            "description": "An identifier that is persistent across browser sessions.", 
+            "description": "An identifier that is persistent across browser sessions.",
             "type": "integer"
-          }, 
+          },
           "incognito": {
-            "description": "False if this download is recorded in the history, true if it is not recorded.", 
+            "description": "False if this download is recorded in the history, true if it is not recorded.",
             "type": "boolean"
-          }, 
+          },
           "mime": {
-            "description": "The file's MIME type.", 
+            "description": "The file's MIME type.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "paused": {
-            "description": "True if the download has stopped reading data from the host, but kept the connection open.", 
+            "description": "True if the download has stopped reading data from the host, but kept the connection open.",
             "type": "boolean"
-          }, 
+          },
           "referrer": {
-            "optional": true, 
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "startTime": {
-            "description": "Number of milliseconds between the unix epoch and when this download began.", 
+            "description": "Number of milliseconds between the unix epoch and when this download began.",
             "type": "string"
-          }, 
+          },
           "state": {
-            "$ref": "State", 
+            "$ref": "State",
             "description": "Indicates whether the download is progressing, interrupted, or complete."
-          }, 
+          },
           "totalBytes": {
-            "description": "Number of bytes in the whole file, without considering file compression, or -1 if unknown.", 
+            "description": "Number of bytes in the whole file, without considering file compression, or -1 if unknown.",
             "type": "number"
-          }, 
+          },
           "url": {
-            "description": "Absolute URL.", 
+            "description": "Absolute URL.",
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       {
-        "id": "StringDelta", 
+        "id": "StringDelta",
         "properties": {
           "current": {
-            "optional": true, 
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "previous": {
-            "optional": true, 
+            "optional": true,
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       {
-        "id": "DoubleDelta", 
+        "id": "DoubleDelta",
         "properties": {
           "current": {
-            "optional": true, 
+            "optional": true,
             "type": "number"
-          }, 
+          },
           "previous": {
-            "optional": true, 
+            "optional": true,
             "type": "number"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       {
-        "id": "BooleanDelta", 
+        "id": "BooleanDelta",
         "properties": {
           "current": {
-            "optional": true, 
+            "optional": true,
             "type": "boolean"
-          }, 
+          },
           "previous": {
-            "optional": true, 
+            "optional": true,
             "type": "boolean"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       {
         "choices": [
           {
-            "pattern": "^[1-9]\\d*$", 
+            "pattern": "^[1-9]\\d*$",
             "type": "string"
-          }, 
+          },
           {
             "$ref": "extensionTypes.Date"
           }
-        ], 
-        "description": "A time specified as a Date object, a number or string representing milliseconds since the epoch, or an ISO 8601 string", 
+        ],
+        "description": "A time specified as a Date object, a number or string representing milliseconds since the epoch, or an ISO 8601 string",
         "id": "DownloadTime"
-      }, 
+      },
       {
-        "description": "Parameters that combine to specify a predicate that can be used to select a set of downloads.  Used for example in search() and erase()", 
-        "id": "DownloadQuery", 
+        "description": "Parameters that combine to specify a predicate that can be used to select a set of downloads.  Used for example in search() and erase()",
+        "id": "DownloadQuery",
         "properties": {
           "bytesReceived": {
-            "description": "Number of bytes received so far from the host, without considering file compression.", 
-            "optional": true, 
+            "description": "Number of bytes received so far from the host, without considering file compression.",
+            "optional": true,
             "type": "number"
-          }, 
+          },
           "danger": {
-            "$ref": "DangerType", 
-            "description": "Indication of whether this download is thought to be safe or known to be suspicious.", 
+            "$ref": "DangerType",
+            "description": "Indication of whether this download is thought to be safe or known to be suspicious.",
             "optional": true
-          }, 
+          },
           "endTime": {
-            "optional": true, 
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "endedAfter": {
-            "$ref": "DownloadTime", 
-            "description": "Limits results to downloads that ended after the given ms since the epoch.", 
+            "$ref": "DownloadTime",
+            "description": "Limits results to downloads that ended after the given ms since the epoch.",
             "optional": true
-          }, 
+          },
           "endedBefore": {
-            "$ref": "DownloadTime", 
-            "description": "Limits results to downloads that ended before the given ms since the epoch.", 
+            "$ref": "DownloadTime",
+            "description": "Limits results to downloads that ended before the given ms since the epoch.",
             "optional": true
-          }, 
+          },
           "error": {
-            "$ref": "InterruptReason", 
-            "description": "Why a download was interrupted.", 
+            "$ref": "InterruptReason",
+            "description": "Why a download was interrupted.",
             "optional": true
-          }, 
+          },
           "exists": {
-            "optional": true, 
+            "optional": true,
             "type": "boolean"
-          }, 
+          },
           "fileSize": {
-            "description": "Number of bytes in the whole file post-decompression, or -1 if unknown.", 
-            "optional": true, 
+            "description": "Number of bytes in the whole file post-decompression, or -1 if unknown.",
+            "optional": true,
             "type": "number"
-          }, 
+          },
           "filename": {
-            "description": "Absolute local path.", 
-            "optional": true, 
+            "description": "Absolute local path.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "filenameRegex": {
-            "description": "Limits results to <a href='#type-DownloadItem'>DownloadItems</a> whose <code>filename</code> matches the given regular expression.", 
-            "optional": true, 
+            "description": "Limits results to <a href='#type-DownloadItem'>DownloadItems</a> whose <code>filename</code> matches the given regular expression.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "id": {
-            "optional": true, 
+            "optional": true,
             "type": "integer"
-          }, 
+          },
           "limit": {
-            "description": "Setting this integer limits the number of results. Otherwise, all matching <a href='#type-DownloadItem'>DownloadItems</a> will be returned.", 
-            "optional": true, 
+            "description": "Setting this integer limits the number of results. Otherwise, all matching <a href='#type-DownloadItem'>DownloadItems</a> will be returned.",
+            "optional": true,
             "type": "integer"
-          }, 
+          },
           "mime": {
-            "description": "The file's MIME type.", 
-            "optional": true, 
+            "description": "The file's MIME type.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "orderBy": {
-            "description": "Setting elements of this array to <a href='#type-DownloadItem'>DownloadItem</a> properties in order to sort the search results. For example, setting <code>orderBy='startTime'</code> sorts the <a href='#type-DownloadItem'>DownloadItems</a> by their start time in ascending order. To specify descending order, prefix <code>orderBy</code> with a hyphen: '-startTime'.", 
+            "description": "Setting elements of this array to <a href='#type-DownloadItem'>DownloadItem</a> properties in order to sort the search results. For example, setting <code>orderBy='startTime'</code> sorts the <a href='#type-DownloadItem'>DownloadItems</a> by their start time in ascending order. To specify descending order, prefix <code>orderBy</code> with a hyphen: '-startTime'.",
             "items": {
               "type": "string"
-            }, 
-            "optional": true, 
+            },
+            "optional": true,
             "type": "array"
-          }, 
+          },
           "paused": {
-            "description": "True if the download has stopped reading data from the host, but kept the connection open.", 
-            "optional": true, 
+            "description": "True if the download has stopped reading data from the host, but kept the connection open.",
+            "optional": true,
             "type": "boolean"
-          }, 
+          },
           "query": {
-            "description": "This array of search terms limits results to <a href='#type-DownloadItem'>DownloadItems</a> whose <code>filename</code> or <code>url</code> contain all of the search terms that do not begin with a dash '-' and none of the search terms that do begin with a dash.", 
+            "description": "This array of search terms limits results to <a href='#type-DownloadItem'>DownloadItems</a> whose <code>filename</code> or <code>url</code> contain all of the search terms that do not begin with a dash '-' and none of the search terms that do begin with a dash.",
             "items": {
               "type": "string"
-            }, 
-            "optional": true, 
+            },
+            "optional": true,
             "type": "array"
-          }, 
+          },
           "startTime": {
-            "optional": true, 
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "startedAfter": {
-            "$ref": "DownloadTime", 
-            "description": "Limits results to downloads that started after the given ms since the epoch.", 
+            "$ref": "DownloadTime",
+            "description": "Limits results to downloads that started after the given ms since the epoch.",
             "optional": true
-          }, 
+          },
           "startedBefore": {
-            "$ref": "DownloadTime", 
-            "description": "Limits results to downloads that started before the given ms since the epoch.", 
+            "$ref": "DownloadTime",
+            "description": "Limits results to downloads that started before the given ms since the epoch.",
             "optional": true
-          }, 
+          },
           "state": {
-            "$ref": "State", 
-            "description": "Indicates whether the download is progressing, interrupted, or complete.", 
+            "$ref": "State",
+            "description": "Indicates whether the download is progressing, interrupted, or complete.",
             "optional": true
-          }, 
+          },
           "totalBytes": {
-            "description": "Number of bytes in the whole file, without considering file compression, or -1 if unknown.", 
-            "optional": true, 
+            "description": "Number of bytes in the whole file, without considering file compression, or -1 if unknown.",
+            "optional": true,
             "type": "number"
-          }, 
+          },
           "totalBytesGreater": {
-            "description": "Limits results to downloads whose totalBytes is greater than the given integer.", 
-            "optional": true, 
+            "description": "Limits results to downloads whose totalBytes is greater than the given integer.",
+            "optional": true,
             "type": "number"
-          }, 
+          },
           "totalBytesLess": {
-            "description": "Limits results to downloads whose totalBytes is less than the given integer.", 
-            "optional": true, 
+            "description": "Limits results to downloads whose totalBytes is less than the given integer.",
+            "optional": true,
             "type": "number"
-          }, 
+          },
           "url": {
-            "description": "Absolute URL.", 
-            "optional": true, 
+            "description": "Absolute URL.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "urlRegex": {
-            "description": "Limits results to <a href='#type-DownloadItem'>DownloadItems</a> whose <code>url</code> matches the given regular expression.", 
-            "optional": true, 
+            "description": "Limits results to <a href='#type-DownloadItem'>DownloadItems</a> whose <code>url</code> matches the given regular expression.",
+            "optional": true,
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
       }
     ]
-  }, 
+  },
   {
-    "description": "The <code>chrome.events</code> namespace contains common types used by APIs dispatching events to notify you when something interesting happens.", 
-    "namespace": "events", 
+    "description": "The <code>chrome.events</code> namespace contains common types used by APIs dispatching events to notify you when something interesting happens.",
+    "namespace": "events",
     "types": [
       {
-        "description": "Description of a declarative rule for handling events.", 
-        "id": "Rule", 
+        "description": "Description of a declarative rule for handling events.",
+        "id": "Rule",
         "properties": {
           "actions": {
-            "description": "List of actions that are triggered if one of the condtions is fulfilled.", 
+            "description": "List of actions that are triggered if one of the condtions is fulfilled.",
             "items": {
               "type": "any"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "conditions": {
-            "description": "List of conditions that can trigger the actions.", 
+            "description": "List of conditions that can trigger the actions.",
             "items": {
               "type": "any"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "id": {
-            "description": "Optional identifier that allows referencing this rule.", 
-            "optional": true, 
+            "description": "Optional identifier that allows referencing this rule.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "priority": {
-            "description": "Optional priority of this rule. Defaults to 100.", 
-            "optional": true, 
+            "description": "Optional priority of this rule. Defaults to 100.",
+            "optional": true,
             "type": "integer"
-          }, 
+          },
           "tags": {
-            "description": "Tags can be used to annotate rules and perform operations on sets of rules.", 
+            "description": "Tags can be used to annotate rules and perform operations on sets of rules.",
             "items": {
               "type": "string"
-            }, 
-            "optional": true, 
+            },
+            "optional": true,
             "type": "array"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       {
-        "description": "An object which allows the addition and removal of listeners for a Chrome event.", 
+        "description": "An object which allows the addition and removal of listeners for a Chrome event.",
         "functions": [
           {
-            "description": "Registers an event listener <em>callback</em> to an event.", 
-            "name": "addListener", 
+            "description": "Registers an event listener <em>callback</em> to an event.",
+            "name": "addListener",
             "parameters": [
               {
-                "description": "Called when an event occurs. The parameters of this function depend on the type of event.", 
-                "name": "callback", 
+                "description": "Called when an event occurs. The parameters of this function depend on the type of event.",
+                "name": "callback",
                 "type": "function"
               }
-            ], 
+            ],
             "type": "function"
-          }, 
+          },
           {
-            "description": "Deregisters an event listener <em>callback</em> from an event.", 
-            "name": "removeListener", 
+            "description": "Deregisters an event listener <em>callback</em> from an event.",
+            "name": "removeListener",
             "parameters": [
               {
-                "description": "Listener that shall be unregistered.", 
-                "name": "callback", 
+                "description": "Listener that shall be unregistered.",
+                "name": "callback",
                 "type": "function"
               }
-            ], 
+            ],
             "type": "function"
-          }, 
+          },
           {
-            "name": "hasListener", 
+            "name": "hasListener",
             "parameters": [
               {
-                "description": "Listener whose registration status shall be tested.", 
-                "name": "callback", 
+                "description": "Listener whose registration status shall be tested.",
+                "name": "callback",
                 "type": "function"
               }
-            ], 
+            ],
             "returns": {
-              "description": "True if <em>callback</em> is registered to the event.", 
+              "description": "True if <em>callback</em> is registered to the event.",
               "type": "boolean"
-            }, 
+            },
             "type": "function"
-          }, 
+          },
           {
-            "name": "hasListeners", 
-            "parameters": [], 
+            "name": "hasListeners",
+            "parameters": [],
             "returns": {
-              "description": "True if any event listeners are registered to the event.", 
+              "description": "True if any event listeners are registered to the event.",
               "type": "boolean"
-            }, 
+            },
             "type": "function"
-          }, 
+          },
           {
-            "description": "Registers rules to handle events.", 
-            "name": "addRules", 
+            "description": "Registers rules to handle events.",
+            "name": "addRules",
             "parameters": [
               {
-                "description": "Name of the event this function affects.", 
-                "name": "eventName", 
+                "description": "Name of the event this function affects.",
+                "name": "eventName",
                 "type": "string"
-              }, 
+              },
               {
-                "description": "If provided, this is an integer that uniquely identfies the <webview> associated with this function call.", 
-                "name": "webViewInstanceId", 
+                "description": "If provided, this is an integer that uniquely identfies the <webview> associated with this function call.",
+                "name": "webViewInstanceId",
                 "type": "integer"
-              }, 
+              },
               {
-                "description": "Rules to be registered. These do not replace previously registered rules.", 
+                "description": "Rules to be registered. These do not replace previously registered rules.",
                 "items": {
                   "$ref": "Rule"
-                }, 
-                "name": "rules", 
+                },
+                "name": "rules",
                 "type": "array"
-              }, 
+              },
               {
-                "description": "Called with registered rules.", 
-                "name": "callback", 
-                "optional": true, 
+                "description": "Called with registered rules.",
+                "name": "callback",
+                "optional": true,
                 "parameters": [
                   {
-                    "description": "Rules that were registered, the optional parameters are filled with values.", 
+                    "description": "Rules that were registered, the optional parameters are filled with values.",
                     "items": {
                       "$ref": "Rule"
-                    }, 
-                    "name": "rules", 
+                    },
+                    "name": "rules",
                     "type": "array"
                   }
-                ], 
+                ],
                 "type": "function"
               }
-            ], 
-            "type": "function", 
+            ],
+            "type": "function",
             "unsupported": true
-          }, 
+          },
           {
-            "description": "Returns currently registered rules.", 
-            "name": "getRules", 
+            "description": "Returns currently registered rules.",
+            "name": "getRules",
             "parameters": [
               {
-                "description": "Name of the event this function affects.", 
-                "name": "eventName", 
+                "description": "Name of the event this function affects.",
+                "name": "eventName",
                 "type": "string"
-              }, 
+              },
               {
-                "description": "If provided, this is an integer that uniquely identfies the <webview> associated with this function call.", 
-                "name": "webViewInstanceId", 
+                "description": "If provided, this is an integer that uniquely identfies the <webview> associated with this function call.",
+                "name": "webViewInstanceId",
                 "type": "integer"
-              }, 
+              },
               {
-                "description": "If an array is passed, only rules with identifiers contained in this array are returned.", 
+                "description": "If an array is passed, only rules with identifiers contained in this array are returned.",
                 "items": {
                   "type": "string"
-                }, 
-                "name": "ruleIdentifiers", 
-                "optional": true, 
+                },
+                "name": "ruleIdentifiers",
+                "optional": true,
                 "type": "array"
-              }, 
+              },
               {
-                "description": "Called with registered rules.", 
-                "name": "callback", 
+                "description": "Called with registered rules.",
+                "name": "callback",
                 "parameters": [
                   {
-                    "description": "Rules that were registered, the optional parameters are filled with values.", 
+                    "description": "Rules that were registered, the optional parameters are filled with values.",
                     "items": {
                       "$ref": "Rule"
-                    }, 
-                    "name": "rules", 
+                    },
+                    "name": "rules",
                     "type": "array"
                   }
-                ], 
+                ],
                 "type": "function"
               }
-            ], 
-            "type": "function", 
+            ],
+            "type": "function",
             "unsupported": true
-          }, 
+          },
           {
-            "description": "Unregisters currently registered rules.", 
-            "name": "removeRules", 
+            "description": "Unregisters currently registered rules.",
+            "name": "removeRules",
             "parameters": [
               {
-                "description": "Name of the event this function affects.", 
-                "name": "eventName", 
+                "description": "Name of the event this function affects.",
+                "name": "eventName",
                 "type": "string"
-              }, 
+              },
               {
-                "description": "If provided, this is an integer that uniquely identfies the <webview> associated with this function call.", 
-                "name": "webViewInstanceId", 
+                "description": "If provided, this is an integer that uniquely identfies the <webview> associated with this function call.",
+                "name": "webViewInstanceId",
                 "type": "integer"
-              }, 
+              },
               {
-                "description": "If an array is passed, only rules with identifiers contained in this array are unregistered.", 
+                "description": "If an array is passed, only rules with identifiers contained in this array are unregistered.",
                 "items": {
                   "type": "string"
-                }, 
-                "name": "ruleIdentifiers", 
-                "optional": true, 
+                },
+                "name": "ruleIdentifiers",
+                "optional": true,
                 "type": "array"
-              }, 
+              },
               {
-                "description": "Called when rules were unregistered.", 
-                "name": "callback", 
-                "optional": true, 
-                "parameters": [], 
+                "description": "Called when rules were unregistered.",
+                "name": "callback",
+                "optional": true,
+                "parameters": [],
                 "type": "function"
               }
-            ], 
-            "type": "function", 
+            ],
+            "type": "function",
             "unsupported": true
           }
-        ], 
-        "id": "Event", 
+        ],
+        "id": "Event",
         "type": "object"
-      }, 
+      },
       {
-        "description": "Filters URLs for various criteria. See <a href='events#filtered'>event filtering</a>. All criteria are case sensitive.", 
-        "id": "UrlFilter", 
+        "description": "Filters URLs for various criteria. See <a href='events#filtered'>event filtering</a>. All criteria are case sensitive.",
+        "id": "UrlFilter",
         "properties": {
           "hostContains": {
-            "description": "Matches if the host name of the URL contains a specified string. To test whether a host name component has a prefix 'foo', use hostContains: '.foo'. This matches 'www.foobar.com' and 'foo.com', because an implicit dot is added at the beginning of the host name. Similarly, hostContains can be used to match against component suffix ('foo.') and to exactly match against components ('.foo.'). Suffix- and exact-matching for the last components need to be done separately using hostSuffix, because no implicit dot is added at the end of the host name.", 
-            "optional": true, 
+            "description": "Matches if the host name of the URL contains a specified string. To test whether a host name component has a prefix 'foo', use hostContains: '.foo'. This matches 'www.foobar.com' and 'foo.com', because an implicit dot is added at the beginning of the host name. Similarly, hostContains can be used to match against component suffix ('foo.') and to exactly match against components ('.foo.'). Suffix- and exact-matching for the last components need to be done separately using hostSuffix, because no implicit dot is added at the end of the host name.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "hostEquals": {
-            "description": "Matches if the host name of the URL is equal to a specified string.", 
-            "optional": true, 
+            "description": "Matches if the host name of the URL is equal to a specified string.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "hostPrefix": {
-            "description": "Matches if the host name of the URL starts with a specified string.", 
-            "optional": true, 
+            "description": "Matches if the host name of the URL starts with a specified string.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "hostSuffix": {
-            "description": "Matches if the host name of the URL ends with a specified string.", 
-            "optional": true, 
+            "description": "Matches if the host name of the URL ends with a specified string.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "originAndPathMatches": {
-            "description": "Matches if the URL without query segment and fragment identifier matches a specified regular expression. Port numbers are stripped from the URL if they match the default port number. The regular expressions use the <a href=\"https://github.com/google/re2/blob/master/doc/syntax.txt\">RE2 syntax</a>.", 
-            "optional": true, 
+            "description": "Matches if the URL without query segment and fragment identifier matches a specified regular expression. Port numbers are stripped from the URL if they match the default port number. The regular expressions use the <a href=\"https://github.com/google/re2/blob/master/doc/syntax.txt\">RE2 syntax</a>.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "pathContains": {
-            "description": "Matches if the path segment of the URL contains a specified string.", 
-            "optional": true, 
+            "description": "Matches if the path segment of the URL contains a specified string.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "pathEquals": {
-            "description": "Matches if the path segment of the URL is equal to a specified string.", 
-            "optional": true, 
+            "description": "Matches if the path segment of the URL is equal to a specified string.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "pathPrefix": {
-            "description": "Matches if the path segment of the URL starts with a specified string.", 
-            "optional": true, 
+            "description": "Matches if the path segment of the URL starts with a specified string.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "pathSuffix": {
-            "description": "Matches if the path segment of the URL ends with a specified string.", 
-            "optional": true, 
+            "description": "Matches if the path segment of the URL ends with a specified string.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "ports": {
-            "description": "Matches if the port of the URL is contained in any of the specified port lists. For example <code>[80, 443, [1000, 1200]]</code> matches all requests on port 80, 443 and in the range 1000-1200.", 
+            "description": "Matches if the port of the URL is contained in any of the specified port lists. For example <code>[80, 443, [1000, 1200]]</code> matches all requests on port 80, 443 and in the range 1000-1200.",
             "items": {
               "choices": [
                 {
-                  "description": "A specific port.", 
+                  "description": "A specific port.",
                   "type": "integer"
-                }, 
+                },
                 {
-                  "description": "A pair of integers identiying the start and end (both inclusive) of a port range.", 
+                  "description": "A pair of integers identiying the start and end (both inclusive) of a port range.",
                   "items": {
                     "type": "integer"
-                  }, 
-                  "maxItems": 2, 
-                  "minItems": 2, 
+                  },
+                  "maxItems": 2,
+                  "minItems": 2,
                   "type": "array"
                 }
               ]
-            }, 
-            "optional": true, 
+            },
+            "optional": true,
             "type": "array"
-          }, 
+          },
           "queryContains": {
-            "description": "Matches if the query segment of the URL contains a specified string.", 
-            "optional": true, 
+            "description": "Matches if the query segment of the URL contains a specified string.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "queryEquals": {
-            "description": "Matches if the query segment of the URL is equal to a specified string.", 
-            "optional": true, 
+            "description": "Matches if the query segment of the URL is equal to a specified string.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "queryPrefix": {
-            "description": "Matches if the query segment of the URL starts with a specified string.", 
-            "optional": true, 
+            "description": "Matches if the query segment of the URL starts with a specified string.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "querySuffix": {
-            "description": "Matches if the query segment of the URL ends with a specified string.", 
-            "optional": true, 
+            "description": "Matches if the query segment of the URL ends with a specified string.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "schemes": {
-            "description": "Matches if the scheme of the URL is equal to any of the schemes specified in the array.", 
+            "description": "Matches if the scheme of the URL is equal to any of the schemes specified in the array.",
             "items": {
               "type": "string"
-            }, 
-            "optional": true, 
+            },
+            "optional": true,
             "type": "array"
-          }, 
+          },
           "urlContains": {
-            "description": "Matches if the URL (without fragment identifier) contains a specified string. Port numbers are stripped from the URL if they match the default port number.", 
-            "optional": true, 
+            "description": "Matches if the URL (without fragment identifier) contains a specified string. Port numbers are stripped from the URL if they match the default port number.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "urlEquals": {
-            "description": "Matches if the URL (without fragment identifier) is equal to a specified string. Port numbers are stripped from the URL if they match the default port number.", 
-            "optional": true, 
+            "description": "Matches if the URL (without fragment identifier) is equal to a specified string. Port numbers are stripped from the URL if they match the default port number.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "urlMatches": {
-            "description": "Matches if the URL (without fragment identifier) matches a specified regular expression. Port numbers are stripped from the URL if they match the default port number. The regular expressions use the <a href=\"https://github.com/google/re2/blob/master/doc/syntax.txt\">RE2 syntax</a>.", 
-            "optional": true, 
+            "description": "Matches if the URL (without fragment identifier) matches a specified regular expression. Port numbers are stripped from the URL if they match the default port number. The regular expressions use the <a href=\"https://github.com/google/re2/blob/master/doc/syntax.txt\">RE2 syntax</a>.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "urlPrefix": {
-            "description": "Matches if the URL (without fragment identifier) starts with a specified string. Port numbers are stripped from the URL if they match the default port number.", 
-            "optional": true, 
+            "description": "Matches if the URL (without fragment identifier) starts with a specified string. Port numbers are stripped from the URL if they match the default port number.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "urlSuffix": {
-            "description": "Matches if the URL (without fragment identifier) ends with a specified string. Port numbers are stripped from the URL if they match the default port number.", 
-            "optional": true, 
+            "description": "Matches if the URL (without fragment identifier) ends with a specified string. Port numbers are stripped from the URL if they match the default port number.",
+            "optional": true,
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
       }
     ]
-  }, 
+  },
+  {
+    "namespace": "experiments",
+    "types": [
+      {
+        "id": "ExperimentAPI",
+        "properties": {
+          "child": {
+            "optional": true,
+            "properties": {
+              "paths": {
+                "$ref": "APIPaths"
+              },
+              "scopes": {
+                "items": {
+                  "$ref": "APIChildScope",
+                  "onError": "warn"
+                },
+                "minItems": 1,
+                "type": "array"
+              },
+              "script": {
+                "$ref": "ExperimentURL"
+              }
+            },
+            "type": "object"
+          },
+          "parent": {
+            "optional": true,
+            "properties": {
+              "events": {
+                "$ref": "APIEvents",
+                "default": [],
+                "optional": true
+              },
+              "paths": {
+                "$ref": "APIPaths",
+                "default": [],
+                "optional": true
+              },
+              "scopes": {
+                "default": [],
+                "items": {
+                  "$ref": "APIParentScope",
+                  "onError": "warn"
+                },
+                "optional": true,
+                "type": "array"
+              },
+              "script": {
+                "$ref": "ExperimentURL"
+              }
+            },
+            "type": "object"
+          },
+          "schema": {
+            "$ref": "ExperimentURL"
+          }
+        },
+        "type": "object"
+      },
+      {
+        "format": "unresolvedRelativeUrl",
+        "id": "ExperimentURL",
+        "type": "string"
+      },
+      {
+        "id": "APIPaths",
+        "items": {
+          "$ref": "APIPath"
+        },
+        "minItems": 1,
+        "type": "array"
+      },
+      {
+        "id": "APIPath",
+        "items": {
+          "type": "string"
+        },
+        "minItems": 1,
+        "type": "array"
+      },
+      {
+        "id": "APIEvents",
+        "items": {
+          "$ref": "APIEvent",
+          "onError": "warn"
+        },
+        "type": "array"
+      },
+      {
+        "enum": [
+          "startup"
+        ],
+        "id": "APIEvent",
+        "type": "string"
+      },
+      {
+        "enum": [
+          "addon_parent",
+          "content_parent",
+          "devtools_parent"
+        ],
+        "id": "APIParentScope",
+        "type": "string"
+      },
+      {
+        "enum": [
+          "addon_child",
+          "content_child",
+          "devtools_child"
+        ],
+        "id": "APIChildScope",
+        "type": "string"
+      }
+    ]
+  },
   {
     "allowedContexts": [
-      "content", 
+      "content",
       "devtools"
-    ], 
-    "description": "The <code>browser.extension</code> API has utilities that can be used by any extension page. It includes support for exchanging messages between an extension and its content scripts or between extensions, as described in detail in $(topic:messaging)[Message Passing].", 
+    ],
+    "description": "The <code>browser.extension</code> API has utilities that can be used by any extension page. It includes support for exchanging messages between an extension and its content scripts or between extensions, as described in detail in $(topic:messaging)[Message Passing].",
     "events": [
       {
-        "deprecated": "Please use $(ref:runtime.onMessage).", 
-        "description": "Fired when a request is sent from either an extension process or a content script.", 
-        "name": "onRequest", 
+        "deprecated": "Please use $(ref:runtime.onMessage).",
+        "description": "Fired when a request is sent from either an extension process or a content script.",
+        "name": "onRequest",
         "parameters": [
           {
-            "description": "The request sent by the calling script.", 
-            "name": "request", 
-            "optional": true, 
+            "description": "The request sent by the calling script.",
+            "name": "request",
+            "optional": true,
             "type": "any"
-          }, 
+          },
           {
-            "$ref": "runtime.MessageSender", 
+            "$ref": "runtime.MessageSender",
             "name": "sender"
-          }, 
+          },
           {
-            "description": "Function to call (at most once) when you have a response. The argument should be any JSON-ifiable object, or undefined if there is no response. If you have more than one <code>onRequest</code> listener in the same document, then only one may send a response.", 
-            "name": "sendResponse", 
+            "description": "Function to call (at most once) when you have a response. The argument should be any JSON-ifiable object, or undefined if there is no response. If you have more than one <code>onRequest</code> listener in the same document, then only one may send a response.",
+            "name": "sendResponse",
             "type": "function"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
-      }, 
+      },
       {
-        "deprecated": "Please use $(ref:runtime.onMessageExternal).", 
-        "description": "Fired when a request is sent from another extension.", 
-        "name": "onRequestExternal", 
+        "deprecated": "Please use $(ref:runtime.onMessageExternal).",
+        "description": "Fired when a request is sent from another extension.",
+        "name": "onRequestExternal",
         "parameters": [
           {
-            "description": "The request sent by the calling script.", 
-            "name": "request", 
-            "optional": true, 
+            "description": "The request sent by the calling script.",
+            "name": "request",
+            "optional": true,
             "type": "any"
-          }, 
+          },
           {
-            "$ref": "runtime.MessageSender", 
+            "$ref": "runtime.MessageSender",
             "name": "sender"
-          }, 
+          },
           {
-            "description": "Function to call when you have a response. The argument should be any JSON-ifiable object, or undefined if there is no response.", 
-            "name": "sendResponse", 
+            "description": "Function to call when you have a response. The argument should be any JSON-ifiable object, or undefined if there is no response.",
+            "name": "sendResponse",
             "type": "function"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
       }
-    ], 
+    ],
     "functions": [
       {
         "allowedContexts": [
-          "content", 
+          "content",
           "devtools"
-        ], 
-        "description": "Converts a relative path within an extension install directory to a fully-qualified URL.", 
-        "name": "getURL", 
+        ],
+        "description": "Converts a relative path within an extension install directory to a fully-qualified URL.",
+        "name": "getURL",
         "parameters": [
           {
-            "description": "A path to a resource within an extension expressed relative to its install directory.", 
-            "name": "path", 
+            "description": "A path to a resource within an extension expressed relative to its install directory.",
+            "name": "path",
             "type": "string"
           }
-        ], 
+        ],
         "returns": {
-          "description": "The fully-qualified URL to the resource.", 
+          "description": "The fully-qualified URL to the resource.",
           "type": "string"
-        }, 
+        },
         "type": "function"
-      }, 
+      },
       {
-        "description": "Returns an array of the JavaScript 'window' objects for each of the pages running inside the current extension.", 
-        "name": "getViews", 
+        "description": "Returns an array of the JavaScript 'window' objects for each of the pages running inside the current extension.",
+        "name": "getViews",
         "parameters": [
           {
-            "name": "fetchProperties", 
-            "optional": true, 
+            "name": "fetchProperties",
+            "optional": true,
             "properties": {
               "tabId": {
-                "description": "Find a view according to a tab id. If this field is omitted, returns all views.", 
-                "optional": true, 
+                "description": "Find a view according to a tab id. If this field is omitted, returns all views.",
+                "optional": true,
                 "type": "integer"
-              }, 
+              },
               "type": {
-                "$ref": "ViewType", 
-                "description": "The type of view to get. If omitted, returns all views (including background pages and tabs). Valid values: 'tab', 'popup', 'sidebar'.", 
+                "$ref": "ViewType",
+                "description": "The type of view to get. If omitted, returns all views (including background pages and tabs). Valid values: 'tab', 'popup', 'sidebar'.",
                 "optional": true
-              }, 
+              },
               "windowId": {
-                "description": "The window to restrict the search to. If omitted, returns all views.", 
-                "optional": true, 
+                "description": "The window to restrict the search to. If omitted, returns all views.",
+                "optional": true,
                 "type": "integer"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "returns": {
-          "description": "Array of global objects", 
+          "description": "Array of global objects",
           "items": {
             "additionalProperties": {
               "type": "any"
-            }, 
-            "isInstanceOf": "Window", 
+            },
+            "isInstanceOf": "Window",
             "type": "object"
-          }, 
+          },
           "type": "array"
-        }, 
+        },
         "type": "function"
-      }, 
+      },
       {
-        "description": "Returns the JavaScript 'window' object for the background page running inside the current extension. Returns null if the extension has no background page.", 
-        "name": "getBackgroundPage", 
-        "parameters": [], 
+        "description": "Returns the JavaScript 'window' object for the background page running inside the current extension. Returns null if the extension has no background page.",
+        "name": "getBackgroundPage",
+        "parameters": [],
         "returns": {
           "additionalProperties": {
             "type": "any"
-          }, 
-          "isInstanceOf": "Window", 
-          "optional": true, 
+          },
+          "isInstanceOf": "Window",
+          "optional": true,
           "type": "object"
-        }, 
+        },
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Retrieves the state of the extension's access to Incognito-mode (as determined by the user-controlled 'Allowed in Incognito' checkbox.", 
-        "name": "isAllowedIncognitoAccess", 
+        "async": "callback",
+        "description": "Retrieves the state of the extension's access to Incognito-mode (as determined by the user-controlled 'Allowed in Incognito' checkbox.",
+        "name": "isAllowedIncognitoAccess",
         "parameters": [
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
-                "description": "True if the extension has access to Incognito mode, false otherwise.", 
-                "name": "isAllowedAccess", 
+                "description": "True if the extension has access to Incognito mode, false otherwise.",
+                "name": "isAllowedAccess",
                 "type": "boolean"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Retrieves the state of the extension's access to the 'file://' scheme (as determined by the user-controlled 'Allow access to File URLs' checkbox.", 
-        "name": "isAllowedFileSchemeAccess", 
+        "async": "callback",
+        "description": "Retrieves the state of the extension's access to the 'file://' scheme (as determined by the user-controlled 'Allow access to File URLs' checkbox.",
+        "name": "isAllowedFileSchemeAccess",
         "parameters": [
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
-                "description": "True if the extension can access the 'file://' scheme, false otherwise.", 
-                "name": "isAllowedAccess", 
+                "description": "True if the extension can access the 'file://' scheme, false otherwise.",
+                "name": "isAllowedAccess",
                 "type": "boolean"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Sets the value of the ap CGI parameter used in the extension's update URL.  This value is ignored for extensions that are hosted in the browser vendor's store.", 
-        "name": "setUpdateUrlData", 
+        "description": "Sets the value of the ap CGI parameter used in the extension's update URL.  This value is ignored for extensions that are hosted in the browser vendor's store.",
+        "name": "setUpdateUrlData",
         "parameters": [
           {
-            "maxLength": 1024, 
-            "name": "data", 
+            "maxLength": 1024,
+            "name": "data",
             "type": "string"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
       }
-    ], 
-    "namespace": "extension", 
+    ],
+    "namespace": "extension",
     "properties": {
       "inIncognitoContext": {
         "allowedContexts": [
-          "content", 
+          "content",
           "devtools"
-        ], 
-        "description": "True for content scripts running inside incognito tabs, and for extension pages running inside an incognito process. The latter only applies to extensions with 'split' incognito_behavior.", 
-        "optional": true, 
+        ],
+        "description": "True for content scripts running inside incognito tabs, and for extension pages running inside an incognito process. The latter only applies to extensions with 'split' incognito_behavior.",
+        "optional": true,
         "type": "boolean"
-      }, 
+      },
       "lastError": {
         "additionalProperties": {
           "type": "any"
-        }, 
+        },
         "allowedContexts": [
-          "content", 
+          "content",
           "devtools"
-        ], 
-        "description": "Set for the lifetime of a callback if an ansychronous extension api has resulted in an error. If no error has occured lastError will be <var>undefined</var>.", 
-        "optional": true, 
+        ],
+        "description": "Set for the lifetime of a callback if an ansychronous extension api has resulted in an error. If no error has occured lastError will be <var>undefined</var>.",
+        "optional": true,
         "properties": {
           "message": {
-            "description": "Description of the error that has taken place.", 
+            "description": "Description of the error that has taken place.",
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
       }
-    }, 
+    },
     "types": [
       {
-        "description": "The type of extension view.", 
+        "description": "The type of extension view.",
         "enum": [
-          "tab", 
-          "popup", 
+          "tab",
+          "popup",
           "sidebar"
-        ], 
-        "id": "ViewType", 
+        ],
+        "id": "ViewType",
         "type": "string"
       }
     ]
-  }, 
+  },
   {
-    "description": "The <code>browser.extensionTypes</code> API contains type declarations for WebExtensions.", 
-    "namespace": "extensionTypes", 
+    "description": "The <code>browser.extensionTypes</code> API contains type declarations for WebExtensions.",
+    "namespace": "extensionTypes",
     "types": [
       {
-        "description": "The format of an image.", 
+        "description": "The format of an image.",
         "enum": [
-          "jpeg", 
+          "jpeg",
           "png"
-        ], 
-        "id": "ImageFormat", 
+        ],
+        "id": "ImageFormat",
         "type": "string"
-      }, 
+      },
       {
-        "description": "Details about the format and quality of an image.", 
-        "id": "ImageDetails", 
+        "description": "Details about the format and quality of an image.",
+        "id": "ImageDetails",
         "properties": {
           "format": {
-            "$ref": "ImageFormat", 
-            "description": "The format of the resulting image.  Default is <code>\"jpeg\"</code>.", 
+            "$ref": "ImageFormat",
+            "description": "The format of the resulting image.  Default is <code>\"jpeg\"</code>.",
             "optional": true
-          }, 
+          },
           "quality": {
-            "description": "When format is <code>\"jpeg\"</code>, controls the quality of the resulting image.  This value is ignored for PNG images.  As quality is decreased, the resulting image will have more visual artifacts, and the number of bytes needed to store it will decrease.", 
-            "maximum": 100, 
-            "minimum": 0, 
-            "optional": true, 
+            "description": "When format is <code>\"jpeg\"</code>, controls the quality of the resulting image.  This value is ignored for PNG images.  As quality is decreased, the resulting image will have more visual artifacts, and the number of bytes needed to store it will decrease.",
+            "maximum": 100,
+            "minimum": 0,
+            "optional": true,
             "type": "integer"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       {
-        "description": "The soonest that the JavaScript or CSS will be injected into the tab.", 
+        "description": "The soonest that the JavaScript or CSS will be injected into the tab.",
         "enum": [
-          "document_start", 
-          "document_end", 
+          "document_start",
+          "document_end",
           "document_idle"
-        ], 
-        "id": "RunAt", 
+        ],
+        "id": "RunAt",
         "type": "string"
-      }, 
+      },
       {
-        "description": "The origin of the CSS to inject, this affects the cascading order (priority) of the stylesheet.", 
+        "description": "The origin of the CSS to inject, this affects the cascading order (priority) of the stylesheet.",
         "enum": [
-          "user", 
+          "user",
           "author"
-        ], 
-        "id": "CSSOrigin", 
+        ],
+        "id": "CSSOrigin",
         "type": "string"
-      }, 
+      },
       {
-        "description": "Details of the script or CSS to inject. Either the code or the file property must be set, but both may not be set at the same time.", 
-        "id": "InjectDetails", 
+        "description": "Details of the script or CSS to inject. Either the code or the file property must be set, but both may not be set at the same time.",
+        "id": "InjectDetails",
         "properties": {
           "allFrames": {
-            "description": "If allFrames is <code>true</code>, implies that the JavaScript or CSS should be injected into all frames of current page. By default, it's <code>false</code> and is only injected into the top frame.", 
-            "optional": true, 
+            "description": "If allFrames is <code>true</code>, implies that the JavaScript or CSS should be injected into all frames of current page. By default, it's <code>false</code> and is only injected into the top frame.",
+            "optional": true,
             "type": "boolean"
-          }, 
+          },
           "code": {
-            "description": "JavaScript or CSS code to inject.<br><br><b>Warning:</b><br>Be careful using the <code>code</code> parameter. Incorrect use of it may open your extension to <a href=\"https://en.wikipedia.org/wiki/Cross-site_scripting\">cross site scripting</a> attacks.", 
-            "optional": true, 
+            "description": "JavaScript or CSS code to inject.<br><br><b>Warning:</b><br>Be careful using the <code>code</code> parameter. Incorrect use of it may open your extension to <a href=\"https://en.wikipedia.org/wiki/Cross-site_scripting\">cross site scripting</a> attacks.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "cssOrigin": {
-            "$ref": "CSSOrigin", 
-            "description": "The css origin of the stylesheet to inject. Defaults to \"author\".", 
+            "$ref": "CSSOrigin",
+            "description": "The css origin of the stylesheet to inject. Defaults to \"author\".",
             "optional": true
-          }, 
+          },
           "file": {
-            "description": "JavaScript or CSS file to inject.", 
-            "optional": true, 
+            "description": "JavaScript or CSS file to inject.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "frameId": {
-            "description": "The ID of the frame to inject the script into. This may not be used in combination with <code>allFrames</code>.", 
-            "minimum": 0, 
-            "optional": true, 
+            "description": "The ID of the frame to inject the script into. This may not be used in combination with <code>allFrames</code>.",
+            "minimum": 0,
+            "optional": true,
             "type": "integer"
-          }, 
+          },
           "matchAboutBlank": {
-            "description": "If matchAboutBlank is true, then the code is also injected in about:blank and about:srcdoc frames if your extension has access to its parent document. Code cannot be inserted in top-level about:-frames. By default it is <code>false</code>.", 
-            "optional": true, 
+            "description": "If matchAboutBlank is true, then the code is also injected in about:blank and about:srcdoc frames if your extension has access to its parent document. Code cannot be inserted in top-level about:-frames. By default it is <code>false</code>.",
+            "optional": true,
             "type": "boolean"
-          }, 
+          },
           "runAt": {
-            "$ref": "RunAt", 
-            "default": "document_idle", 
-            "description": "The soonest that the JavaScript or CSS will be injected into the tab. Defaults to \"document_idle\".", 
+            "$ref": "RunAt",
+            "default": "document_idle",
+            "description": "The soonest that the JavaScript or CSS will be injected into the tab. Defaults to \"document_idle\".",
             "optional": true
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       {
         "choices": [
           {
-            "format": "date", 
+            "format": "date",
             "type": "string"
-          }, 
+          },
           {
-            "minimum": 0, 
+            "minimum": 0,
             "type": "integer"
-          }, 
+          },
           {
             "additionalProperties": {
               "type": "any"
-            }, 
-            "isInstanceOf": "Date", 
+            },
+            "isInstanceOf": "Date",
             "type": "object"
           }
-        ], 
+        ],
         "id": "Date"
+      },
+      {
+        "choices": [
+          {
+            "properties": {
+              "file": {
+                "$ref": "manifest.ExtensionURL"
+              }
+            },
+            "type": "object"
+          },
+          {
+            "properties": {
+              "code": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "id": "ExtensionFileOrCode"
+      },
+      {
+        "choices": [
+          {
+            "type": "null"
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "boolean"
+          },
+          {
+            "items": {
+              "$ref": "PlainJSONValue"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "PlainJSONValue"
+            },
+            "type": "object"
+          }
+        ],
+        "description": "A plain JSON value",
+        "id": "PlainJSONValue"
       }
     ]
-  }, 
+  },
   {
-    "description": "Use the <code>browser.find</code> API to interact with the browser's <code>Find</code> interface.", 
+    "description": "Use the <code>browser.find</code> API to interact with the browser's <code>Find</code> interface.",
     "functions": [
       {
-        "async": true, 
-        "description": "Search for text in document and store found ranges in array, in document order.", 
-        "name": "find", 
+        "async": true,
+        "description": "Search for text in document and store found ranges in array, in document order.",
+        "name": "find",
         "parameters": [
           {
-            "description": "The string to search for.", 
-            "name": "queryphrase", 
+            "description": "The string to search for.",
+            "name": "queryphrase",
             "type": "string"
-          }, 
+          },
           {
-            "description": "Search parameters.", 
-            "name": "params", 
-            "optional": true, 
+            "description": "Search parameters.",
+            "name": "params",
+            "optional": true,
             "properties": {
               "caseSensitive": {
-                "description": "Find only ranges with case sensitive match.", 
-                "optional": true, 
+                "description": "Find only ranges with case sensitive match.",
+                "optional": true,
                 "type": "boolean"
-              }, 
+              },
               "entireWord": {
-                "description": "Find only ranges that match entire word.", 
-                "optional": true, 
+                "description": "Find only ranges that match entire word.",
+                "optional": true,
                 "type": "boolean"
-              }, 
+              },
               "includeRangeData": {
-                "description": "Return range data which provides range data in a serializable form.", 
-                "optional": true, 
+                "description": "Return range data which provides range data in a serializable form.",
+                "optional": true,
                 "type": "boolean"
-              }, 
+              },
               "includeRectData": {
-                "description": "Return rectangle data which describes visual position of search results.", 
-                "optional": true, 
+                "description": "Return rectangle data which describes visual position of search results.",
+                "optional": true,
                 "type": "boolean"
-              }, 
+              },
               "tabId": {
-                "description": "Tab to query. Defaults to the active tab.", 
-                "minimum": 0, 
-                "optional": true, 
+                "description": "Tab to query. Defaults to the active tab.",
+                "minimum": 0,
+                "optional": true,
                 "type": "integer"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": true, 
-        "description": "Highlight a range", 
-        "name": "highlightResults", 
+        "async": true,
+        "description": "Highlight a range",
+        "name": "highlightResults",
         "parameters": [
           {
-            "description": "highlightResults parameters", 
-            "name": "params", 
-            "optional": true, 
+            "description": "highlightResults parameters",
+            "name": "params",
+            "optional": true,
             "properties": {
               "noScroll": {
-                "description": "Don't scroll to highlighted item.", 
-                "optional": true, 
+                "description": "Don't scroll to highlighted item.",
+                "optional": true,
                 "type": "boolean"
-              }, 
+              },
               "rangeIndex": {
-                "description": "Found range to be highlighted. Default highlights all ranges.", 
-                "minimum": 0, 
-                "optional": true, 
+                "description": "Found range to be highlighted. Default highlights all ranges.",
+                "minimum": 0,
+                "optional": true,
                 "type": "integer"
-              }, 
+              },
               "tabId": {
-                "description": "Tab to highlight. Defaults to the active tab.", 
-                "minimum": 0, 
-                "optional": true, 
+                "description": "Tab to highlight. Defaults to the active tab.",
+                "minimum": 0,
+                "optional": true,
                 "type": "integer"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": true, 
-        "description": "Remove all highlighting from previous searches.", 
-        "name": "removeHighlighting", 
+        "async": true,
+        "description": "Remove all highlighting from previous searches.",
+        "name": "removeHighlighting",
         "parameters": [
           {
-            "description": "Tab to highlight. Defaults to the active tab.", 
-            "name": "tabId", 
-            "optional": true, 
+            "description": "Tab to highlight. Defaults to the active tab.",
+            "name": "tabId",
+            "optional": true,
             "type": "integer"
           }
-        ], 
+        ],
         "type": "function"
       }
-    ], 
-    "namespace": "find", 
+    ],
+    "namespace": "find",
     "permissions": [
       "find"
     ]
-  }, 
+  },
   {
-    "description": "Exposes the browser's profiler.", 
+    "description": "Exposes the browser's profiler.",
     "events": [
       {
-        "description": "Fires when the profiler starts/stops running.", 
-        "name": "onRunning", 
+        "description": "Fires when the profiler starts/stops running.",
+        "name": "onRunning",
         "parameters": [
           {
-            "description": "Whether the profiler is running or not. Pausing the profiler will not affect this value.", 
-            "name": "isRunning", 
+            "description": "Whether the profiler is running or not. Pausing the profiler will not affect this value.",
+            "name": "isRunning",
             "type": "boolean"
           }
-        ], 
+        ],
         "type": "function"
       }
-    ], 
+    ],
     "functions": [
       {
-        "async": true, 
-        "description": "Starts the profiler with the specified settings.", 
-        "name": "start", 
+        "async": true,
+        "description": "Starts the profiler with the specified settings.",
+        "name": "start",
         "parameters": [
           {
-            "name": "settings", 
+            "name": "settings",
             "properties": {
               "bufferSize": {
-                "description": "The size in bytes of the buffer used to store profiling data. A larger value allows capturing a profile that covers a greater amount of time.", 
-                "minimum": 0, 
+                "description": "The maximum size in bytes of the buffer used to store profiling data. A larger value allows capturing a profile that covers a greater amount of time.",
+                "minimum": 0,
                 "type": "integer"
-              }, 
+              },
               "features": {
-                "description": "A list of active features for the profiler.", 
+                "description": "A list of active features for the profiler.",
                 "items": {
                   "$ref": "ProfilerFeature"
-                }, 
+                },
                 "type": "array"
-              }, 
+              },
               "interval": {
-                "description": "Interval in milliseconds between samples of profiling data. A smaller value will increase the detail of the profiles captured.", 
+                "description": "Interval in milliseconds between samples of profiling data. A smaller value will increase the detail of the profiles captured.",
                 "type": "number"
-              }, 
+              },
               "threads": {
-                "description": "A list of thread names for which to capture profiles.", 
+                "description": "A list of thread names for which to capture profiles.",
                 "items": {
                   "type": "string"
-                }, 
-                "optional": true, 
+                },
+                "optional": true,
                 "type": "array"
+              },
+              "windowLength": {
+                "description": "The length of the window of time that's kept in the buffer. Any collected samples are discarded as soon as they are older than the number of seconds specified in this setting. Zero means no duration restriction.",
+                "optional": true,
+                "type": "number"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": true, 
-        "description": "Stops the profiler and discards any captured profile data.", 
-        "name": "stop", 
-        "parameters": [], 
+        "async": true,
+        "description": "Stops the profiler and discards any captured profile data.",
+        "name": "stop",
+        "parameters": [],
         "type": "function"
-      }, 
+      },
       {
-        "async": true, 
-        "description": "Pauses the profiler, keeping any profile data that is already written.", 
-        "name": "pause", 
-        "parameters": [], 
+        "async": true,
+        "description": "Pauses the profiler, keeping any profile data that is already written.",
+        "name": "pause",
+        "parameters": [],
         "type": "function"
-      }, 
+      },
       {
-        "async": true, 
-        "description": "Resumes the profiler with the settings that were initially used to start it.", 
-        "name": "resume", 
-        "parameters": [], 
+        "async": true,
+        "description": "Resumes the profiler with the settings that were initially used to start it.",
+        "name": "resume",
+        "parameters": [],
         "type": "function"
-      }, 
+      },
       {
-        "async": true, 
-        "description": "Gathers the profile data from the current profiling session.", 
-        "name": "getProfile", 
-        "parameters": [], 
-        "type": "function"
-      }, 
-      {
-        "async": true, 
-        "description": "Gathers the profile data from the current profiling session. The returned promise resolves to an array buffer that contains a JSON string.", 
-        "name": "getProfileAsArrayBuffer", 
-        "parameters": [], 
-        "type": "function"
-      }, 
-      {
-        "async": true, 
-        "description": "Gets the debug symbols for a particular library.", 
-        "name": "getSymbols", 
+        "async": true,
+        "description": "Gathers the profile data from the current profiling session, and writes it to disk. The returned promise resolves to a path that locates the created file.",
+        "name": "dumpProfileToFile",
         "parameters": [
           {
-            "description": "The name of the library's debug file. For example, 'xul.pdb", 
-            "name": "debugName", 
-            "type": "string"
-          }, 
-          {
-            "description": "The Breakpad ID of the library", 
-            "name": "breakpadId", 
+            "description": "The name of the file inside the profile/profiler directory",
+            "name": "fileName",
             "type": "string"
           }
-        ], 
+        ],
+        "type": "function"
+      },
+      {
+        "async": true,
+        "description": "Gathers the profile data from the current profiling session.",
+        "name": "getProfile",
+        "parameters": [],
+        "type": "function"
+      },
+      {
+        "async": true,
+        "description": "Gathers the profile data from the current profiling session. The returned promise resolves to an array buffer that contains a JSON string.",
+        "name": "getProfileAsArrayBuffer",
+        "parameters": [],
+        "type": "function"
+      },
+      {
+        "async": true,
+        "description": "Gathers the profile data from the current profiling session. The returned promise resolves to an array buffer that contains a gzipped JSON string.",
+        "name": "getProfileAsGzippedArrayBuffer",
+        "parameters": [],
+        "type": "function"
+      },
+      {
+        "async": true,
+        "description": "Gets the debug symbols for a particular library.",
+        "name": "getSymbols",
+        "parameters": [
+          {
+            "description": "The name of the library's debug file. For example, 'xul.pdb",
+            "name": "debugName",
+            "type": "string"
+          },
+          {
+            "description": "The Breakpad ID of the library",
+            "name": "breakpadId",
+            "type": "string"
+          }
+        ],
         "type": "function"
       }
-    ], 
-    "namespace": "geckoProfiler", 
+    ],
+    "namespace": "geckoProfiler",
     "permissions": [
       "geckoProfiler"
-    ], 
+    ],
     "types": [
       {
         "enum": [
-          "java", 
-          "js", 
-          "leaf", 
-          "mainthreadio", 
-          "memory", 
-          "privacy", 
-          "restyle", 
-          "stackwalk", 
-          "tasktracer", 
-          "threads"
-        ], 
-        "id": "ProfilerFeature", 
+          "java",
+          "js",
+          "leaf",
+          "mainthreadio",
+          "memory",
+          "privacy",
+          "responsiveness",
+          "screenshots",
+          "seqstyle",
+          "stackwalk",
+          "tasktracer",
+          "threads",
+          "trackopts",
+          "jstracer",
+          "jsallocations"
+        ],
+        "id": "ProfilerFeature",
+        "type": "string"
+      },
+      {
+        "enum": [
+          "windowLength"
+        ],
+        "id": "supports",
         "type": "string"
       }
     ]
-  }, 
+  },
   {
-    "description": "Use the <code>browser.history</code> API to interact with the browser's record of visited pages. You can add, remove, and query for URLs in the browser's history. To override the history page with your own version, see $(topic:override)[Override Pages].", 
+    "description": "Use the <code>browser.history</code> API to interact with the browser's record of visited pages. You can add, remove, and query for URLs in the browser's history. To override the history page with your own version, see $(topic:override)[Override Pages].",
     "events": [
       {
-        "description": "Fired when a URL is visited, providing the HistoryItem data for that URL.  This event fires before the page has loaded.", 
-        "name": "onVisited", 
+        "description": "Fired when a URL is visited, providing the HistoryItem data for that URL.  This event fires before the page has loaded.",
+        "name": "onVisited",
         "parameters": [
           {
-            "$ref": "HistoryItem", 
+            "$ref": "HistoryItem",
             "name": "result"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Fired when one or more URLs are removed from the history service.  When all visits have been removed the URL is purged from history.", 
-        "name": "onVisitRemoved", 
+        "description": "Fired when one or more URLs are removed from the history service.  When all visits have been removed the URL is purged from history.",
+        "name": "onVisitRemoved",
         "parameters": [
           {
-            "name": "removed", 
+            "name": "removed",
             "properties": {
               "allHistory": {
-                "description": "True if all history was removed.  If true, then urls will be empty.", 
+                "description": "True if all history was removed.  If true, then urls will be empty.",
                 "type": "boolean"
-              }, 
+              },
               "urls": {
                 "items": {
                   "type": "string"
-                }, 
+                },
                 "type": "array"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Fired when the title of a URL is changed in the browser history.", 
-        "name": "onTitleChanged", 
+        "description": "Fired when the title of a URL is changed in the browser history.",
+        "name": "onTitleChanged",
         "parameters": [
           {
-            "name": "changed", 
+            "name": "changed",
             "properties": {
               "title": {
-                "description": "The new title for the URL.", 
+                "description": "The new title for the URL.",
                 "type": "string"
-              }, 
+              },
               "url": {
-                "description": "The URL for which the title has changed", 
+                "description": "The URL for which the title has changed",
                 "type": "string"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "type": "function"
       }
-    ], 
+    ],
     "functions": [
       {
-        "async": "callback", 
-        "description": "Searches the history for the last visit time of each page matching the query.", 
-        "name": "search", 
+        "async": "callback",
+        "description": "Searches the history for the last visit time of each page matching the query.",
+        "name": "search",
         "parameters": [
           {
-            "name": "query", 
+            "name": "query",
             "properties": {
               "endTime": {
-                "$ref": "extensionTypes.Date", 
-                "description": "Limit results to those visited before this date.", 
+                "$ref": "extensionTypes.Date",
+                "description": "Limit results to those visited before this date.",
                 "optional": true
-              }, 
+              },
               "maxResults": {
-                "description": "The maximum number of results to retrieve.  Defaults to 100.", 
-                "minimum": 1, 
-                "optional": true, 
+                "description": "The maximum number of results to retrieve.  Defaults to 100.",
+                "minimum": 1,
+                "optional": true,
                 "type": "integer"
-              }, 
+              },
               "startTime": {
-                "$ref": "extensionTypes.Date", 
-                "description": "Limit results to those visited after this date. If not specified, this defaults to 24 hours in the past.", 
+                "$ref": "extensionTypes.Date",
+                "description": "Limit results to those visited after this date. If not specified, this defaults to 24 hours in the past.",
                 "optional": true
-              }, 
+              },
               "text": {
-                "description": "A free-text query to the history service.  Leave empty to retrieve all pages.", 
+                "description": "A free-text query to the history service.  Leave empty to retrieve all pages.",
                 "type": "string"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
                 "items": {
                   "$ref": "HistoryItem"
-                }, 
-                "name": "results", 
+                },
+                "name": "results",
                 "type": "array"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Retrieves information about visits to a URL.", 
-        "name": "getVisits", 
+        "async": "callback",
+        "description": "Retrieves information about visits to a URL.",
+        "name": "getVisits",
         "parameters": [
           {
-            "name": "details", 
+            "name": "details",
             "properties": {
               "url": {
-                "description": "The URL for which to retrieve visit information.  It must be in the format as returned from a call to history.search.", 
+                "description": "The URL for which to retrieve visit information.  It must be in the format as returned from a call to history.search.",
                 "type": "string"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
                 "items": {
                   "$ref": "VisitItem"
-                }, 
-                "name": "results", 
+                },
+                "name": "results",
                 "type": "array"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Adds a URL to the history with a default visitTime of the current time and a default $(topic:transition-types)[transition type] of \"link\".", 
-        "name": "addUrl", 
+        "async": "callback",
+        "description": "Adds a URL to the history with a default visitTime of the current time and a default $(topic:transition-types)[transition type] of \"link\".",
+        "name": "addUrl",
         "parameters": [
           {
-            "name": "details", 
+            "name": "details",
             "properties": {
               "title": {
-                "description": "The title of the page.", 
-                "optional": true, 
+                "description": "The title of the page.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "transition": {
-                "$ref": "TransitionType", 
-                "description": "The $(topic:transition-types)[transition type] for this visit from its referrer.", 
+                "$ref": "TransitionType",
+                "description": "The $(topic:transition-types)[transition type] for this visit from its referrer.",
                 "optional": true
-              }, 
+              },
               "url": {
-                "description": "The URL to add. Must be a valid URL that can be added to history.", 
+                "description": "The URL to add. Must be a valid URL that can be added to history.",
                 "type": "string"
-              }, 
+              },
               "visitTime": {
-                "$ref": "extensionTypes.Date", 
-                "description": "The date when this visit occurred.", 
+                "$ref": "extensionTypes.Date",
+                "description": "The date when this visit occurred.",
                 "optional": true
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Removes all occurrences of the given URL from the history.", 
-        "name": "deleteUrl", 
+        "async": "callback",
+        "description": "Removes all occurrences of the given URL from the history.",
+        "name": "deleteUrl",
         "parameters": [
           {
-            "name": "details", 
+            "name": "details",
             "properties": {
               "url": {
-                "description": "The URL to remove.", 
+                "description": "The URL to remove.",
                 "type": "string"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Removes all items within the specified date range from the history.  Pages will not be removed from the history unless all visits fall within the range.", 
-        "name": "deleteRange", 
+        "async": "callback",
+        "description": "Removes all items within the specified date range from the history.  Pages will not be removed from the history unless all visits fall within the range.",
+        "name": "deleteRange",
         "parameters": [
           {
-            "name": "range", 
+            "name": "range",
             "properties": {
               "endTime": {
-                "$ref": "extensionTypes.Date", 
+                "$ref": "extensionTypes.Date",
                 "description": "Items added to history before this date."
-              }, 
+              },
               "startTime": {
-                "$ref": "extensionTypes.Date", 
+                "$ref": "extensionTypes.Date",
                 "description": "Items added to history after this date."
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "name": "callback", 
-            "parameters": [], 
+            "name": "callback",
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Deletes all items from the history.", 
-        "name": "deleteAll", 
+        "async": "callback",
+        "description": "Deletes all items from the history.",
+        "name": "deleteAll",
         "parameters": [
           {
-            "name": "callback", 
-            "parameters": [], 
+            "name": "callback",
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
       }
-    ], 
-    "namespace": "history", 
+    ],
+    "namespace": "history",
     "permissions": [
       "history"
-    ], 
+    ],
     "types": [
       {
-        "description": "The $(topic:transition-types)[transition type] for this visit from its referrer.", 
+        "description": "The $(topic:transition-types)[transition type] for this visit from its referrer.",
         "enum": [
-          "link", 
-          "typed", 
-          "auto_bookmark", 
-          "auto_subframe", 
-          "manual_subframe", 
-          "generated", 
-          "auto_toplevel", 
-          "form_submit", 
-          "reload", 
-          "keyword", 
+          "link",
+          "typed",
+          "auto_bookmark",
+          "auto_subframe",
+          "manual_subframe",
+          "generated",
+          "auto_toplevel",
+          "form_submit",
+          "reload",
+          "keyword",
           "keyword_generated"
-        ], 
-        "id": "TransitionType", 
+        ],
+        "id": "TransitionType",
         "type": "string"
-      }, 
+      },
       {
-        "description": "An object encapsulating one result of a history query.", 
-        "id": "HistoryItem", 
+        "description": "An object encapsulating one result of a history query.",
+        "id": "HistoryItem",
         "properties": {
           "id": {
-            "description": "The unique identifier for the item.", 
+            "description": "The unique identifier for the item.",
             "type": "string"
-          }, 
+          },
           "lastVisitTime": {
-            "description": "When this page was last loaded, represented in milliseconds since the epoch.", 
-            "optional": true, 
+            "description": "When this page was last loaded, represented in milliseconds since the epoch.",
+            "optional": true,
             "type": "number"
-          }, 
+          },
           "title": {
-            "description": "The title of the page when it was last loaded.", 
-            "optional": true, 
+            "description": "The title of the page when it was last loaded.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "typedCount": {
-            "description": "The number of times the user has navigated to this page by typing in the address.", 
-            "optional": true, 
+            "description": "The number of times the user has navigated to this page by typing in the address.",
+            "optional": true,
             "type": "integer"
-          }, 
+          },
           "url": {
-            "description": "The URL navigated to by a user.", 
-            "optional": true, 
+            "description": "The URL navigated to by a user.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "visitCount": {
-            "description": "The number of times the user has navigated to this page.", 
-            "optional": true, 
+            "description": "The number of times the user has navigated to this page.",
+            "optional": true,
             "type": "integer"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       {
-        "description": "An object encapsulating one visit to a URL.", 
-        "id": "VisitItem", 
+        "description": "An object encapsulating one visit to a URL.",
+        "id": "VisitItem",
         "properties": {
           "id": {
-            "description": "The unique identifier for the item.", 
+            "description": "The unique identifier for the item.",
             "type": "string"
-          }, 
+          },
           "referringVisitId": {
-            "description": "The visit ID of the referrer.", 
+            "description": "The visit ID of the referrer.",
             "type": "string"
-          }, 
+          },
           "transition": {
-            "$ref": "TransitionType", 
+            "$ref": "TransitionType",
             "description": "The $(topic:transition-types)[transition type] for this visit from its referrer."
-          }, 
+          },
           "visitId": {
-            "description": "The unique identifier for this visit.", 
+            "description": "The unique identifier for this visit.",
             "type": "string"
-          }, 
+          },
           "visitTime": {
-            "description": "When this visit occurred, represented in milliseconds since the epoch.", 
-            "optional": true, 
+            "description": "When this visit occurred, represented in milliseconds since the epoch.",
+            "optional": true,
             "type": "number"
           }
-        }, 
+        },
         "type": "object"
       }
     ]
-  }, 
+  },
   {
     "allowedContexts": [
-      "content", 
+      "content",
       "devtools"
-    ], 
+    ],
     "defaultContexts": [
-      "content", 
+      "content",
       "devtools"
-    ], 
-    "description": "Use the <code>browser.i18n</code> infrastructure to implement internationalization across your whole app or extension.", 
-    "events": [], 
+    ],
+    "description": "Use the <code>browser.i18n</code> infrastructure to implement internationalization across your whole app or extension.",
+    "events": [],
     "functions": [
       {
-        "async": "callback", 
-        "description": "Gets the accept-languages of the browser. This is different from the locale used by the browser; to get the locale, use $(ref:i18n.getUILanguage).", 
-        "name": "getAcceptLanguages", 
+        "async": "callback",
+        "description": "Gets the accept-languages of the browser. This is different from the locale used by the browser; to get the locale, use $(ref:i18n.getUILanguage).",
+        "name": "getAcceptLanguages",
         "parameters": [
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
-                "description": "Array of LanguageCode", 
+                "description": "Array of LanguageCode",
                 "items": {
                   "$ref": "LanguageCode"
-                }, 
-                "name": "languages", 
+                },
+                "name": "languages",
                 "type": "array"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Gets the localized string for the specified message. If the message is missing, this method returns an empty string (''). If the format of the <code>getMessage()</code> call is wrong &mdash; for example, <em>messageName</em> is not a string or the <em>substitutions</em> array has more than 9 elements &mdash; this method returns <code>undefined</code>.", 
-        "name": "getMessage", 
+        "description": "Gets the localized string for the specified message. If the message is missing, this method returns an empty string (''). If the format of the <code>getMessage()</code> call is wrong &mdash; for example, <em>messageName</em> is not a string or the <em>substitutions</em> array has more than 9 elements &mdash; this method returns <code>undefined</code>.",
+        "name": "getMessage",
         "parameters": [
           {
-            "description": "The name of the message, as specified in the <code>$(topic:i18n-messages)[messages.json]</code> file.", 
-            "name": "messageName", 
+            "description": "The name of the message, as specified in the <code>$(topic:i18n-messages)[messages.json]</code> file.",
+            "name": "messageName",
             "type": "string"
-          }, 
+          },
           {
-            "description": "Substitution strings, if the message requires any.", 
-            "name": "substitutions", 
-            "optional": true, 
+            "description": "Substitution strings, if the message requires any.",
+            "name": "substitutions",
+            "optional": true,
             "type": "any"
           }
-        ], 
+        ],
         "returns": {
-          "description": "Message localized for current locale.", 
+          "description": "Message localized for current locale.",
           "type": "string"
-        }, 
+        },
         "type": "function"
-      }, 
+      },
       {
-        "description": "Gets the browser UI language of the browser. This is different from $(ref:i18n.getAcceptLanguages) which returns the preferred user languages.", 
-        "name": "getUILanguage", 
-        "parameters": [], 
+        "description": "Gets the browser UI language of the browser. This is different from $(ref:i18n.getAcceptLanguages) which returns the preferred user languages.",
+        "name": "getUILanguage",
+        "parameters": [],
         "returns": {
-          "description": "The browser UI language code such as en-US or fr-FR.", 
+          "description": "The browser UI language code such as en-US or fr-FR.",
           "type": "string"
-        }, 
+        },
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Detects the language of the provided text using CLD.", 
-        "name": "detectLanguage", 
+        "async": "callback",
+        "description": "Detects the language of the provided text using CLD.",
+        "name": "detectLanguage",
         "parameters": [
           {
-            "description": "User input string to be translated.", 
-            "name": "text", 
+            "description": "User input string to be translated.",
+            "name": "text",
             "type": "string"
-          }, 
+          },
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
-                "description": "LanguageDetectionResult object that holds detected langugae reliability and array of DetectedLanguage", 
-                "name": "result", 
+                "description": "LanguageDetectionResult object that holds detected langugae reliability and array of DetectedLanguage",
+                "name": "result",
                 "properties": {
                   "isReliable": {
-                    "description": "CLD detected language reliability", 
+                    "description": "CLD detected language reliability",
                     "type": "boolean"
-                  }, 
+                  },
                   "languages": {
-                    "description": "array of detectedLanguage", 
+                    "description": "array of detectedLanguage",
                     "items": {
-                      "description": "DetectedLanguage object that holds detected ISO language code and its percentage in the input string", 
+                      "description": "DetectedLanguage object that holds detected ISO language code and its percentage in the input string",
                       "properties": {
                         "language": {
                           "$ref": "LanguageCode"
-                        }, 
+                        },
                         "percentage": {
-                          "description": "The percentage of the detected language", 
+                          "description": "The percentage of the detected language",
                           "type": "integer"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "type": "array"
                   }
-                }, 
+                },
                 "type": "object"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
       }
-    ], 
-    "namespace": "i18n", 
+    ],
+    "namespace": "i18n",
     "types": [
       {
-        "description": "An ISO language code such as <code>en</code> or <code>fr</code>. For a complete list of languages supported by this method, see <a href='http://src.chromium.org/viewvc/chrome/trunk/src/third_party/cld/languages/internal/languages.cc'>kLanguageInfoTable</a>. For an unknown language, <code>und</code> will be returned, which means that [percentage] of the text is unknown to CLD", 
-        "id": "LanguageCode", 
+        "description": "An ISO language code such as <code>en</code> or <code>fr</code>. For a complete list of languages supported by this method, see <a href='http://src.chromium.org/viewvc/chrome/trunk/src/third_party/cld/languages/internal/languages.cc'>kLanguageInfoTable</a>. For an unknown language, <code>und</code> will be returned, which means that [percentage] of the text is unknown to CLD",
+        "id": "LanguageCode",
         "type": "string"
       }
     ]
-  }, 
+  },
   {
-    "description": "Use the chrome.identity API to get OAuth2 access tokens. ", 
+    "description": "Use the chrome.identity API to get OAuth2 access tokens. ",
     "events": [
       {
-        "description": "Fired when signin state changes for an account on the user's profile.", 
-        "name": "onSignInChanged", 
+        "description": "Fired when signin state changes for an account on the user's profile.",
+        "name": "onSignInChanged",
         "parameters": [
           {
-            "$ref": "AccountInfo", 
+            "$ref": "AccountInfo",
             "name": "account"
-          }, 
+          },
           {
-            "name": "signedIn", 
+            "name": "signedIn",
             "type": "boolean"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
       }
-    ], 
+    ],
     "functions": [
       {
-        "async": "callback", 
-        "description": "Retrieves a list of AccountInfo objects describing the accounts present on the profile.", 
-        "name": "getAccounts", 
+        "async": "callback",
+        "description": "Retrieves a list of AccountInfo objects describing the accounts present on the profile.",
+        "name": "getAccounts",
         "parameters": [
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
                 "items": {
                   "$ref": "AccountInfo"
-                }, 
-                "name": "results", 
+                },
+                "name": "results",
                 "type": "array"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Gets an OAuth2 access token using the client ID and scopes specified in the oauth2 section of manifest.json.", 
-        "name": "getAuthToken", 
+        "async": "callback",
+        "description": "Gets an OAuth2 access token using the client ID and scopes specified in the oauth2 section of manifest.json.",
+        "name": "getAuthToken",
         "parameters": [
           {
-            "name": "details", 
-            "optional": true, 
+            "name": "details",
+            "optional": true,
             "properties": {
               "account": {
-                "$ref": "AccountInfo", 
+                "$ref": "AccountInfo",
                 "optional": true
-              }, 
+              },
               "interactive": {
-                "optional": true, 
+                "optional": true,
                 "type": "boolean"
-              }, 
+              },
               "scopes": {
                 "items": {
                   "type": "string"
-                }, 
-                "optional": true, 
+                },
+                "optional": true,
                 "type": "array"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
+            "name": "callback",
+            "optional": true,
             "parameters": [
               {
                 "items": {
                   "$ref": "AccountInfo"
-                }, 
-                "name": "results", 
+                },
+                "name": "results",
                 "type": "array"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Retrieves email address and obfuscated gaia id of the user signed into a profile.", 
-        "name": "getProfileUserInfo", 
+        "async": "callback",
+        "description": "Retrieves email address and obfuscated gaia id of the user signed into a profile.",
+        "name": "getProfileUserInfo",
         "parameters": [
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
-                "name": "userinfo", 
+                "name": "userinfo",
                 "properties": {
                   "email": {
                     "type": "string"
-                  }, 
+                  },
                   "id": {
                     "type": "string"
                   }
-                }, 
+                },
                 "type": "object"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Removes an OAuth2 access token from the Identity API's token cache.", 
-        "name": "removeCachedAuthToken", 
+        "async": "callback",
+        "description": "Removes an OAuth2 access token from the Identity API's token cache.",
+        "name": "removeCachedAuthToken",
         "parameters": [
           {
-            "name": "details", 
+            "name": "details",
             "properties": {
               "token": {
                 "type": "string"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
+            "name": "callback",
+            "optional": true,
             "parameters": [
               {
-                "name": "userinfo", 
+                "name": "userinfo",
                 "properties": {
                   "email": {
                     "type": "string"
-                  }, 
+                  },
                   "id": {
                     "type": "string"
                   }
-                }, 
+                },
                 "type": "object"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Starts an auth flow at the specified URL.", 
-        "name": "launchWebAuthFlow", 
+        "async": "callback",
+        "description": "Starts an auth flow at the specified URL.",
+        "name": "launchWebAuthFlow",
         "parameters": [
           {
-            "name": "details", 
+            "name": "details",
             "properties": {
               "interactive": {
-                "optional": true, 
+                "optional": true,
                 "type": "boolean"
-              }, 
+              },
               "url": {
                 "$ref": "manifest.HttpURL"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
-                "name": " responseUrl", 
-                "optional": true, 
+                "name": " responseUrl",
+                "optional": true,
                 "type": "string"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Generates a redirect URL to be used in |launchWebAuthFlow|.", 
-        "name": "getRedirectURL", 
+        "description": "Generates a redirect URL to be used in |launchWebAuthFlow|.",
+        "name": "getRedirectURL",
         "parameters": [
           {
-            "default": "", 
-            "description": "The path appended to the end of the generated URL. ", 
-            "name": "path", 
-            "optional": true, 
+            "default": "",
+            "description": "The path appended to the end of the generated URL. ",
+            "name": "path",
+            "optional": true,
             "type": "string"
           }
-        ], 
+        ],
         "returns": {
           "type": "string"
-        }, 
+        },
         "type": "function"
       }
-    ], 
-    "namespace": "identity", 
+    ],
+    "namespace": "identity",
     "permissions": [
       "identity"
-    ], 
+    ],
     "types": [
       {
-        "description": "An object encapsulating an OAuth account id.", 
-        "id": "AccountInfo", 
+        "description": "An object encapsulating an OAuth account id.",
+        "id": "AccountInfo",
         "properties": {
           "id": {
-            "description": "A unique identifier for the account. This ID will not change for the lifetime of the account. ", 
+            "description": "A unique identifier for the account. This ID will not change for the lifetime of the account. ",
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
       }
     ]
-  }, 
+  },
   {
-    "description": "Use the <code>browser.idle</code> API to detect when the machine's idle state changes.", 
+    "description": "Use the <code>browser.idle</code> API to detect when the machine's idle state changes.",
     "events": [
       {
-        "description": "Fired when the system changes to an active or idle state. The event fires with \"idle\" if the the user has not generated any input for a specified number of seconds, and \"active\" when the user generates input on an idle system.", 
-        "name": "onStateChanged", 
+        "description": "Fired when the system changes to an active or idle state. The event fires with \"idle\" if the the user has not generated any input for a specified number of seconds, and \"active\" when the user generates input on an idle system.",
+        "name": "onStateChanged",
         "parameters": [
           {
-            "$ref": "IdleState", 
+            "$ref": "IdleState",
             "name": "newState"
           }
-        ], 
+        ],
         "type": "function"
       }
-    ], 
+    ],
     "functions": [
       {
-        "async": "callback", 
-        "description": "Returns \"idle\" if the user has not generated any input for a specified number of seconds, or \"active\" otherwise.", 
-        "name": "queryState", 
+        "async": "callback",
+        "description": "Returns \"idle\" if the user has not generated any input for a specified number of seconds, or \"active\" otherwise.",
+        "name": "queryState",
         "parameters": [
           {
-            "description": "The system is considered idle if detectionIntervalInSeconds seconds have elapsed since the last user input detected.", 
-            "minimum": 15, 
-            "name": "detectionIntervalInSeconds", 
+            "description": "The system is considered idle if detectionIntervalInSeconds seconds have elapsed since the last user input detected.",
+            "minimum": 15,
+            "name": "detectionIntervalInSeconds",
             "type": "integer"
-          }, 
+          },
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
-                "$ref": "IdleState", 
+                "$ref": "IdleState",
                 "name": "newState"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Sets the interval, in seconds, used to determine when the system is in an idle state for onStateChanged events. The default interval is 60 seconds.", 
-        "name": "setDetectionInterval", 
+        "description": "Sets the interval, in seconds, used to determine when the system is in an idle state for onStateChanged events. The default interval is 60 seconds.",
+        "name": "setDetectionInterval",
         "parameters": [
           {
-            "description": "Threshold, in seconds, used to determine when the system is in an idle state.", 
-            "minimum": 15, 
-            "name": "intervalInSeconds", 
+            "description": "Threshold, in seconds, used to determine when the system is in an idle state.",
+            "minimum": 15,
+            "name": "intervalInSeconds",
             "type": "integer"
           }
-        ], 
+        ],
         "type": "function"
       }
-    ], 
-    "namespace": "idle", 
+    ],
+    "namespace": "idle",
     "permissions": [
       "idle"
-    ], 
+    ],
     "types": [
       {
         "enum": [
-          "active", 
+          "active",
           "idle"
-        ], 
-        "id": "IdleState", 
+        ],
+        "id": "IdleState",
         "type": "string"
       }
     ]
-  }, 
+  },
   {
-    "description": "The <code>browser.management</code> API provides ways to manage the list of extensions that are installed and running.", 
+    "description": "The <code>browser.management</code> API provides ways to manage the list of extensions that are installed and running.",
     "events": [
       {
-        "description": "Fired when an addon has been disabled.", 
-        "name": "onDisabled", 
+        "description": "Fired when an addon has been disabled.",
+        "name": "onDisabled",
         "parameters": [
           {
-            "$ref": "ExtensionInfo", 
+            "$ref": "ExtensionInfo",
             "name": "info"
           }
-        ], 
+        ],
         "permissions": [
           "management"
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Fired when an addon has been enabled.", 
-        "name": "onEnabled", 
+        "description": "Fired when an addon has been enabled.",
+        "name": "onEnabled",
         "parameters": [
           {
-            "$ref": "ExtensionInfo", 
+            "$ref": "ExtensionInfo",
             "name": "info"
           }
-        ], 
+        ],
         "permissions": [
           "management"
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Fired when an addon has been installed.", 
-        "name": "onInstalled", 
+        "description": "Fired when an addon has been installed.",
+        "name": "onInstalled",
         "parameters": [
           {
-            "$ref": "ExtensionInfo", 
+            "$ref": "ExtensionInfo",
             "name": "info"
           }
-        ], 
+        ],
         "permissions": [
           "management"
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Fired when an addon has been uninstalled.", 
-        "name": "onUninstalled", 
+        "description": "Fired when an addon has been uninstalled.",
+        "name": "onUninstalled",
         "parameters": [
           {
-            "$ref": "ExtensionInfo", 
+            "$ref": "ExtensionInfo",
             "name": "info"
           }
-        ], 
+        ],
         "permissions": [
           "management"
-        ], 
+        ],
         "type": "function"
       }
-    ], 
+    ],
     "functions": [
       {
-        "async": "callback", 
-        "description": "Returns a list of information about installed extensions.", 
-        "name": "getAll", 
+        "async": "callback",
+        "description": "Returns a list of information about installed extensions.",
+        "name": "getAll",
         "parameters": [
           {
-            "name": "callback", 
-            "optional": true, 
+            "name": "callback",
+            "optional": true,
             "parameters": [
               {
                 "items": {
                   "$ref": "ExtensionInfo"
-                }, 
-                "name": "result", 
+                },
+                "name": "result",
                 "type": "array"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "permissions": [
           "management"
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Returns information about the installed extension that has the given ID.", 
-        "name": "get", 
+        "async": "callback",
+        "description": "Returns information about the installed extension that has the given ID.",
+        "name": "get",
         "parameters": [
           {
-            "$ref": "manifest.ExtensionID", 
-            "description": "The ID from an item of $(ref:management.ExtensionInfo).", 
+            "$ref": "manifest.ExtensionID",
+            "description": "The ID from an item of $(ref:management.ExtensionInfo).",
             "name": "id"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
+            "name": "callback",
+            "optional": true,
             "parameters": [
               {
-                "$ref": "ExtensionInfo", 
+                "$ref": "ExtensionInfo",
                 "name": "result"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "permissions": [
           "management"
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Returns information about the calling extension. Note: This function can be used without requesting the 'management' permission in the manifest.", 
-        "name": "getSelf", 
+        "async": "callback",
+        "description": "Installs and enables a theme extension from the given url.",
+        "name": "install",
         "parameters": [
           {
-            "name": "callback", 
-            "optional": true, 
+            "name": "options",
+            "properties": {
+              "hash": {
+                "description": "A hash of the XPI file, using sha256 or stronger.",
+                "optional": true,
+                "pattern": "^(sha256|sha512):[0-9a-fA-F]{64,128}$",
+                "type": "string"
+              },
+              "url": {
+                "$ref": "manifest.HttpURL",
+                "description": "URL pointing to the XPI file on addons.mozilla.org or similar."
+              }
+            },
+            "type": "object"
+          },
+          {
+            "name": "callback",
+            "optional": true,
             "parameters": [
               {
-                "$ref": "ExtensionInfo", 
-                "name": "result"
+                "name": "result",
+                "properties": {
+                  "id": {
+                    "$ref": "manifest.ExtensionID"
+                  }
+                },
+                "type": "object"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
+        "permissions": [
+          "management"
+        ],
+        "requireUserInput": true,
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Uninstalls the calling extension. Note: This function can be used without requesting the 'management' permission in the manifest.", 
-        "name": "uninstallSelf", 
+        "async": "callback",
+        "description": "Returns information about the calling extension. Note: This function can be used without requesting the 'management' permission in the manifest.",
+        "name": "getSelf",
         "parameters": [
           {
-            "name": "options", 
-            "optional": true, 
+            "name": "callback",
+            "optional": true,
+            "parameters": [
+              {
+                "$ref": "ExtensionInfo",
+                "name": "result"
+              }
+            ],
+            "type": "function"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": "callback",
+        "description": "Uninstalls the calling extension. Note: This function can be used without requesting the 'management' permission in the manifest.",
+        "name": "uninstallSelf",
+        "parameters": [
+          {
+            "name": "options",
+            "optional": true,
             "properties": {
               "dialogMessage": {
-                "description": "The message to display to a user when being asked to confirm removal of the extension.", 
-                "optional": true, 
+                "description": "The message to display to a user when being asked to confirm removal of the extension.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "showConfirmDialog": {
-                "description": "Whether or not a confirm-uninstall dialog should prompt the user. Defaults to false.", 
-                "optional": true, 
+                "description": "Whether or not a confirm-uninstall dialog should prompt the user. Defaults to false.",
+                "optional": true,
                 "type": "boolean"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Enables or disables the given add-on.", 
-        "name": "setEnabled", 
+        "async": "callback",
+        "description": "Enables or disables the given add-on.",
+        "name": "setEnabled",
         "parameters": [
           {
-            "description": "ID of the add-on to enable/disable.", 
-            "name": "id", 
+            "description": "ID of the add-on to enable/disable.",
+            "name": "id",
             "type": "string"
-          }, 
+          },
           {
-            "description": "Whether to enable or disable the add-on.", 
-            "name": "enabled", 
+            "description": "Whether to enable or disable the add-on.",
+            "name": "enabled",
             "type": "boolean"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
         "permissions": [
           "management"
-        ], 
+        ],
         "type": "function"
       }
-    ], 
-    "namespace": "management", 
+    ],
+    "namespace": "management",
     "types": [
       {
-        "description": "Information about an icon belonging to an extension.", 
-        "id": "IconInfo", 
+        "description": "Information about an icon belonging to an extension.",
+        "id": "IconInfo",
         "properties": {
           "size": {
-            "description": "A number representing the width and height of the icon. Likely values include (but are not limited to) 128, 48, 24, and 16.", 
+            "description": "A number representing the width and height of the icon. Likely values include (but are not limited to) 128, 48, 24, and 16.",
             "type": "integer"
-          }, 
+          },
           "url": {
-            "description": "The URL for this icon image. To display a grayscale version of the icon (to indicate that an extension is disabled, for example), append <code>?grayscale=true</code> to the URL.", 
+            "description": "The URL for this icon image. To display a grayscale version of the icon (to indicate that an extension is disabled, for example), append <code>?grayscale=true</code> to the URL.",
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       {
-        "description": "A reason the item is disabled.", 
+        "description": "A reason the item is disabled.",
         "enum": [
-          "unknown", 
+          "unknown",
           "permissions_increase"
-        ], 
-        "id": "ExtensionDisabledReason", 
+        ],
+        "id": "ExtensionDisabledReason",
         "type": "string"
-      }, 
+      },
       {
-        "description": "The type of this extension. Will always be 'extension'.", 
+        "description": "The type of this extension, 'extension' or 'theme'.",
         "enum": [
-          "extension", 
+          "extension",
           "theme"
-        ], 
-        "id": "ExtensionType", 
+        ],
+        "id": "ExtensionType",
         "type": "string"
-      }, 
+      },
       {
-        "description": "How the extension was installed. One of<br><var>development</var>: The extension was loaded unpacked in developer mode,<br><var>normal</var>: The extension was installed normally via an .xpi file,<br><var>sideload</var>: The extension was installed by other software on the machine,<br><var>other</var>: The extension was installed by other means.", 
+        "description": "How the extension was installed. One of<br><var>development</var>: The extension was loaded unpacked in developer mode,<br><var>normal</var>: The extension was installed normally via an .xpi file,<br><var>sideload</var>: The extension was installed by other software on the machine,<br><var>other</var>: The extension was installed by other means.",
         "enum": [
-          "development", 
-          "normal", 
-          "sideload", 
+          "development",
+          "normal",
+          "sideload",
           "other"
-        ], 
-        "id": "ExtensionInstallType", 
+        ],
+        "id": "ExtensionInstallType",
         "type": "string"
-      }, 
+      },
       {
-        "description": "Information about an installed extension.", 
-        "id": "ExtensionInfo", 
+        "description": "Information about an installed extension.",
+        "id": "ExtensionInfo",
         "properties": {
           "description": {
-            "description": "The description of this extension.", 
+            "description": "The description of this extension.",
             "type": "string"
-          }, 
+          },
           "disabledReason": {
-            "$ref": "ExtensionDisabledReason", 
-            "description": "A reason the item is disabled.", 
+            "$ref": "ExtensionDisabledReason",
+            "description": "A reason the item is disabled.",
             "optional": true
-          }, 
+          },
           "enabled": {
-            "description": "Whether it is currently enabled or disabled.", 
+            "description": "Whether it is currently enabled or disabled.",
             "type": "boolean"
-          }, 
+          },
           "homepageUrl": {
-            "description": "The URL of the homepage of this extension.", 
-            "optional": true, 
+            "description": "The URL of the homepage of this extension.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "hostPermissions": {
-            "description": "Returns a list of host based permissions.", 
+            "description": "Returns a list of host based permissions.",
             "items": {
               "type": "string"
-            }, 
-            "optional": true, 
+            },
+            "optional": true,
             "type": "array"
-          }, 
+          },
           "icons": {
-            "description": "A list of icon information. Note that this just reflects what was declared in the manifest, and the actual image at that url may be larger or smaller than what was declared, so you might consider using explicit width and height attributes on img tags referencing these images. See the <a href='manifest/icons'>manifest documentation on icons</a> for more details.", 
+            "description": "A list of icon information. Note that this just reflects what was declared in the manifest, and the actual image at that url may be larger or smaller than what was declared, so you might consider using explicit width and height attributes on img tags referencing these images. See the <a href='manifest/icons'>manifest documentation on icons</a> for more details.",
             "items": {
               "$ref": "IconInfo"
-            }, 
-            "optional": true, 
+            },
+            "optional": true,
             "type": "array"
-          }, 
+          },
           "id": {
-            "description": "The extension's unique identifier.", 
+            "description": "The extension's unique identifier.",
             "type": "string"
-          }, 
+          },
           "installType": {
-            "$ref": "ExtensionInstallType", 
+            "$ref": "ExtensionInstallType",
             "description": "How the extension was installed."
-          }, 
+          },
           "mayDisable": {
-            "description": "Whether this extension can be disabled or uninstalled by the user.", 
+            "description": "Whether this extension can be disabled or uninstalled by the user.",
             "type": "boolean"
-          }, 
+          },
           "name": {
-            "description": "The name of this extension.", 
+            "description": "The name of this extension.",
             "type": "string"
-          }, 
+          },
           "optionsUrl": {
-            "description": "The url for the item's options page, if it has one.", 
+            "description": "The url for the item's options page, if it has one.",
             "type": "string"
-          }, 
+          },
           "permissions": {
-            "description": "Returns a list of API based permissions.", 
+            "description": "Returns a list of API based permissions.",
             "items": {
               "type": "string"
-            }, 
-            "optional": true, 
+            },
+            "optional": true,
             "type": "array"
-          }, 
+          },
           "shortName": {
-            "description": "A short version of the name of this extension.", 
-            "optional": true, 
+            "description": "A short version of the name of this extension.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "type": {
-            "$ref": "ExtensionType", 
-            "description": "The type of this extension. Will always return 'extension'."
-          }, 
+            "$ref": "ExtensionType",
+            "description": "The type of this extension, 'extension' or 'theme'."
+          },
           "updateUrl": {
-            "description": "The update URL of this extension.", 
-            "optional": true, 
+            "description": "The update URL of this extension.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "version": {
-            "description": "The <a href='manifest/version'>version</a> of this extension.", 
+            "description": "The <a href='manifest/version'>version</a> of this extension.",
             "type": "string"
-          }, 
+          },
           "versionName": {
-            "description": "The <a href='manifest/version#version_name'>version name</a> of this extension if the manifest specified one.", 
-            "optional": true, 
+            "description": "The <a href='manifest/version#version_name'>version name</a> of this extension if the manifest specified one.",
+            "optional": true,
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
       }
     ]
-  }, 
+  },
   {
-    "namespace": "manifest", 
-    "permissions": [], 
+    "namespace": "manifest",
+    "permissions": [],
     "types": [
       {
-        "additionalProperties": {
-          "$ref": "UnrecognizedProperty"
-        }, 
-        "description": "Represents a WebExtension manifest.json file", 
-        "id": "WebExtensionManifest", 
+        "description": "Common properties for all manifest.json files",
+        "id": "ManifestBase",
         "properties": {
           "applications": {
-            "optional": true, 
+            "optional": true,
             "properties": {
               "gecko": {
-                "$ref": "FirefoxSpecificProperties", 
+                "$ref": "FirefoxSpecificProperties",
                 "optional": true
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           "author": {
-            "onError": "warn", 
-            "optional": true, 
-            "preprocess": "localize", 
+            "onError": "warn",
+            "optional": true,
+            "preprocess": "localize",
             "type": "string"
-          }, 
+          },
+          "browser_specific_settings": {
+            "additionalProperties": {
+              "$ref": "UnrecognizedProperty"
+            },
+            "optional": true,
+            "properties": {
+              "edge": {
+                "additionalProperties": {
+                  "type": "any"
+                },
+                "optional": true,
+                "type": "object"
+              },
+              "gecko": {
+                "$ref": "FirefoxSpecificProperties",
+                "optional": true
+              }
+            },
+            "type": "object"
+          },
+          "description": {
+            "optional": true,
+            "preprocess": "localize",
+            "type": "string"
+          },
+          "homepage_url": {
+            "format": "url",
+            "optional": true,
+            "preprocess": "localize",
+            "type": "string"
+          },
+          "manifest_version": {
+            "maximum": 2,
+            "minimum": 2,
+            "type": "integer"
+          },
+          "name": {
+            "optional": false,
+            "preprocess": "localize",
+            "type": "string"
+          },
+          "short_name": {
+            "optional": true,
+            "preprocess": "localize",
+            "type": "string"
+          },
+          "version": {
+            "optional": false,
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      {
+        "$import": "ManifestBase",
+        "additionalProperties": {
+          "$ref": "UnrecognizedProperty"
+        },
+        "description": "Represents a WebExtension manifest.json file",
+        "id": "WebExtensionManifest",
+        "properties": {
           "background": {
             "choices": [
               {
                 "additionalProperties": {
                   "$ref": "UnrecognizedProperty"
-                }, 
+                },
                 "properties": {
                   "page": {
                     "$ref": "ExtensionURL"
-                  }, 
+                  },
                   "persistent": {
-                    "$ref": "PersistentBackgroundProperty", 
+                    "$ref": "PersistentBackgroundProperty",
                     "optional": true
                   }
-                }, 
+                },
                 "type": "object"
-              }, 
+              },
               {
                 "additionalProperties": {
                   "$ref": "UnrecognizedProperty"
-                }, 
+                },
                 "properties": {
                   "persistent": {
-                    "$ref": "PersistentBackgroundProperty", 
+                    "$ref": "PersistentBackgroundProperty",
                     "optional": true
-                  }, 
+                  },
                   "scripts": {
                     "items": {
                       "$ref": "ExtensionURL"
-                    }, 
+                    },
                     "type": "array"
                   }
-                }, 
+                },
                 "type": "object"
               }
-            ], 
+            ],
             "optional": true
-          }, 
-          "browser_specific_settings": {
-            "optional": true, 
-            "properties": {
-              "gecko": {
-                "$ref": "FirefoxSpecificProperties", 
-                "optional": true
-              }
-            }, 
-            "type": "object"
-          }, 
+          },
           "content_scripts": {
             "items": {
               "$ref": "ContentScript"
-            }, 
-            "optional": true, 
+            },
+            "optional": true,
             "type": "array"
-          }, 
+          },
           "content_security_policy": {
-            "format": "contentSecurityPolicy", 
-            "onError": "warn", 
-            "optional": true, 
+            "format": "contentSecurityPolicy",
+            "onError": "warn",
+            "optional": true,
             "type": "string"
-          }, 
-          "description": {
-            "optional": true, 
-            "preprocess": "localize", 
-            "type": "string"
-          }, 
+          },
           "developer": {
-            "optional": true, 
+            "optional": true,
             "properties": {
               "name": {
-                "optional": true, 
-                "preprocess": "localize", 
+                "optional": true,
+                "preprocess": "localize",
                 "type": "string"
-              }, 
+              },
               "url": {
-                "optional": true, 
-                "preprocess": "localize", 
+                "optional": true,
+                "preprocess": "localize",
                 "type": "string"
               }
-            }, 
+            },
             "type": "object"
-          }, 
-          "homepage_url": {
-            "format": "url", 
-            "optional": true, 
-            "preprocess": "localize", 
-            "type": "string"
-          }, 
+          },
+          "hidden": {
+            "default": false,
+            "optional": true,
+            "type": "boolean"
+          },
           "icons": {
-            "optional": true, 
+            "optional": true,
             "patternProperties": {
               "^[1-9]\\d*$": {
-                "type": "string"
+                "$ref": "ExtensionFileUrl"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           "incognito": {
+            "default": "spanning",
             "enum": [
+              "not_allowed",
               "spanning"
-            ], 
-            "onError": "warn", 
-            "optional": true, 
+            ],
+            "optional": true,
             "type": "string"
-          }, 
-          "manifest_version": {
-            "maximum": 2, 
-            "minimum": 2, 
-            "type": "integer"
-          }, 
+          },
           "minimum_chrome_version": {
-            "optional": true, 
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "minimum_opera_version": {
-            "optional": true, 
+            "optional": true,
             "type": "string"
-          }, 
-          "name": {
-            "optional": false, 
-            "preprocess": "localize", 
-            "type": "string"
-          }, 
+          },
           "optional_permissions": {
-            "default": [], 
+            "default": [],
             "items": {
-              "$ref": "OptionalPermissionOrOrigin", 
+              "$ref": "OptionalPermissionOrOrigin",
               "onError": "warn"
-            }, 
-            "optional": true, 
+            },
+            "optional": true,
             "type": "array"
-          }, 
+          },
           "options_ui": {
             "additionalProperties": {
-              "deprecated": "An unexpected property was found in the WebExtension manifest", 
+              "deprecated": "An unexpected property was found in the WebExtension manifest",
               "type": "any"
-            }, 
-            "optional": true, 
+            },
+            "optional": true,
             "properties": {
               "browser_style": {
-                "optional": true, 
+                "default": true,
+                "optional": true,
                 "type": "boolean"
-              }, 
+              },
               "chrome_style": {
-                "optional": true, 
+                "optional": true,
                 "type": "boolean"
-              }, 
+              },
               "open_in_tab": {
-                "optional": true, 
+                "optional": true,
                 "type": "boolean"
-              }, 
+              },
               "page": {
                 "$ref": "ExtensionURL"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           "permissions": {
-            "default": [], 
+            "default": [],
             "items": {
-              "$ref": "PermissionOrOrigin", 
+              "$ref": "PermissionOrOrigin",
               "onError": "warn"
-            }, 
-            "optional": true, 
+            },
+            "optional": true,
             "type": "array"
-          }, 
-          "short_name": {
-            "optional": true, 
-            "preprocess": "localize", 
-            "type": "string"
-          }, 
-          "version": {
-            "optional": false, 
-            "type": "string"
-          }, 
+          },
           "web_accessible_resources": {
             "items": {
               "type": "string"
-            }, 
-            "optional": true, 
+            },
+            "optional": true,
             "type": "array"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       {
-        "description": "Represents a WebExtension language pack manifest.json file", 
-        "id": "WebExtensionLangpackManifest", 
+        "$import": "ManifestBase",
+        "description": "Represents a WebExtension language pack manifest.json file",
+        "id": "WebExtensionLangpackManifest",
         "properties": {
-          "applications": {
-            "optional": true, 
-            "properties": {
-              "gecko": {
-                "$ref": "FirefoxSpecificProperties", 
-                "optional": true
-              }
-            }, 
-            "type": "object"
-          }, 
-          "author": {
-            "onError": "warn", 
-            "optional": true, 
-            "preprocess": "localize", 
-            "type": "string"
-          }, 
-          "browser_specific_settings": {
-            "optional": true, 
-            "properties": {
-              "gecko": {
-                "$ref": "FirefoxSpecificProperties", 
-                "optional": true
-              }
-            }, 
-            "type": "object"
-          }, 
-          "description": {
-            "optional": true, 
-            "preprocess": "localize", 
-            "type": "string"
-          }, 
           "homepage_url": {
-            "format": "url", 
-            "optional": true, 
-            "preprocess": "localize", 
+            "format": "url",
+            "optional": true,
+            "preprocess": "localize",
             "type": "string"
-          }, 
+          },
           "langpack_id": {
-            "pattern": "^[a-zA-Z][a-zA-Z-]+$", 
+            "pattern": "^[a-zA-Z][a-zA-Z-]+$",
             "type": "string"
-          }, 
+          },
           "languages": {
             "patternProperties": {
               "^[a-z]{2}[a-zA-Z-]*$": {
@@ -6189,8266 +6822,10363 @@
                         "choices": [
                           {
                             "$ref": "ExtensionURL"
-                          }, 
+                          },
                           {
                             "patternProperties": {
                               "^[a-z]+$": {
                                 "$ref": "ExtensionURL"
                               }
-                            }, 
+                            },
                             "type": "object"
                           }
                         ]
                       }
-                    }, 
+                    },
                     "type": "object"
-                  }, 
+                  },
                   "version": {
                     "type": "string"
                   }
-                }, 
+                },
                 "type": "object"
               }
-            }, 
+            },
             "type": "object"
-          }, 
-          "manifest_version": {
-            "maximum": 2, 
-            "minimum": 2, 
-            "type": "integer"
-          }, 
-          "name": {
-            "optional": false, 
-            "preprocess": "localize", 
-            "type": "string"
-          }, 
-          "short_name": {
-            "optional": true, 
-            "preprocess": "localize", 
-            "type": "string"
-          }, 
+          },
           "sources": {
-            "optional": true, 
+            "optional": true,
             "patternProperties": {
               "^[a-z]+$": {
                 "properties": {
                   "base_path": {
                     "$ref": "ExtensionURL"
-                  }, 
+                  },
                   "paths": {
                     "items": {
-                      "format": "strictRelativeUrl", 
+                      "format": "strictRelativeUrl",
                       "type": "string"
-                    }, 
-                    "optional": true, 
+                    },
+                    "optional": true,
                     "type": "array"
                   }
-                }, 
+                },
                 "type": "object"
               }
-            }, 
+            },
             "type": "object"
-          }, 
-          "version": {
-            "optional": false, 
+          }
+        },
+        "type": "object"
+      },
+      {
+        "$import": "ManifestBase",
+        "description": "Represents a WebExtension dictionary manifest.json file",
+        "id": "WebExtensionDictionaryManifest",
+        "properties": {
+          "dictionaries": {
+            "patternProperties": {
+              "^[a-z]{2}[a-zA-Z-]*$": {
+                "format": "strictRelativeUrl",
+                "pattern": "\\.dic$",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "homepage_url": {
+            "format": "url",
+            "optional": true,
+            "preprocess": "localize",
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       {
         "additionalProperties": {
           "$ref": "UnrecognizedProperty"
-        }, 
-        "id": "ThemeIcons", 
+        },
+        "id": "ThemeIcons",
         "properties": {
           "dark": {
-            "$ref": "ExtensionURL", 
+            "$ref": "ExtensionURL",
             "description": "The dark icon to use for light themes"
-          }, 
+          },
           "light": {
-            "$ref": "ExtensionURL", 
+            "$ref": "ExtensionURL",
             "description": "A light icon to use for dark themes"
-          }, 
+          },
           "size": {
-            "description": "The size of the icons", 
+            "description": "The size of the icons",
             "type": "integer"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       {
         "choices": [
           {
             "enum": [
-              "clipboardRead", 
-              "clipboardWrite", 
-              "geolocation", 
-              "idle", 
+              "clipboardRead",
+              "clipboardWrite",
+              "geolocation",
+              "idle",
               "notifications"
-            ], 
+            ],
             "type": "string"
           }
-        ], 
+        ],
         "id": "OptionalPermission"
-      }, 
+      },
       {
         "choices": [
           {
             "$ref": "OptionalPermission"
-          }, 
+          },
           {
             "$ref": "MatchPattern"
           }
-        ], 
+        ],
         "id": "OptionalPermissionOrOrigin"
-      }, 
+      },
       {
         "choices": [
           {
             "$ref": "OptionalPermission"
-          }, 
+          },
           {
             "enum": [
-              "alarms", 
-              "mozillaAddons", 
-              "storage", 
+              "alarms",
+              "mozillaAddons",
+              "storage",
               "unlimitedStorage"
-            ], 
+            ],
             "type": "string"
           }
-        ], 
+        ],
         "id": "Permission"
-      }, 
+      },
       {
         "choices": [
           {
             "$ref": "Permission"
-          }, 
+          },
           {
             "$ref": "MatchPattern"
           }
-        ], 
+        ],
         "id": "PermissionOrOrigin"
-      }, 
+      },
       {
-        "format": "url", 
-        "id": "HttpURL", 
-        "pattern": "^https?://.*$", 
+        "format": "url",
+        "id": "HttpURL",
+        "pattern": "^https?://.*$",
         "type": "string"
-      }, 
+      },
       {
-        "format": "strictRelativeUrl", 
-        "id": "ExtensionURL", 
+        "format": "strictRelativeUrl",
+        "id": "ExtensionURL",
         "type": "string"
-      }, 
+      },
       {
-        "format": "imageDataOrStrictRelativeUrl", 
-        "id": "ImageDataOrExtensionURL", 
+        "format": "strictRelativeUrl",
+        "id": "ExtensionFileUrl",
+        "pattern": "\\S",
+        "preprocess": "localize",
         "type": "string"
-      }, 
+      },
+      {
+        "format": "imageDataOrStrictRelativeUrl",
+        "id": "ImageDataOrExtensionURL",
+        "type": "string"
+      },
       {
         "choices": [
           {
-            "pattern": "(?i)^\\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\}$", 
+            "pattern": "(?i)^\\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\}$",
             "type": "string"
-          }, 
+          },
           {
-            "pattern": "(?i)^[a-z0-9-._]*@[a-z0-9-._]+$", 
+            "pattern": "(?i)^[a-z0-9-._]*@[a-z0-9-._]+$",
             "type": "string"
           }
-        ], 
+        ],
         "id": "ExtensionID"
-      }, 
+      },
       {
-        "id": "FirefoxSpecificProperties", 
+        "id": "FirefoxSpecificProperties",
         "properties": {
           "id": {
-            "$ref": "ExtensionID", 
+            "$ref": "ExtensionID",
             "optional": true
-          }, 
+          },
           "strict_max_version": {
-            "optional": true, 
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "strict_min_version": {
-            "optional": true, 
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "update_url": {
-            "format": "url", 
-            "optional": true, 
+            "format": "url",
+            "optional": true,
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       {
         "choices": [
           {
             "enum": [
               "<all_urls>"
-            ], 
+            ],
             "type": "string"
-          }, 
+          },
           {
-            "pattern": "^(https?|wss?|file|ftp|\\*)://(\\*|\\*\\.[^*/]+|[^*/]+)/.*$", 
-            "type": "string"
-          }, 
+            "$ref": "MatchPatternRestricted"
+          },
           {
-            "pattern": "^file:///.*$", 
-            "type": "string"
+            "$ref": "MatchPatternUnestricted"
           }
-        ], 
+        ],
         "id": "MatchPattern"
-      }, 
+      },
       {
         "choices": [
           {
-            "enum": [
-              "<all_urls>"
-            ], 
+            "pattern": "^(https?|wss?|file|ftp|\\*)://(\\*|\\*\\.[^*/]+|[^*/]+)/.*$",
             "type": "string"
-          }, 
+          },
           {
-            "pattern": "^(https?|wss?|file|ftp|moz-extension|\\*)://(\\*|\\*\\.[^*/]+|[^*/]+)/.*$", 
-            "type": "string"
-          }, 
-          {
-            "pattern": "^file:///.*$", 
+            "pattern": "^file:///.*$",
             "type": "string"
           }
-        ], 
-        "description": "Same as MatchPattern above, but includes moz-extension protocol", 
-        "id": "MatchPatternInternal"
-      }, 
+        ],
+        "description": "Same as MatchPattern above, but excludes <all_urls>",
+        "id": "MatchPatternRestricted"
+      },
+      {
+        "choices": [
+          {
+            "pattern": "^resource://(\\*|\\*\\.[^*/]+|[^*/]+)/.*$|^about:",
+            "type": "string"
+          }
+        ],
+        "description": "Mostly unrestricted match patterns for privileged add-ons. This should technically be rejected for unprivileged add-ons, but, reasons. The MatchPattern class will still refuse privileged schemes for those extensions.",
+        "id": "MatchPatternUnestricted"
+      },
       {
         "additionalProperties": {
           "$ref": "UnrecognizedProperty"
-        }, 
-        "description": "Details of the script or CSS to inject. Either the code or the file property must be set, but both may not be set at the same time. Based on InjectDetails, but using underscore rather than camel case naming conventions.", 
-        "id": "ContentScript", 
+        },
+        "description": "Details of the script or CSS to inject. Either the code or the file property must be set, but both may not be set at the same time. Based on InjectDetails, but using underscore rather than camel case naming conventions.",
+        "id": "ContentScript",
         "properties": {
           "all_frames": {
-            "description": "If allFrames is <code>true</code>, implies that the JavaScript or CSS should be injected into all frames of current page. By default, it's <code>false</code> and is only injected into the top frame.", 
-            "optional": true, 
+            "description": "If allFrames is <code>true</code>, implies that the JavaScript or CSS should be injected into all frames of current page. By default, it's <code>false</code> and is only injected into the top frame.",
+            "optional": true,
             "type": "boolean"
-          }, 
+          },
           "css": {
-            "description": "The list of CSS files to inject", 
+            "description": "The list of CSS files to inject",
             "items": {
               "$ref": "ExtensionURL"
-            }, 
-            "optional": true, 
+            },
+            "optional": true,
             "type": "array"
-          }, 
+          },
           "exclude_globs": {
             "items": {
               "type": "string"
-            }, 
-            "optional": true, 
+            },
+            "optional": true,
             "type": "array"
-          }, 
+          },
           "exclude_matches": {
             "items": {
               "$ref": "MatchPattern"
-            }, 
-            "minItems": 1, 
-            "optional": true, 
+            },
+            "minItems": 1,
+            "optional": true,
             "type": "array"
-          }, 
+          },
           "include_globs": {
             "items": {
               "type": "string"
-            }, 
-            "optional": true, 
+            },
+            "optional": true,
             "type": "array"
-          }, 
+          },
           "js": {
-            "description": "The list of CSS files to inject", 
+            "description": "The list of JS files to inject",
             "items": {
               "$ref": "ExtensionURL"
-            }, 
-            "optional": true, 
+            },
+            "optional": true,
             "type": "array"
-          }, 
+          },
           "match_about_blank": {
-            "description": "If matchAboutBlank is true, then the code is also injected in about:blank and about:srcdoc frames if your extension has access to its parent document. Code cannot be inserted in top-level about:-frames. By default it is <code>false</code>.", 
-            "optional": true, 
+            "description": "If matchAboutBlank is true, then the code is also injected in about:blank and about:srcdoc frames if your extension has access to its parent document. Code cannot be inserted in top-level about:-frames. By default it is <code>false</code>.",
+            "optional": true,
             "type": "boolean"
-          }, 
+          },
           "matches": {
             "items": {
               "$ref": "MatchPattern"
-            }, 
-            "minItems": 1, 
-            "optional": false, 
+            },
+            "minItems": 1,
+            "optional": false,
             "type": "array"
-          }, 
+          },
           "run_at": {
-            "$ref": "extensionTypes.RunAt", 
-            "default": "document_idle", 
-            "description": "The soonest that the JavaScript or CSS will be injected into the tab. Defaults to \"document_idle\".", 
+            "$ref": "extensionTypes.RunAt",
+            "default": "document_idle",
+            "description": "The soonest that the JavaScript or CSS will be injected into the tab. Defaults to \"document_idle\".",
             "optional": true
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       {
         "choices": [
           {
-            "additionalProperties": false, 
+            "additionalProperties": false,
             "patternProperties": {
               "^[1-9]\\d*$": {
-                "$ref": "ExtensionURL"
+                "$ref": "ExtensionFileUrl"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "$ref": "ExtensionURL"
+            "$ref": "ExtensionFileUrl"
           }
-        ], 
+        ],
         "id": "IconPath"
-      }, 
+      },
       {
         "choices": [
           {
-            "additionalProperties": false, 
+            "additionalProperties": false,
             "patternProperties": {
               "^[1-9]\\d*$": {
                 "$ref": "ImageData"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
             "$ref": "ImageData"
           }
-        ], 
+        ],
         "id": "IconImageData"
-      }, 
+      },
       {
-        "id": "ImageData", 
-        "isInstanceOf": "ImageData", 
-        "postprocess": "convertImageDataToURL", 
+        "id": "ImageData",
+        "isInstanceOf": "ImageData",
+        "postprocess": "convertImageDataToURL",
         "type": "object"
-      }, 
+      },
       {
-        "deprecated": "An unexpected property was found in the WebExtension manifest.", 
-        "id": "UnrecognizedProperty", 
+        "deprecated": "An unexpected property was found in the WebExtension manifest.",
+        "id": "UnrecognizedProperty",
         "type": "any"
-      }, 
+      },
       {
-        "deprecated": "Event pages are not currently supported. This will run as a persistent background page.", 
-        "id": "PersistentBackgroundProperty", 
-        "type": "boolean"
+        "choices": [
+          {
+            "enum": [
+              true
+            ],
+            "type": "boolean"
+          },
+          {
+            "deprecated": "Event pages are not currently supported. This will run as a persistent background page.",
+            "enum": [
+              false
+            ],
+            "type": "boolean"
+          }
+        ],
+        "id": "PersistentBackgroundProperty"
       }
     ]
-  }, 
+  },
   {
-    "$import": "menus", 
-    "description": "Use the browser.contextMenus API to add items to the browser's context menu. You can choose what types of objects your context menu additions apply to, such as images, hyperlinks, and pages.", 
-    "namespace": "contextMenus", 
+    "$import": "menus",
+    "description": "Use the browser.contextMenus API to add items to the browser's context menu. You can choose what types of objects your context menu additions apply to, such as images, hyperlinks, and pages.",
+    "namespace": "contextMenus",
     "permissions": [
       "contextMenus"
-    ], 
+    ],
     "types": [
       {
-        "description": "The different contexts a menu can appear in. Specifying 'all' is equivalent to the combination of all other contexts except for 'tab' and 'tools_menu'.", 
+        "description": "The different contexts a menu can appear in. Specifying 'all' is equivalent to the combination of all other contexts except for 'tab' and 'tools_menu'.",
         "enum": [
-          "all", 
-          "page", 
-          "frame", 
-          "selection", 
-          "link", 
-          "editable", 
-          "password", 
-          "image", 
-          "video", 
-          "audio", 
-          "launcher", 
-          "browser_action", 
-          "page_action", 
+          "all",
+          "page",
+          "frame",
+          "selection",
+          "link",
+          "editable",
+          "password",
+          "image",
+          "video",
+          "audio",
+          "launcher",
+          "bookmark",
+          "browser_action",
+          "page_action",
           "tab"
-        ], 
-        "id": "ContextType", 
+        ],
+        "id": "ContextType",
         "type": "string"
       }
     ]
-  }, 
+  },
   {
-    "description": "Use the browser.menus API to add items to the browser's menus. You can choose what types of objects your context menu additions apply to, such as images, hyperlinks, and pages.", 
+    "description": "Use the browser.menus API to add items to the browser's menus. You can choose what types of objects your context menu additions apply to, such as images, hyperlinks, and pages.",
     "events": [
       {
-        "description": "Fired when a context menu item is clicked.", 
-        "name": "onClicked", 
+        "description": "Fired when a context menu item is clicked.",
+        "name": "onClicked",
         "parameters": [
           {
-            "$ref": "OnClickData", 
-            "description": "Information about the item clicked and the context where the click happened.", 
+            "$ref": "OnClickData",
+            "description": "Information about the item clicked and the context where the click happened.",
             "name": "info"
-          }, 
+          },
           {
-            "$ref": "tabs.Tab", 
-            "description": "The details of the tab where the click took place. If the click did not take place in a tab, this parameter will be missing.", 
-            "name": "tab", 
+            "$ref": "tabs.Tab",
+            "description": "The details of the tab where the click took place. If the click did not take place in a tab, this parameter will be missing.",
+            "name": "tab",
             "optional": true
           }
-        ], 
+        ],
         "type": "function"
-      }
-    ], 
-    "functions": [
+      },
       {
-        "description": "Creates a new context menu item. Note that if an error occurs during creation, you may not find out until the creation callback fires (the details will be in $(ref:runtime.lastError)).", 
-        "name": "create", 
+        "description": "Fired when a menu is shown. The extension can add, modify or remove menu items and call menus.refresh() to update the menu.",
+        "name": "onShown",
         "parameters": [
           {
-            "name": "createProperties", 
+            "description": "Information about the context of the menu action and the created menu items. For more information about each property, see OnClickData. The following properties are only set if the extension has host permissions for the given context: linkUrl, linkText, srcUrl, pageUrl, frameUrl, selectionText.",
+            "name": "info",
             "properties": {
-              "checked": {
-                "description": "The initial state of a checkbox or radio item: true for selected and false for unselected. Only one radio item can be selected at a time in a given group of radio items.", 
-                "optional": true, 
-                "type": "boolean"
-              }, 
-              "command": {
-                "description": "Specifies a command to issue for the context click.  Currently supports internal commands _execute_page_action, _execute_browser_action and _execute_sidebar_action.", 
-                "optional": true, 
-                "type": "string"
-              }, 
               "contexts": {
-                "description": "List of contexts this menu item will appear in. Defaults to ['page'] if not specified.", 
+                "description": "A list of all contexts that apply to the menu.",
                 "items": {
                   "$ref": "ContextType"
-                }, 
-                "minItems": 1, 
-                "optional": true, 
+                },
                 "type": "array"
-              }, 
+              },
+              "editable": {
+                "type": "boolean"
+              },
+              "frameUrl": {
+                "optional": true,
+                "type": "string"
+              },
+              "linkText": {
+                "optional": true,
+                "type": "string"
+              },
+              "linkUrl": {
+                "optional": true,
+                "type": "string"
+              },
+              "mediaType": {
+                "optional": true,
+                "type": "string"
+              },
+              "menuIds": {
+                "description": "A list of IDs of the menu items that were shown.",
+                "items": {
+                  "choices": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "type": "array"
+              },
+              "pageUrl": {
+                "optional": true,
+                "type": "string"
+              },
+              "selectionText": {
+                "optional": true,
+                "type": "string"
+              },
+              "srcUrl": {
+                "optional": true,
+                "type": "string"
+              },
+              "targetElementId": {
+                "optional": true,
+                "type": "integer"
+              },
+              "viewType": {
+                "$ref": "extension.ViewType",
+                "optional": true
+              }
+            },
+            "type": "object"
+          },
+          {
+            "$ref": "tabs.Tab",
+            "description": "The details of the tab where the menu was opened.",
+            "name": "tab"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "description": "Fired when a menu is hidden. This event is only fired if onShown has fired before.",
+        "name": "onHidden",
+        "parameters": [],
+        "type": "function"
+      }
+    ],
+    "functions": [
+      {
+        "description": "Creates a new context menu item. Note that if an error occurs during creation, you may not find out until the creation callback fires (the details will be in $(ref:runtime.lastError)).",
+        "name": "create",
+        "parameters": [
+          {
+            "name": "createProperties",
+            "properties": {
+              "checked": {
+                "description": "The initial state of a checkbox or radio item: true for selected and false for unselected. Only one radio item can be selected at a time in a given group of radio items.",
+                "optional": true,
+                "type": "boolean"
+              },
+              "command": {
+                "description": "Specifies a command to issue for the context click.  Currently supports internal commands _execute_page_action, _execute_browser_action and _execute_sidebar_action.",
+                "optional": true,
+                "type": "string"
+              },
+              "contexts": {
+                "description": "List of contexts this menu item will appear in. Defaults to ['page'] if not specified.",
+                "items": {
+                  "$ref": "ContextType"
+                },
+                "minItems": 1,
+                "optional": true,
+                "type": "array"
+              },
               "documentUrlPatterns": {
-                "description": "Lets you restrict the item to apply only to documents whose URL matches one of the given patterns. (This applies to frames as well.) For details on the format of a pattern, see $(topic:match_patterns)[Match Patterns].", 
+                "description": "Lets you restrict the item to apply only to documents whose URL matches one of the given patterns. (This applies to frames as well.) For details on the format of a pattern, see $(topic:match_patterns)[Match Patterns].",
                 "items": {
                   "type": "string"
-                }, 
-                "optional": true, 
+                },
+                "optional": true,
                 "type": "array"
-              }, 
+              },
               "enabled": {
-                "description": "Whether this context menu item is enabled or disabled. Defaults to true.", 
-                "optional": true, 
+                "description": "Whether this context menu item is enabled or disabled. Defaults to true.",
+                "optional": true,
                 "type": "boolean"
-              }, 
+              },
               "icons": {
-                "optional": true, 
+                "optional": true,
                 "patternProperties": {
                   "^[1-9]\\d*$": {
                     "type": "string"
                   }
-                }, 
+                },
                 "type": "object"
-              }, 
+              },
               "id": {
-                "description": "The unique ID to assign to this item. Mandatory for event pages. Cannot be the same as another ID for this extension.", 
-                "optional": true, 
+                "description": "The unique ID to assign to this item. Mandatory for event pages. Cannot be the same as another ID for this extension.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "onclick": {
-                "description": "A function that will be called back when the menu item is clicked. Event pages cannot use this; instead, they should register a listener for $(ref:contextMenus.onClicked).", 
-                "optional": true, 
+                "description": "A function that will be called back when the menu item is clicked. Event pages cannot use this; instead, they should register a listener for $(ref:contextMenus.onClicked).",
+                "optional": true,
                 "parameters": [
                   {
-                    "$ref": "contextMenusInternal.OnClickData", 
-                    "description": "Information about the item clicked and the context where the click happened.", 
+                    "$ref": "OnClickData",
+                    "description": "Information about the item clicked and the context where the click happened.",
                     "name": "info"
-                  }, 
+                  },
                   {
-                    "$ref": "tabs.Tab", 
-                    "description": "The details of the tab where the click took place. Note: this parameter only present for extensions.", 
+                    "$ref": "tabs.Tab",
+                    "description": "The details of the tab where the click took place. Note: this parameter only present for extensions.",
                     "name": "tab"
                   }
-                ], 
+                ],
                 "type": "function"
-              }, 
+              },
               "parentId": {
                 "choices": [
                   {
                     "type": "integer"
-                  }, 
+                  },
                   {
                     "type": "string"
                   }
-                ], 
-                "description": "The ID of a parent menu item; this makes the item a child of a previously added item.", 
+                ],
+                "description": "The ID of a parent menu item; this makes the item a child of a previously added item.",
                 "optional": true
-              }, 
+              },
               "targetUrlPatterns": {
-                "description": "Similar to documentUrlPatterns, but lets you filter based on the src attribute of img/audio/video tags and the href of anchor tags.", 
+                "description": "Similar to documentUrlPatterns, but lets you filter based on the src attribute of img/audio/video tags and the href of anchor tags.",
                 "items": {
                   "type": "string"
-                }, 
-                "optional": true, 
+                },
+                "optional": true,
                 "type": "array"
-              }, 
+              },
               "title": {
-                "description": "The text to be displayed in the item; this is <em>required</em> unless <code>type</code> is 'separator'. When the context is 'selection', you can use <code>%s</code> within the string to show the selected text. For example, if this parameter's value is \"Translate '%s' to Pig Latin\" and the user selects the word \"cool\", the context menu item for the selection is \"Translate 'cool' to Pig Latin\".", 
-                "optional": true, 
+                "description": "The text to be displayed in the item; this is <em>required</em> unless <code>type</code> is 'separator'. When the context is 'selection', you can use <code>%s</code> within the string to show the selected text. For example, if this parameter's value is \"Translate '%s' to Pig Latin\" and the user selects the word \"cool\", the context menu item for the selection is \"Translate 'cool' to Pig Latin\".",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "type": {
-                "$ref": "ItemType", 
-                "description": "The type of menu item. Defaults to 'normal' if not specified.", 
+                "$ref": "ItemType",
+                "description": "The type of menu item. Defaults to 'normal' if not specified.",
                 "optional": true
+              },
+              "viewTypes": {
+                "description": "List of view types where the menu item will be shown. Defaults to any view, including those without a viewType.",
+                "items": {
+                  "$ref": "extension.ViewType"
+                },
+                "minItems": 1,
+                "optional": true,
+                "type": "array"
+              },
+              "visible": {
+                "description": "Whether the item is visible in the menu.",
+                "optional": true,
+                "type": "boolean"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "description": "Called when the item has been created in the browser. If there were any problems creating the item, details will be available in $(ref:runtime.lastError).", 
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "description": "Called when the item has been created in the browser. If there were any problems creating the item, details will be available in $(ref:runtime.lastError).",
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
         "returns": {
           "choices": [
             {
               "type": "integer"
-            }, 
+            },
             {
               "type": "string"
             }
-          ], 
+          ],
           "description": "The ID of the newly created item."
-        }, 
+        },
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Updates a previously created context menu item.", 
-        "name": "update", 
+        "async": "callback",
+        "description": "Updates a previously created context menu item.",
+        "name": "update",
         "parameters": [
           {
             "choices": [
               {
                 "type": "integer"
-              }, 
+              },
               {
                 "type": "string"
               }
-            ], 
-            "description": "The ID of the item to update.", 
+            ],
+            "description": "The ID of the item to update.",
             "name": "id"
-          }, 
+          },
           {
-            "description": "The properties to update. Accepts the same values as the create function.", 
-            "name": "updateProperties", 
+            "description": "The properties to update. Accepts the same values as the create function.",
+            "name": "updateProperties",
             "properties": {
               "checked": {
-                "optional": true, 
+                "optional": true,
                 "type": "boolean"
-              }, 
+              },
               "contexts": {
                 "items": {
                   "$ref": "ContextType"
-                }, 
-                "minItems": 1, 
-                "optional": true, 
+                },
+                "minItems": 1,
+                "optional": true,
                 "type": "array"
-              }, 
+              },
               "documentUrlPatterns": {
                 "items": {
                   "type": "string"
-                }, 
-                "optional": true, 
+                },
+                "optional": true,
                 "type": "array"
-              }, 
+              },
               "enabled": {
-                "optional": true, 
+                "optional": true,
                 "type": "boolean"
-              }, 
+              },
+              "icons": {
+                "optional": "omit-key-if-missing",
+                "patternProperties": {
+                  "^[1-9]\\d*$": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
               "onclick": {
-                "optional": "omit-key-if-missing", 
+                "optional": "omit-key-if-missing",
                 "parameters": [
                   {
-                    "$ref": "menusInternal.OnClickData", 
+                    "$ref": "OnClickData",
                     "name": "info"
-                  }, 
+                  },
                   {
-                    "$ref": "tabs.Tab", 
-                    "description": "The details of the tab where the click took place. Note: this parameter only present for extensions.", 
+                    "$ref": "tabs.Tab",
+                    "description": "The details of the tab where the click took place. Note: this parameter only present for extensions.",
                     "name": "tab"
                   }
-                ], 
+                ],
                 "type": "function"
-              }, 
+              },
               "parentId": {
                 "choices": [
                   {
                     "type": "integer"
-                  }, 
+                  },
                   {
                     "type": "string"
                   }
-                ], 
-                "description": "Note: You cannot change an item to be a child of one of its own descendants.", 
+                ],
+                "description": "Note: You cannot change an item to be a child of one of its own descendants.",
                 "optional": true
-              }, 
+              },
               "targetUrlPatterns": {
                 "items": {
                   "type": "string"
-                }, 
-                "optional": true, 
+                },
+                "optional": true,
                 "type": "array"
-              }, 
+              },
               "title": {
-                "optional": true, 
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "type": {
-                "$ref": "ItemType", 
+                "$ref": "ItemType",
                 "optional": true
+              },
+              "viewTypes": {
+                "items": {
+                  "$ref": "extension.ViewType"
+                },
+                "minItems": 1,
+                "optional": true,
+                "type": "array"
+              },
+              "visible": {
+                "description": "Whether the item is visible in the menu.",
+                "optional": true,
+                "type": "boolean"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "description": "Called when the context menu has been updated.", 
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "description": "Called when the context menu has been updated.",
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Removes a context menu item.", 
-        "name": "remove", 
+        "async": "callback",
+        "description": "Removes a context menu item.",
+        "name": "remove",
         "parameters": [
           {
             "choices": [
               {
                 "type": "integer"
-              }, 
+              },
               {
                 "type": "string"
               }
-            ], 
-            "description": "The ID of the context menu item to remove.", 
+            ],
+            "description": "The ID of the context menu item to remove.",
             "name": "menuItemId"
-          }, 
+          },
           {
-            "description": "Called when the context menu has been removed.", 
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "description": "Called when the context menu has been removed.",
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Removes all context menu items added by this extension.", 
-        "name": "removeAll", 
+        "async": "callback",
+        "description": "Removes all context menu items added by this extension.",
+        "name": "removeAll",
         "parameters": [
           {
-            "description": "Called when removal is complete.", 
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "description": "Called when removal is complete.",
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
+        "type": "function"
+      },
+      {
+        "description": "Show the matching menu items from this extension instead of the default menu. This should be called during a 'contextmenu' DOM event handler, and only applies to the menu that opens after this event.",
+        "name": "overrideContext",
+        "parameters": [
+          {
+            "name": "contextOptions",
+            "properties": {
+              "bookmarkId": {
+                "description": "Required when context is 'bookmark'. Requires 'bookmark' permission.",
+                "minLength": 1,
+                "optional": true,
+                "type": "string"
+              },
+              "context": {
+                "description": "ContextType to override, to allow menu items from other extensions in the menu. Currently only 'bookmark' and 'tab' are supported. showDefaults cannot be used with this option.",
+                "enum": [
+                  "bookmark",
+                  "tab"
+                ],
+                "optional": true,
+                "type": "string"
+              },
+              "showDefaults": {
+                "default": false,
+                "description": "Whether to also include default menu items in the menu.",
+                "optional": true,
+                "type": "boolean"
+              },
+              "tabId": {
+                "description": "Required when context is 'tab'. Requires 'tabs' permission.",
+                "minimum": 0,
+                "optional": true,
+                "type": "integer"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "permissions": [
+          "menus.overrideContext"
+        ],
+        "type": "function"
+      },
+      {
+        "async": true,
+        "description": "Updates the extension items in the shown menu, including changes that have been made since the menu was shown. Has no effect if the menu is hidden. Rebuilding a shown menu is an expensive operation, only invoke this method when necessary.",
+        "name": "refresh",
+        "parameters": [],
         "type": "function"
       }
-    ], 
-    "namespace": "menus", 
+    ],
+    "namespace": "menus",
     "permissions": [
       "menus"
-    ], 
+    ],
     "properties": {
       "ACTION_MENU_TOP_LEVEL_LIMIT": {
-        "description": "The maximum number of top level extension items that can be added to an extension action context menu. Any items beyond this limit will be ignored.", 
+        "description": "The maximum number of top level extension items that can be added to an extension action context menu. Any items beyond this limit will be ignored.",
         "value": 6
       }
-    }, 
+    },
     "types": [
       {
-        "description": "The different contexts a menu can appear in. Specifying 'all' is equivalent to the combination of all other contexts except for 'tab' and 'tools_menu'.", 
+        "description": "The different contexts a menu can appear in. Specifying 'all' is equivalent to the combination of all other contexts except for 'tab' and 'tools_menu'.",
         "enum": [
-          "all", 
-          "page", 
-          "frame", 
-          "selection", 
-          "link", 
-          "editable", 
-          "password", 
-          "image", 
-          "video", 
-          "audio", 
-          "launcher", 
-          "browser_action", 
-          "page_action", 
-          "tab", 
+          "all",
+          "page",
+          "frame",
+          "selection",
+          "link",
+          "editable",
+          "password",
+          "image",
+          "video",
+          "audio",
+          "launcher",
+          "bookmark",
+          "browser_action",
+          "page_action",
+          "tab",
           "tools_menu"
-        ], 
-        "id": "ContextType", 
+        ],
+        "id": "ContextType",
         "type": "string"
-      }, 
+      },
       {
-        "description": "The type of menu item.", 
+        "description": "The type of menu item.",
         "enum": [
-          "normal", 
-          "checkbox", 
-          "radio", 
+          "normal",
+          "checkbox",
+          "radio",
           "separator"
-        ], 
-        "id": "ItemType", 
+        ],
+        "id": "ItemType",
         "type": "string"
-      }, 
+      },
       {
-        "description": "Information sent when a context menu item is clicked.", 
-        "id": "OnClickData", 
+        "description": "Information sent when a context menu item is clicked.",
+        "id": "OnClickData",
         "properties": {
+          "bookmarkId": {
+            "description": "The id of the bookmark where the context menu was clicked, if it was on a bookmark.",
+            "type": "string"
+          },
+          "button": {
+            "description": "An integer value of button by which menu item was clicked.",
+            "optional": true,
+            "type": "integer"
+          },
           "checked": {
-            "description": "A flag indicating the state of a checkbox or radio item after it is clicked.", 
-            "optional": true, 
+            "description": "A flag indicating the state of a checkbox or radio item after it is clicked.",
+            "optional": true,
             "type": "boolean"
-          }, 
+          },
           "editable": {
-            "description": "A flag indicating whether the element is editable (text input, textarea, etc.).", 
+            "description": "A flag indicating whether the element is editable (text input, textarea, etc.).",
             "type": "boolean"
-          }, 
+          },
+          "frameId": {
+            "description": "The id of the frame of the element where the context menu was clicked.",
+            "minimum": 0,
+            "optional": true,
+            "type": "integer"
+          },
           "frameUrl": {
-            "description": " The URL of the frame of the element where the context menu was clicked, if it was in a frame.", 
-            "optional": true, 
+            "description": " The URL of the frame of the element where the context menu was clicked, if it was in a frame.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "linkText": {
-            "description": "If the element is a link, the text of that link.", 
-            "optional": true, 
+            "description": "If the element is a link, the text of that link.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "linkUrl": {
-            "description": "If the element is a link, the URL it points to.", 
-            "optional": true, 
+            "description": "If the element is a link, the URL it points to.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "mediaType": {
-            "description": "One of 'image', 'video', or 'audio' if the context menu was activated on one of these types of elements.", 
-            "optional": true, 
+            "description": "One of 'image', 'video', or 'audio' if the context menu was activated on one of these types of elements.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "menuItemId": {
             "choices": [
               {
                 "type": "integer"
-              }, 
+              },
               {
                 "type": "string"
               }
-            ], 
+            ],
             "description": "The ID of the menu item that was clicked."
-          }, 
+          },
           "modifiers": {
-            "description": "An array of keyboard modifiers that were held while the menu item was clicked.", 
+            "description": "An array of keyboard modifiers that were held while the menu item was clicked.",
             "items": {
               "enum": [
-                "Shift", 
-                "Alt", 
-                "Command", 
-                "Ctrl", 
+                "Shift",
+                "Alt",
+                "Command",
+                "Ctrl",
                 "MacCtrl"
-              ], 
+              ],
               "type": "string"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "pageUrl": {
-            "description": "The URL of the page where the menu item was clicked. This property is not set if the click occured in a context where there is no current page, such as in a launcher context menu.", 
-            "optional": true, 
+            "description": "The URL of the page where the menu item was clicked. This property is not set if the click occured in a context where there is no current page, such as in a launcher context menu.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "parentMenuItemId": {
             "choices": [
               {
                 "type": "integer"
-              }, 
+              },
               {
                 "type": "string"
               }
-            ], 
-            "description": "The parent ID, if any, for the item clicked.", 
+            ],
+            "description": "The parent ID, if any, for the item clicked.",
             "optional": true
-          }, 
+          },
           "selectionText": {
-            "description": "The text for the context selection, if any.", 
-            "optional": true, 
+            "description": "The text for the context selection, if any.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "srcUrl": {
-            "description": "Will be present for elements with a 'src' URL.", 
-            "optional": true, 
+            "description": "Will be present for elements with a 'src' URL.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
+          "targetElementId": {
+            "description": "An identifier of the clicked element, if any. Use menus.getTargetElement in the page to find the corresponding element.",
+            "optional": true,
+            "type": "integer"
+          },
+          "viewType": {
+            "$ref": "extension.ViewType",
+            "description": "The type of view where the menu is clicked. May be unset if the menu is not associated with a view.",
+            "optional": true
+          },
           "wasChecked": {
-            "description": "A flag indicating the state of a checkbox or radio item before it was clicked.", 
-            "optional": true, 
+            "description": "A flag indicating the state of a checkbox or radio item before it was clicked.",
+            "optional": true,
             "type": "boolean"
           }
-        }, 
+        },
         "type": "object"
       }
     ]
-  }, 
+  },
   {
     "allowedContexts": [
-      "addon_parent_only"
-    ], 
-    "description": "Use the <code>browser.contextMenus</code> API to add items to the browser's context menu. You can choose what types of objects your context menu additions apply to, such as images, hyperlinks, and pages.", 
-    "namespace": "menusInternal", 
+      "content",
+      "devtools"
+    ],
+    "description": "The part of the menus API that is available in all extension contexts, including content scripts.",
+    "functions": [
+      {
+        "allowedContexts": [
+          "content",
+          "devtools"
+        ],
+        "description": "Retrieve the element that was associated with a recent contextmenu event.",
+        "name": "getTargetElement",
+        "parameters": [
+          {
+            "description": "The identifier of the clicked element, available as info.targetElementId in the menus.onShown, onClicked or onclick event.",
+            "name": "targetElementId",
+            "type": "integer"
+          }
+        ],
+        "returns": {
+          "additionalProperties": {
+            "type": "any"
+          },
+          "isInstanceOf": "Element",
+          "optional": true,
+          "type": "object"
+        },
+        "type": "function"
+      }
+    ],
+    "namespace": "menus",
+    "permissions": [
+      "menus"
+    ]
+  },
+  {
+    "description": "This API provides the ability to determine the status of and detect changes in the network connection. This API can only be used in privileged extensions.",
+    "events": [
+      {
+        "description": "Fired when the network connection state changes.",
+        "name": "onConnectionChanged",
+        "parameters": [
+          {
+            "$ref": "NetworkLinkInfo",
+            "name": "details"
+          }
+        ],
+        "type": "function"
+      }
+    ],
+    "functions": [
+      {
+        "async": true,
+        "description": "Returns the $(ref:NetworkLinkInfo} of the current network connection.",
+        "name": "getLinkInfo",
+        "parameters": [],
+        "type": "function"
+      }
+    ],
+    "namespace": "networkStatus",
+    "permissions": [
+      "networkStatus"
+    ],
     "types": [
       {
-        "description": "Information sent when a context menu item is clicked.", 
-        "id": "OnClickData", 
+        "id": "NetworkLinkInfo",
         "properties": {
-          "checked": {
-            "description": "A flag indicating the state of a checkbox or radio item after it is clicked.", 
-            "optional": true, 
-            "type": "boolean"
-          }, 
-          "editable": {
-            "description": "A flag indicating whether the element is editable (text input, textarea, etc.).", 
-            "type": "boolean"
-          }, 
-          "frameUrl": {
-            "description": " The URL of the frame of the element where the context menu was clicked, if it was in a frame.", 
-            "optional": true, 
+          "id": {
+            "description": "If known, the network id or name.",
+            "optional": true,
             "type": "string"
-          }, 
-          "linkUrl": {
-            "description": "If the element is a link, the URL it points to.", 
-            "optional": true, 
+          },
+          "status": {
+            "description": "Status of the network link, if \"unknown\" then link is usually assumed to be \"up\"",
+            "enum": [
+              "unknown",
+              "up",
+              "down"
+            ],
             "type": "string"
-          }, 
-          "mediaType": {
-            "description": "One of 'image', 'video', or 'audio' if the context menu was activated on one of these types of elements.", 
-            "optional": true, 
+          },
+          "type": {
+            "description": "If known, the type of network connection that is avialable.",
+            "enum": [
+              "unknown",
+              "ethernet",
+              "usb",
+              "wifi",
+              "wimax",
+              "2g",
+              "3g",
+              "4g"
+            ],
             "type": "string"
-          }, 
-          "menuItemId": {
-            "choices": [
-              {
-                "type": "integer"
-              }, 
-              {
-                "type": "string"
-              }
-            ], 
-            "description": "The ID of the menu item that was clicked."
-          }, 
-          "pageUrl": {
-            "description": "The URL of the page where the menu item was clicked. This property is not set if the click occured in a context where there is no current page, such as in a launcher context menu.", 
-            "optional": true, 
-            "type": "string"
-          }, 
-          "parentMenuItemId": {
-            "choices": [
-              {
-                "type": "integer"
-              }, 
-              {
-                "type": "string"
-              }
-            ], 
-            "description": "The parent ID, if any, for the item clicked.", 
-            "optional": true
-          }, 
-          "selectionText": {
-            "description": "The text for the context selection, if any.", 
-            "optional": true, 
-            "type": "string"
-          }, 
-          "srcUrl": {
-            "description": "Will be present for elements with a 'src' URL.", 
-            "optional": true, 
-            "type": "string"
-          }, 
-          "wasChecked": {
-            "description": "A flag indicating the state of a checkbox or radio item before it was clicked.", 
-            "optional": true, 
-            "type": "boolean"
           }
-        }, 
+        },
         "type": "object"
       }
     ]
-  }, 
+  },
+  {
+    "allowedContexts": [
+      "content",
+      "devtools"
+    ],
+    "defaultContexts": [
+      "content",
+      "devtools"
+    ],
+    "description": "Normandy Study API",
+    "events": [
+      {
+        "description": "Fired when a user unenrolls from a study but before the addon is uninstalled.",
+        "name": "onUnenroll",
+        "parameters": [
+          {
+            "description": "The reason why the study is ending.",
+            "name": "reason",
+            "type": "string"
+          }
+        ],
+        "type": "function"
+      }
+    ],
+    "functions": [
+      {
+        "async": true,
+        "description": "Returns a study object for the current study.",
+        "name": "getStudy",
+        "parameters": [],
+        "type": "function"
+      },
+      {
+        "async": true,
+        "description": "Marks the study as ended and then uninstalls the addon.",
+        "name": "endStudy",
+        "parameters": [
+          {
+            "description": "The reason why the study is ending.",
+            "name": "reason",
+            "type": "string"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": true,
+        "description": "Returns an object with metadata about the client which may be required for constructing survey URLs.",
+        "name": "getClientMetadata",
+        "parameters": [],
+        "type": "function"
+      }
+    ],
+    "namespace": "normandyAddonStudy",
+    "permissions": [
+      "normandyAddonStudy"
+    ],
+    "types": [
+      {
+        "id": "Study",
+        "properties": {
+          "active": {
+            "description": "The state of the study.",
+            "type": "boolean"
+          },
+          "addonId": {
+            "description": "The ID of the extension installed by the study.",
+            "type": "string"
+          },
+          "addonUrl": {
+            "description": "The URL of the XPI that was downloaded and installed by the study.",
+            "type": "string"
+          },
+          "addonVersion": {
+            "description": "The version of the extension installed by the study.",
+            "type": "string"
+          },
+          "branch": {
+            "description": "The study branch in which the user is enrolled.",
+            "type": "string"
+          },
+          "extensionApiId": {
+            "description": "The record ID for the extension in Normandy server's database.",
+            "type": "integer"
+          },
+          "extensionHash": {
+            "description": "A hash of the extension XPI file.",
+            "type": "string"
+          },
+          "extensionHashAlgorithm": {
+            "description": "The algorithm used to hash the extension XPI file.",
+            "type": "string"
+          },
+          "recipeId": {
+            "description": "The ID of the recipe for the study.",
+            "type": "integer"
+          },
+          "slug": {
+            "description": "A slug to identify the study.",
+            "type": "string"
+          },
+          "studyEndDate": {
+            "$ref": "extensionTypes.Date",
+            "description": "The end date for the study."
+          },
+          "studyStartDate": {
+            "$ref": "extensionTypes.Date",
+            "description": "The start date for the study."
+          },
+          "userFacingDescription": {
+            "description": "The description presented on about:studies.",
+            "type": "string"
+          },
+          "userFacingName": {
+            "description": "The name presented on about:studies.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }
+    ]
+  },
   {
     "events": [
       {
-        "description": "Fired when the notification closed, either by the system or by user action.", 
-        "name": "onClosed", 
+        "description": "Fired when the notification closed, either by the system or by user action.",
+        "name": "onClosed",
         "parameters": [
           {
-            "description": "The notificationId of the closed notification.", 
-            "name": "notificationId", 
+            "description": "The notificationId of the closed notification.",
+            "name": "notificationId",
             "type": "string"
-          }, 
+          },
           {
-            "description": "True if the notification was closed by the user.", 
-            "name": "byUser", 
+            "description": "True if the notification was closed by the user.",
+            "name": "byUser",
             "type": "boolean"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Fired when the user clicked in a non-button area of the notification.", 
-        "name": "onClicked", 
+        "description": "Fired when the user clicked in a non-button area of the notification.",
+        "name": "onClicked",
         "parameters": [
           {
-            "description": "The notificationId of the clicked notification.", 
-            "name": "notificationId", 
+            "description": "The notificationId of the clicked notification.",
+            "name": "notificationId",
             "type": "string"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Fired when the  user pressed a button in the notification.", 
-        "name": "onButtonClicked", 
+        "description": "Fired when the  user pressed a button in the notification.",
+        "name": "onButtonClicked",
         "parameters": [
           {
-            "description": "The notificationId of the clicked notification.", 
-            "name": "notificationId", 
+            "description": "The notificationId of the clicked notification.",
+            "name": "notificationId",
             "type": "string"
-          }, 
+          },
           {
-            "description": "The index of the button clicked by the user.", 
-            "name": "buttonIndex", 
+            "description": "The index of the button clicked by the user.",
+            "name": "buttonIndex",
             "type": "number"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Fired when the user changes the permission level.", 
-        "name": "onPermissionLevelChanged", 
+        "description": "Fired when the user changes the permission level.",
+        "name": "onPermissionLevelChanged",
         "parameters": [
           {
-            "$ref": "PermissionLevel", 
-            "description": "The new permission level.", 
+            "$ref": "PermissionLevel",
+            "description": "The new permission level.",
             "name": "level"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
-      }, 
+      },
       {
-        "description": "Fired when the user clicked on a link for the app's notification settings.", 
-        "name": "onShowSettings", 
-        "parameters": [], 
-        "type": "function", 
+        "description": "Fired when the user clicked on a link for the app's notification settings.",
+        "name": "onShowSettings",
+        "parameters": [],
+        "type": "function",
         "unsupported": true
-      }, 
+      },
       {
-        "description": "Fired when the notification is shown.", 
-        "name": "onShown", 
+        "description": "Fired when the notification is shown.",
+        "name": "onShown",
         "parameters": [
           {
-            "description": "The notificationId of the shown notification.", 
-            "name": "notificationId", 
+            "description": "The notificationId of the shown notification.",
+            "name": "notificationId",
             "type": "string"
           }
-        ], 
+        ],
         "type": "function"
       }
-    ], 
+    ],
     "functions": [
       {
-        "async": "callback", 
-        "description": "Creates and displays a notification.", 
-        "name": "create", 
+        "async": "callback",
+        "description": "Creates and displays a notification.",
+        "name": "create",
         "parameters": [
           {
-            "description": "Identifier of the notification. If it is empty, this method generates an id. If it matches an existing notification, this method first clears that notification before proceeding with the create operation.", 
-            "name": "notificationId", 
-            "optional": true, 
+            "description": "Identifier of the notification. If it is empty, this method generates an id. If it matches an existing notification, this method first clears that notification before proceeding with the create operation.",
+            "name": "notificationId",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           {
-            "$ref": "CreateNotificationOptions", 
-            "description": "Contents of the notification.", 
+            "$ref": "CreateNotificationOptions",
+            "description": "Contents of the notification.",
             "name": "options"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
+            "name": "callback",
+            "optional": true,
             "parameters": [
               {
-                "description": "The notification id (either supplied or generated) that represents the created notification.", 
-                "name": "notificationId", 
+                "description": "The notification id (either supplied or generated) that represents the created notification.",
+                "name": "notificationId",
                 "type": "string"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Updates an existing notification.", 
-        "name": "update", 
+        "async": "callback",
+        "description": "Updates an existing notification.",
+        "name": "update",
         "parameters": [
           {
-            "description": "The id of the notification to be updated.", 
-            "name": "notificationId", 
+            "description": "The id of the notification to be updated.",
+            "name": "notificationId",
             "type": "string"
-          }, 
+          },
           {
-            "$ref": "UpdateNotificationOptions", 
-            "description": "Contents of the notification to update to.", 
+            "$ref": "UpdateNotificationOptions",
+            "description": "Contents of the notification to update to.",
             "name": "options"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
+            "name": "callback",
+            "optional": true,
             "parameters": [
               {
-                "description": "Indicates whether a matching notification existed.", 
-                "name": "wasUpdated", 
+                "description": "Indicates whether a matching notification existed.",
+                "name": "wasUpdated",
                 "type": "boolean"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Clears an existing notification.", 
-        "name": "clear", 
+        "async": "callback",
+        "description": "Clears an existing notification.",
+        "name": "clear",
         "parameters": [
           {
-            "description": "The id of the notification to be updated.", 
-            "name": "notificationId", 
+            "description": "The id of the notification to be updated.",
+            "name": "notificationId",
             "type": "string"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
+            "name": "callback",
+            "optional": true,
             "parameters": [
               {
-                "description": "Indicates whether a matching notification existed.", 
-                "name": "wasCleared", 
+                "description": "Indicates whether a matching notification existed.",
+                "name": "wasCleared",
                 "type": "boolean"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Retrieves all the notifications.", 
-        "name": "getAll", 
+        "async": "callback",
+        "description": "Retrieves all the notifications.",
+        "name": "getAll",
         "parameters": [
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
                 "additionalProperties": {
                   "$ref": "CreateNotificationOptions"
-                }, 
-                "description": "The set of notifications currently in the system.", 
-                "name": "notifications", 
+                },
+                "description": "The set of notifications currently in the system.",
+                "name": "notifications",
                 "type": "object"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Retrieves whether the user has enabled notifications from this app or extension.", 
-        "name": "getPermissionLevel", 
+        "async": "callback",
+        "description": "Retrieves whether the user has enabled notifications from this app or extension.",
+        "name": "getPermissionLevel",
         "parameters": [
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
-                "$ref": "PermissionLevel", 
-                "description": "The current permission level.", 
+                "$ref": "PermissionLevel",
+                "description": "The current permission level.",
                 "name": "level"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
       }
-    ], 
-    "namespace": "notifications", 
+    ],
+    "namespace": "notifications",
     "permissions": [
       "notifications"
-    ], 
+    ],
     "types": [
       {
         "enum": [
-          "basic", 
-          "image", 
-          "list", 
+          "basic",
+          "image",
+          "list",
           "progress"
-        ], 
-        "id": "TemplateType", 
+        ],
+        "id": "TemplateType",
         "type": "string"
-      }, 
+      },
       {
         "enum": [
-          "granted", 
+          "granted",
           "denied"
-        ], 
-        "id": "PermissionLevel", 
+        ],
+        "id": "PermissionLevel",
         "type": "string"
-      }, 
+      },
       {
-        "id": "NotificationItem", 
+        "id": "NotificationItem",
         "properties": {
           "message": {
-            "description": "Additional details about this item.", 
+            "description": "Additional details about this item.",
             "type": "string"
-          }, 
+          },
           "title": {
-            "description": "Title of one item of a list notification.", 
+            "description": "Title of one item of a list notification.",
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       {
-        "id": "CreateNotificationOptions", 
+        "id": "CreateNotificationOptions",
         "properties": {
           "appIconMaskUrl": {
-            "description": "A URL to the app icon mask.", 
-            "optional": true, 
+            "description": "A URL to the app icon mask.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "buttons": {
-            "description": "Text and icons for up to two notification action buttons.", 
+            "description": "Text and icons for up to two notification action buttons.",
             "items": {
               "properties": {
                 "iconUrl": {
-                  "optional": true, 
+                  "optional": true,
                   "type": "string"
-                }, 
+                },
                 "title": {
                   "type": "string"
                 }
-              }, 
+              },
               "type": "object"
-            }, 
-            "optional": true, 
-            "type": "array", 
+            },
+            "optional": true,
+            "type": "array",
             "unsupported": true
-          }, 
+          },
           "contextMessage": {
-            "description": "Alternate notification content with a lower-weight font.", 
-            "optional": true, 
+            "description": "Alternate notification content with a lower-weight font.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "eventTime": {
-            "description": "A timestamp associated with the notification, in milliseconds past the epoch.", 
-            "optional": true, 
+            "description": "A timestamp associated with the notification, in milliseconds past the epoch.",
+            "optional": true,
             "type": "number"
-          }, 
+          },
           "iconUrl": {
-            "description": "A URL to the sender's avatar, app icon, or a thumbnail for image notifications.", 
-            "optional": true, 
+            "description": "A URL to the sender's avatar, app icon, or a thumbnail for image notifications.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "imageUrl": {
-            "description": "A URL to the image thumbnail for image-type notifications.", 
-            "optional": true, 
+            "description": "A URL to the image thumbnail for image-type notifications.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "isClickable": {
-            "description": "Whether to show UI indicating that the app will visibly respond to clicks on the body of a notification.", 
-            "optional": true, 
+            "description": "Whether to show UI indicating that the app will visibly respond to clicks on the body of a notification.",
+            "optional": true,
             "type": "boolean"
-          }, 
+          },
           "items": {
-            "description": "Items for multi-item notifications.", 
+            "description": "Items for multi-item notifications.",
             "items": {
               "$ref": "NotificationItem"
-            }, 
-            "optional": true, 
+            },
+            "optional": true,
             "type": "array"
-          }, 
+          },
           "message": {
-            "description": "Main notification content.", 
+            "description": "Main notification content.",
             "type": "string"
-          }, 
+          },
           "priority": {
-            "description": "Priority ranges from -2 to 2. -2 is lowest priority. 2 is highest. Zero is default.", 
-            "maximum": 2, 
-            "minimum": -2, 
-            "optional": true, 
+            "description": "Priority ranges from -2 to 2. -2 is lowest priority. 2 is highest. Zero is default.",
+            "maximum": 2,
+            "minimum": -2,
+            "optional": true,
             "type": "integer"
-          }, 
+          },
           "progress": {
-            "description": "Current progress ranges from 0 to 100.", 
-            "maximum": 100, 
-            "minimum": 0, 
-            "optional": true, 
+            "description": "Current progress ranges from 0 to 100.",
+            "maximum": 100,
+            "minimum": 0,
+            "optional": true,
             "type": "integer"
-          }, 
+          },
           "title": {
-            "description": "Title of the notification (e.g. sender name for email).", 
+            "description": "Title of the notification (e.g. sender name for email).",
             "type": "string"
-          }, 
+          },
           "type": {
-            "$ref": "TemplateType", 
+            "$ref": "TemplateType",
             "description": "Which type of notification to display."
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       {
-        "id": "UpdateNotificationOptions", 
+        "id": "UpdateNotificationOptions",
         "properties": {
           "appIconMaskUrl": {
-            "description": "A URL to the app icon mask.", 
-            "optional": true, 
+            "description": "A URL to the app icon mask.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "buttons": {
-            "description": "Text and icons for up to two notification action buttons.", 
+            "description": "Text and icons for up to two notification action buttons.",
             "items": {
               "properties": {
                 "iconUrl": {
-                  "optional": true, 
+                  "optional": true,
                   "type": "string"
-                }, 
+                },
                 "title": {
                   "type": "string"
                 }
-              }, 
+              },
               "type": "object"
-            }, 
-            "optional": true, 
-            "type": "array", 
+            },
+            "optional": true,
+            "type": "array",
             "unsupported": true
-          }, 
+          },
           "contextMessage": {
-            "description": "Alternate notification content with a lower-weight font.", 
-            "optional": true, 
+            "description": "Alternate notification content with a lower-weight font.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "eventTime": {
-            "description": "A timestamp associated with the notification, in milliseconds past the epoch.", 
-            "optional": true, 
+            "description": "A timestamp associated with the notification, in milliseconds past the epoch.",
+            "optional": true,
             "type": "number"
-          }, 
+          },
           "iconUrl": {
-            "description": "A URL to the sender's avatar, app icon, or a thumbnail for image notifications.", 
-            "optional": true, 
+            "description": "A URL to the sender's avatar, app icon, or a thumbnail for image notifications.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "imageUrl": {
-            "description": "A URL to the image thumbnail for image-type notifications.", 
-            "optional": true, 
+            "description": "A URL to the image thumbnail for image-type notifications.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "isClickable": {
-            "description": "Whether to show UI indicating that the app will visibly respond to clicks on the body of a notification.", 
-            "optional": true, 
+            "description": "Whether to show UI indicating that the app will visibly respond to clicks on the body of a notification.",
+            "optional": true,
             "type": "boolean"
-          }, 
+          },
           "items": {
-            "description": "Items for multi-item notifications.", 
+            "description": "Items for multi-item notifications.",
             "items": {
               "$ref": "NotificationItem"
-            }, 
-            "optional": true, 
+            },
+            "optional": true,
             "type": "array"
-          }, 
+          },
           "message": {
-            "description": "Main notification content.", 
-            "optional": true, 
+            "description": "Main notification content.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "priority": {
-            "description": "Priority ranges from -2 to 2. -2 is lowest priority. 2 is highest. Zero is default.", 
-            "maximum": 2, 
-            "minimum": -2, 
-            "optional": true, 
+            "description": "Priority ranges from -2 to 2. -2 is lowest priority. 2 is highest. Zero is default.",
+            "maximum": 2,
+            "minimum": -2,
+            "optional": true,
             "type": "integer"
-          }, 
+          },
           "progress": {
-            "description": "Current progress ranges from 0 to 100.", 
-            "maximum": 100, 
-            "minimum": 0, 
-            "optional": true, 
+            "description": "Current progress ranges from 0 to 100.",
+            "maximum": 100,
+            "minimum": 0,
+            "optional": true,
             "type": "integer"
-          }, 
+          },
           "title": {
-            "description": "Title of the notification (e.g. sender name for email).", 
-            "optional": true, 
+            "description": "Title of the notification (e.g. sender name for email).",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "type": {
-            "$ref": "TemplateType", 
-            "description": "Which type of notification to display.", 
+            "$ref": "TemplateType",
+            "description": "Which type of notification to display.",
             "optional": true
           }
-        }, 
+        },
         "type": "object"
       }
     ]
-  }, 
+  },
   {
-    "description": "The omnibox API allows you to register a keyword with Firefox's address bar.", 
+    "description": "The omnibox API allows you to register a keyword with Firefox's address bar.",
     "events": [
       {
-        "description": "User has started a keyword input session by typing the extension's keyword. This is guaranteed to be sent exactly once per input session, and before any onInputChanged events.", 
-        "name": "onInputStarted", 
-        "parameters": [], 
+        "description": "User has started a keyword input session by typing the extension's keyword. This is guaranteed to be sent exactly once per input session, and before any onInputChanged events.",
+        "name": "onInputStarted",
+        "parameters": [],
         "type": "function"
-      }, 
+      },
       {
-        "description": "User has changed what is typed into the omnibox.", 
-        "name": "onInputChanged", 
+        "description": "User has changed what is typed into the omnibox.",
+        "name": "onInputChanged",
         "parameters": [
           {
-            "name": "text", 
+            "name": "text",
             "type": "string"
-          }, 
+          },
           {
-            "description": "A callback passed to the onInputChanged event used for sending suggestions back to the browser.", 
-            "name": "suggest", 
+            "description": "A callback passed to the onInputChanged event used for sending suggestions back to the browser.",
+            "name": "suggest",
             "parameters": [
               {
-                "description": "Array of suggest results", 
+                "description": "Array of suggest results",
                 "items": {
                   "$ref": "SuggestResult"
-                }, 
-                "name": "suggestResults", 
+                },
+                "name": "suggestResults",
                 "type": "array"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "User has accepted what is typed into the omnibox.", 
-        "name": "onInputEntered", 
+        "description": "User has accepted what is typed into the omnibox.",
+        "name": "onInputEntered",
         "parameters": [
           {
-            "name": "text", 
+            "name": "text",
             "type": "string"
-          }, 
+          },
           {
-            "$ref": "OnInputEnteredDisposition", 
+            "$ref": "OnInputEnteredDisposition",
             "name": "disposition"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "User has ended the keyword input session without accepting the input.", 
-        "name": "onInputCancelled", 
-        "parameters": [], 
+        "description": "User has ended the keyword input session without accepting the input.",
+        "name": "onInputCancelled",
+        "parameters": [],
         "type": "function"
       }
-    ], 
+    ],
     "functions": [
       {
-        "description": "Sets the description and styling for the default suggestion. The default suggestion is the text that is displayed in the first suggestion row underneath the URL bar.", 
-        "name": "setDefaultSuggestion", 
+        "description": "Sets the description and styling for the default suggestion. The default suggestion is the text that is displayed in the first suggestion row underneath the URL bar.",
+        "name": "setDefaultSuggestion",
         "parameters": [
           {
-            "$ref": "DefaultSuggestResult", 
-            "description": "A partial SuggestResult object, without the 'content' parameter.", 
+            "$ref": "DefaultSuggestResult",
+            "description": "A partial SuggestResult object, without the 'content' parameter.",
             "name": "suggestion"
           }
-        ], 
+        ],
         "type": "function"
       }
-    ], 
-    "namespace": "omnibox", 
+    ],
+    "namespace": "omnibox",
     "permissions": [
       "manifest:omnibox"
-    ], 
+    ],
     "types": [
       {
-        "description": "The style type.", 
+        "description": "The style type.",
         "enum": [
-          "url", 
-          "match", 
+          "url",
+          "match",
           "dim"
-        ], 
-        "id": "DescriptionStyleType", 
+        ],
+        "id": "DescriptionStyleType",
         "type": "string"
-      }, 
+      },
       {
-        "description": "The window disposition for the omnibox query. This is the recommended context to display results. For example, if the omnibox command is to navigate to a certain URL, a disposition of 'newForegroundTab' means the navigation should take place in a new selected tab.", 
+        "description": "The window disposition for the omnibox query. This is the recommended context to display results. For example, if the omnibox command is to navigate to a certain URL, a disposition of 'newForegroundTab' means the navigation should take place in a new selected tab.",
         "enum": [
-          "currentTab", 
-          "newForegroundTab", 
+          "currentTab",
+          "newForegroundTab",
           "newBackgroundTab"
-        ], 
-        "id": "OnInputEnteredDisposition", 
+        ],
+        "id": "OnInputEnteredDisposition",
         "type": "string"
-      }, 
+      },
       {
-        "description": "A suggest result.", 
-        "id": "SuggestResult", 
+        "description": "A suggest result.",
+        "id": "SuggestResult",
         "properties": {
           "content": {
-            "description": "The text that is put into the URL bar, and that is sent to the extension when the user chooses this entry.", 
-            "minLength": 1, 
+            "description": "The text that is put into the URL bar, and that is sent to the extension when the user chooses this entry.",
+            "minLength": 1,
             "type": "string"
-          }, 
+          },
           "description": {
-            "description": "The text that is displayed in the URL dropdown. Can contain XML-style markup for styling. The supported tags are 'url' (for a literal URL), 'match' (for highlighting text that matched what the user's query), and 'dim' (for dim helper text). The styles can be nested, eg. <dim><match>dimmed match</match></dim>. You must escape the five predefined entities to display them as text: stackoverflow.com/a/1091953/89484 ", 
-            "minLength": 1, 
+            "description": "The text that is displayed in the URL dropdown. Can contain XML-style markup for styling. The supported tags are 'url' (for a literal URL), 'match' (for highlighting text that matched what the user's query), and 'dim' (for dim helper text). The styles can be nested, eg. <dim><match>dimmed match</match></dim>. You must escape the five predefined entities to display them as text: stackoverflow.com/a/1091953/89484 ",
+            "minLength": 1,
             "type": "string"
-          }, 
+          },
           "descriptionStyles": {
-            "description": "An array of style ranges for the description, as provided by the extension.", 
+            "description": "An array of style ranges for the description, as provided by the extension.",
             "items": {
-              "description": "The style ranges for the description, as provided by the extension.", 
+              "description": "The style ranges for the description, as provided by the extension.",
               "properties": {
                 "length": {
-                  "optional": true, 
+                  "optional": true,
                   "type": "integer"
-                }, 
+                },
                 "offset": {
                   "type": "integer"
-                }, 
+                },
                 "type": {
-                  "$ref": "DescriptionStyleType", 
+                  "$ref": "DescriptionStyleType",
                   "description": "The style type"
                 }
-              }, 
+              },
               "type": "object"
-            }, 
-            "optional": true, 
-            "type": "array", 
+            },
+            "optional": true,
+            "type": "array",
             "unsupported": true
-          }, 
+          },
           "descriptionStylesRaw": {
-            "description": "An array of style ranges for the description, as provided by ToValue().", 
+            "description": "An array of style ranges for the description, as provided by ToValue().",
             "items": {
-              "description": "The style ranges for the description, as provided by ToValue().", 
+              "description": "The style ranges for the description, as provided by ToValue().",
               "properties": {
                 "offset": {
                   "type": "integer"
-                }, 
+                },
                 "type": {
                   "type": "integer"
                 }
-              }, 
+              },
               "type": "object"
-            }, 
-            "optional": true, 
-            "type": "array", 
+            },
+            "optional": true,
+            "type": "array",
             "unsupported": true
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       {
-        "description": "A suggest result.", 
-        "id": "DefaultSuggestResult", 
+        "description": "A suggest result.",
+        "id": "DefaultSuggestResult",
         "properties": {
           "description": {
-            "description": "The text that is displayed in the URL dropdown.", 
-            "minLength": 1, 
+            "description": "The text that is displayed in the URL dropdown.",
+            "minLength": 1,
             "type": "string"
-          }, 
+          },
           "descriptionStyles": {
-            "description": "An array of style ranges for the description, as provided by the extension.", 
+            "description": "An array of style ranges for the description, as provided by the extension.",
             "items": {
-              "description": "The style ranges for the description, as provided by the extension.", 
+              "description": "The style ranges for the description, as provided by the extension.",
               "properties": {
                 "length": {
-                  "optional": true, 
+                  "optional": true,
                   "type": "integer"
-                }, 
+                },
                 "offset": {
                   "type": "integer"
-                }, 
+                },
                 "type": {
-                  "$ref": "DescriptionStyleType", 
+                  "$ref": "DescriptionStyleType",
                   "description": "The style type"
                 }
-              }, 
+              },
               "type": "object"
-            }, 
-            "optional": true, 
-            "type": "array", 
+            },
+            "optional": true,
+            "type": "array",
             "unsupported": true
-          }, 
+          },
           "descriptionStylesRaw": {
-            "description": "An array of style ranges for the description, as provided by ToValue().", 
+            "description": "An array of style ranges for the description, as provided by ToValue().",
             "items": {
-              "description": "The style ranges for the description, as provided by ToValue().", 
+              "description": "The style ranges for the description, as provided by ToValue().",
               "properties": {
                 "offset": {
                   "type": "integer"
-                }, 
+                },
                 "type": {
                   "type": "integer"
                 }
-              }, 
+              },
               "type": "object"
-            }, 
-            "optional": true, 
-            "type": "array", 
+            },
+            "optional": true,
+            "type": "array",
             "unsupported": true
           }
-        }, 
+        },
         "type": "object"
       }
     ]
-  }, 
+  },
   {
-    "description": "Use the <code>browser.pageAction</code> API to put icons inside the address bar. Page actions represent actions that can be taken on the current page, but that aren't applicable to all pages.", 
+    "description": "Use the <code>browser.pageAction</code> API to put icons inside the address bar. Page actions represent actions that can be taken on the current page, but that aren't applicable to all pages.",
     "events": [
       {
-        "description": "Fired when a page action icon is clicked.  This event will not fire if the page action has a popup.", 
-        "name": "onClicked", 
+        "description": "Fired when a page action icon is clicked.  This event will not fire if the page action has a popup.",
+        "name": "onClicked",
         "parameters": [
           {
-            "$ref": "tabs.Tab", 
+            "$ref": "tabs.Tab",
             "name": "tab"
           }
-        ], 
+        ],
         "type": "function"
       }
-    ], 
+    ],
     "functions": [
       {
-        "async": "callback", 
-        "description": "Shows the page action. The page action is shown whenever the tab is selected.", 
-        "name": "show", 
+        "async": "callback",
+        "description": "Shows the page action. The page action is shown whenever the tab is selected.",
+        "name": "show",
         "parameters": [
           {
-            "description": "The id of the tab for which you want to modify the page action.", 
-            "minimum": 0, 
-            "name": "tabId", 
+            "description": "The id of the tab for which you want to modify the page action.",
+            "minimum": 0,
+            "name": "tabId",
             "type": "integer"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Hides the page action.", 
-        "name": "hide", 
+        "async": "callback",
+        "description": "Hides the page action.",
+        "name": "hide",
         "parameters": [
           {
-            "description": "The id of the tab for which you want to modify the page action.", 
-            "minimum": 0, 
-            "name": "tabId", 
+            "description": "The id of the tab for which you want to modify the page action.",
+            "minimum": 0,
+            "name": "tabId",
             "type": "integer"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Sets the title of the page action. This is displayed in a tooltip over the page action.", 
-        "name": "setTitle", 
+        "async": true,
+        "description": "Checks whether the page action is shown.",
+        "name": "isShown",
         "parameters": [
           {
-            "name": "details", 
+            "name": "details",
             "properties": {
               "tabId": {
-                "description": "The id of the tab for which you want to modify the page action.", 
-                "minimum": 0, 
+                "description": "Specify the tab to get the shownness from.",
                 "type": "integer"
-              }, 
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "description": "Sets the title of the page action. This is displayed in a tooltip over the page action.",
+        "name": "setTitle",
+        "parameters": [
+          {
+            "name": "details",
+            "properties": {
+              "tabId": {
+                "description": "The id of the tab for which you want to modify the page action.",
+                "minimum": 0,
+                "type": "integer"
+              },
               "title": {
-                "description": "The tooltip string.", 
-                "type": "string"
+                "choices": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "The tooltip string."
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Gets the title of the page action.", 
-        "name": "getTitle", 
+        "async": "callback",
+        "description": "Gets the title of the page action.",
+        "name": "getTitle",
         "parameters": [
           {
-            "name": "details", 
+            "name": "details",
             "properties": {
               "tabId": {
-                "description": "Specify the tab to get the title from.", 
+                "description": "Specify the tab to get the title from.",
                 "type": "integer"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
-                "name": "result", 
+                "name": "result",
                 "type": "string"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Sets the icon for the page action. The icon can be specified either as the path to an image file or as the pixel data from a canvas element, or as dictionary of either one of those. Either the <b>path</b> or the <b>imageData</b> property must be specified.", 
-        "name": "setIcon", 
+        "async": "callback",
+        "description": "Sets the icon for the page action. The icon can be specified either as the path to an image file or as the pixel data from a canvas element, or as dictionary of either one of those. Either the <b>path</b> or the <b>imageData</b> property must be specified.",
+        "name": "setIcon",
         "parameters": [
           {
-            "name": "details", 
+            "name": "details",
             "properties": {
               "imageData": {
                 "choices": [
                   {
                     "$ref": "ImageDataType"
-                  }, 
+                  },
                   {
                     "patternProperties": {
                       "^[1-9]\\d*$": {
                         "$ref": "ImageDataType"
                       }
-                    }, 
+                    },
                     "type": "object"
                   }
-                ], 
-                "description": "Either an ImageData object or a dictionary {size -> ImageData} representing icon to be set. If the icon is specified as a dictionary, the actual image to be used is chosen depending on screen's pixel density. If the number of image pixels that fit into one screen space unit equals <code>scale</code>, then image with size <code>scale</code> * 19 will be selected. Initially only scales 1 and 2 will be supported. At least one image must be specified. Note that 'details.imageData = foo' is equivalent to 'details.imageData = {'19': foo}'", 
+                ],
+                "description": "Either an ImageData object or a dictionary {size -> ImageData} representing icon to be set. If the icon is specified as a dictionary, the actual image to be used is chosen depending on screen's pixel density. If the number of image pixels that fit into one screen space unit equals <code>scale</code>, then image with size <code>scale</code> * 19 will be selected. Initially only scales 1 and 2 will be supported. At least one image must be specified. Note that 'details.imageData = foo' is equivalent to 'details.imageData = {'19': foo}'",
                 "optional": true
-              }, 
+              },
               "path": {
                 "choices": [
                   {
                     "type": "string"
-                  }, 
+                  },
                   {
                     "patternProperties": {
                       "^[1-9]\\d*$": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "type": "object"
                   }
-                ], 
-                "description": "Either a relative image path or a dictionary {size -> relative image path} pointing to icon to be set. If the icon is specified as a dictionary, the actual image to be used is chosen depending on screen's pixel density. If the number of image pixels that fit into one screen space unit equals <code>scale</code>, then image with size <code>scale</code> * 19 will be selected. Initially only scales 1 and 2 will be supported. At least one image must be specified. Note that 'details.path = foo' is equivalent to 'details.imageData = {'19': foo}'", 
+                ],
+                "description": "Either a relative image path or a dictionary {size -> relative image path} pointing to icon to be set. If the icon is specified as a dictionary, the actual image to be used is chosen depending on screen's pixel density. If the number of image pixels that fit into one screen space unit equals <code>scale</code>, then image with size <code>scale</code> * 19 will be selected. Initially only scales 1 and 2 will be supported. At least one image must be specified. Note that 'details.path = foo' is equivalent to 'details.imageData = {'19': foo}'",
                 "optional": true
-              }, 
+              },
               "tabId": {
-                "description": "The id of the tab for which you want to modify the page action.", 
-                "minimum": 0, 
+                "description": "The id of the tab for which you want to modify the page action.",
+                "minimum": 0,
                 "type": "integer"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": true, 
-        "description": "Sets the html document to be opened as a popup when the user clicks on the page action's icon.", 
-        "name": "setPopup", 
+        "async": true,
+        "description": "Sets the html document to be opened as a popup when the user clicks on the page action's icon.",
+        "name": "setPopup",
         "parameters": [
           {
-            "name": "details", 
+            "name": "details",
             "properties": {
               "popup": {
-                "description": "The html file to show in a popup.  If set to the empty string (''), no popup is shown.", 
-                "type": "string"
-              }, 
+                "choices": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "The html file to show in a popup.  If set to the empty string (''), no popup is shown."
+              },
               "tabId": {
-                "description": "The id of the tab for which you want to modify the page action.", 
-                "minimum": 0, 
+                "description": "The id of the tab for which you want to modify the page action.",
+                "minimum": 0,
                 "type": "integer"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Gets the html document set as the popup for this page action.", 
-        "name": "getPopup", 
+        "async": "callback",
+        "description": "Gets the html document set as the popup for this page action.",
+        "name": "getPopup",
         "parameters": [
           {
-            "name": "details", 
+            "name": "details",
             "properties": {
               "tabId": {
-                "description": "Specify the tab to get the popup from.", 
+                "description": "Specify the tab to get the popup from.",
                 "type": "integer"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
-                "name": "result", 
+                "name": "result",
                 "type": "string"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": true, 
-        "description": "Opens the extension page action in the active window.", 
-        "name": "openPopup", 
-        "parameters": [], 
-        "requireUserInput": true, 
+        "async": true,
+        "description": "Opens the extension page action in the active window.",
+        "name": "openPopup",
+        "parameters": [],
+        "requireUserInput": true,
         "type": "function"
       }
-    ], 
-    "namespace": "pageAction", 
+    ],
+    "namespace": "pageAction",
     "permissions": [
       "manifest:page_action"
-    ], 
+    ],
     "types": [
       {
         "additionalProperties": {
           "type": "any"
-        }, 
-        "description": "Pixel data for an image. Must be an ImageData object (for example, from a <code>canvas</code> element).", 
-        "id": "ImageDataType", 
-        "isInstanceOf": "ImageData", 
-        "postprocess": "convertImageDataToURL", 
+        },
+        "description": "Pixel data for an image. Must be an ImageData object (for example, from a <code>canvas</code> element).",
+        "id": "ImageDataType",
+        "isInstanceOf": "ImageData",
+        "postprocess": "convertImageDataToURL",
         "type": "object"
       }
     ]
-  }, 
+  },
   {
     "events": [
       {
-        "description": "Fired when the extension acquires new permissions.", 
-        "name": "onAdded", 
+        "description": "Fired when the extension acquires new permissions.",
+        "name": "onAdded",
         "parameters": [
           {
-            "$ref": "Permissions", 
+            "$ref": "Permissions",
             "name": "permissions"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
-      }, 
+      },
       {
-        "description": "Fired when permissions are removed from the extension.", 
-        "name": "onRemoved", 
+        "description": "Fired when permissions are removed from the extension.",
+        "name": "onRemoved",
         "parameters": [
           {
-            "$ref": "Permissions", 
+            "$ref": "Permissions",
             "name": "permissions"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
       }
-    ], 
+    ],
     "functions": [
       {
-        "async": "callback", 
-        "description": "Get a list of all the extension's permissions.", 
-        "name": "getAll", 
+        "async": "callback",
+        "description": "Get a list of all the extension's permissions.",
+        "name": "getAll",
         "parameters": [
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
-                "$ref": "AnyPermissions", 
+                "$ref": "AnyPermissions",
                 "name": "permissions"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Check if the extension has the given permissions.", 
-        "name": "contains", 
+        "async": "callback",
+        "description": "Check if the extension has the given permissions.",
+        "name": "contains",
         "parameters": [
           {
-            "$ref": "AnyPermissions", 
+            "$ref": "AnyPermissions",
             "name": "permissions"
-          }, 
+          },
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
-                "name": "result", 
+                "name": "result",
                 "type": "boolean"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
         "allowedContexts": [
           "content"
-        ], 
-        "async": "callback", 
-        "description": "Request the given permissions.", 
-        "name": "request", 
+        ],
+        "async": "callback",
+        "description": "Request the given permissions.",
+        "name": "request",
         "parameters": [
           {
-            "$ref": "Permissions", 
+            "$ref": "Permissions",
             "name": "permissions"
-          }, 
+          },
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
-                "name": "granted", 
+                "name": "granted",
                 "type": "boolean"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
-        "requireUserInput": true, 
+        ],
+        "requireUserInput": true,
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Relinquish the given permissions.", 
-        "name": "remove", 
+        "async": "callback",
+        "description": "Relinquish the given permissions.",
+        "name": "remove",
         "parameters": [
           {
-            "$ref": "Permissions", 
+            "$ref": "Permissions",
             "name": "permissions"
-          }, 
+          },
           {
-            "name": "callback", 
-            "parameters": [], 
+            "name": "callback",
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
       }
-    ], 
-    "namespace": "permissions", 
+    ],
+    "namespace": "permissions",
     "permissions": [
       "manifest:optional_permissions"
-    ], 
+    ],
     "types": [
       {
-        "id": "Permissions", 
+        "id": "Permissions",
         "properties": {
           "origins": {
-            "default": [], 
+            "default": [],
             "items": {
               "$ref": "manifest.MatchPattern"
-            }, 
-            "optional": true, 
+            },
+            "optional": true,
             "type": "array"
-          }, 
+          },
           "permissions": {
-            "default": [], 
+            "default": [],
             "items": {
               "$ref": "manifest.OptionalPermission"
-            }, 
-            "optional": true, 
+            },
+            "optional": true,
             "type": "array"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       {
-        "id": "AnyPermissions", 
+        "id": "AnyPermissions",
         "properties": {
           "origins": {
-            "default": [], 
+            "default": [],
             "items": {
-              "$ref": "manifest.MatchPatternInternal"
-            }, 
-            "optional": true, 
+              "$ref": "manifest.MatchPattern"
+            },
+            "optional": true,
             "type": "array"
-          }, 
+          },
           "permissions": {
-            "default": [], 
+            "default": [],
             "items": {
               "$ref": "manifest.Permission"
-            }, 
-            "optional": true, 
+            },
+            "optional": true,
             "type": "array"
           }
-        }, 
+        },
         "type": "object"
       }
     ]
-  }, 
+  },
   {
-    "description": "PKCS#11 module management API", 
+    "description": "PKCS#11 module management API",
     "functions": [
       {
-        "async": true, 
-        "description": "checks whether a PKCS#11 module, given by name, is installed", 
-        "name": "isModuleInstalled", 
+        "async": true,
+        "description": "checks whether a PKCS#11 module, given by name, is installed",
+        "name": "isModuleInstalled",
         "parameters": [
           {
-            "name": "name", 
+            "name": "name",
             "type": "string"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": true, 
-        "description": "Install a PKCS#11 module with a given name", 
-        "name": "installModule", 
+        "async": true,
+        "description": "Install a PKCS#11 module with a given name",
+        "name": "installModule",
         "parameters": [
           {
-            "name": "name", 
+            "name": "name",
             "type": "string"
-          }, 
+          },
           {
-            "name": "flags", 
-            "optional": true, 
+            "name": "flags",
+            "optional": true,
             "type": "integer"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": true, 
-        "description": "Remove an installed PKCS#11 module from firefox", 
-        "name": "uninstallModule", 
+        "async": true,
+        "description": "Remove an installed PKCS#11 module from firefox",
+        "name": "uninstallModule",
         "parameters": [
           {
-            "name": "name", 
+            "name": "name",
             "type": "string"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": true, 
-        "description": "Enumerate a module's slots, each with their name and whether a token is present", 
-        "name": "getModuleSlots", 
+        "async": true,
+        "description": "Enumerate a module's slots, each with their name and whether a token is present",
+        "name": "getModuleSlots",
         "parameters": [
           {
-            "name": "name", 
+            "name": "name",
             "type": "string"
           }
-        ], 
+        ],
         "type": "function"
       }
-    ], 
-    "namespace": "pkcs11", 
+    ],
+    "namespace": "pkcs11",
     "permissions": [
       "pkcs11"
     ]
-  }, 
+  },
   {
-    "namespace": "privacy", 
+    "namespace": "privacy",
     "permissions": [
       "privacy"
     ]
-  }, 
+  },
   {
-    "description": "Use the <code>browser.privacy</code> API to control usage of the features in the browser that can affect a user's privacy.", 
-    "namespace": "privacy.network", 
+    "description": "Use the <code>browser.privacy</code> API to control usage of the features in the browser that can affect a user's privacy.",
+    "namespace": "privacy.network",
     "permissions": [
       "privacy"
-    ], 
+    ],
     "properties": {
       "networkPredictionEnabled": {
-        "$ref": "types.Setting", 
+        "$ref": "types.Setting",
         "description": "If enabled, the browser attempts to speed up your web browsing experience by pre-resolving DNS entries, prerendering sites (<code>&lt;link rel='prefetch' ...&gt;</code>), and preemptively opening TCP and SSL connections to servers.  This preference's value is a boolean, defaulting to <code>true</code>."
-      }, 
+      },
       "peerConnectionEnabled": {
-        "$ref": "types.Setting", 
+        "$ref": "types.Setting",
         "description": "Allow users to enable and disable RTCPeerConnections (aka WebRTC)."
-      }, 
+      },
       "webRTCIPHandlingPolicy": {
-        "$ref": "types.Setting", 
+        "$ref": "types.Setting",
         "description": "Allow users to specify the media performance/privacy tradeoffs which impacts how WebRTC traffic will be routed and how much local address information is exposed. This preference's value is of type IPHandlingPolicy, defaulting to <code>default</code>."
       }
-    }, 
+    },
     "types": [
       {
-        "description": "The IP handling policy of WebRTC.", 
+        "description": "The IP handling policy of WebRTC.",
         "enum": [
-          "default", 
-          "default_public_and_private_interfaces", 
-          "default_public_interface_only", 
+          "default",
+          "default_public_and_private_interfaces",
+          "default_public_interface_only",
           "disable_non_proxied_udp"
-        ], 
-        "id": "IPHandlingPolicy", 
+        ],
+        "id": "IPHandlingPolicy",
         "type": "string"
       }
     ]
-  }, 
+  },
   {
-    "description": "Use the <code>browser.privacy</code> API to control usage of the features in the browser that can affect a user's privacy.", 
-    "namespace": "privacy.services", 
+    "description": "Use the <code>browser.privacy</code> API to control usage of the features in the browser that can affect a user's privacy.",
+    "namespace": "privacy.services",
     "permissions": [
       "privacy"
-    ], 
+    ],
     "properties": {
       "passwordSavingEnabled": {
-        "$ref": "types.Setting", 
+        "$ref": "types.Setting",
         "description": "If enabled, the password manager will ask if you want to save passwords. This preference's value is a boolean, defaulting to <code>true</code>."
       }
     }
-  }, 
+  },
   {
-    "description": "Use the <code>browser.privacy</code> API to control usage of the features in the browser that can affect a user's privacy.", 
-    "namespace": "privacy.websites", 
+    "description": "Use the <code>browser.privacy</code> API to control usage of the features in the browser that can affect a user's privacy.",
+    "namespace": "privacy.websites",
     "permissions": [
       "privacy"
-    ], 
+    ],
     "properties": {
+      "cookieConfig": {
+        "$ref": "types.Setting",
+        "description": "Allow users to specify the default settings for allowing cookies, as well as whether all cookies should be created as non-persistent cookies. This setting's value is of type CookieConfig."
+      },
       "firstPartyIsolate": {
-        "$ref": "types.Setting", 
+        "$ref": "types.Setting",
         "description": "If enabled, the browser will associate all data (including cookies, HSTS data, cached images, and more) for any third party domains with the domain in the address bar. This prevents third party trackers from using directly stored information to identify you across different websites, but may break websites where you login with a third party account (such as a Facebook or Google login.) The value of this preference is of type boolean, and the default value is <code>false</code>."
-      }, 
+      },
       "hyperlinkAuditingEnabled": {
-        "$ref": "types.Setting", 
+        "$ref": "types.Setting",
         "description": "If enabled, the browser sends auditing pings when requested by a website (<code>&lt;a ping&gt;</code>). The value of this preference is of type boolean, and the default value is <code>true</code>."
-      }, 
+      },
       "protectedContentEnabled": {
-        "$ref": "types.Setting", 
-        "description": "<strong>Available on Windows and ChromeOS only</strong>: If enabled, the browser provides a unique ID to plugins in order to run protected content. The value of this preference is of type boolean, and the default value is <code>true</code>.", 
+        "$ref": "types.Setting",
+        "description": "<strong>Available on Windows and ChromeOS only</strong>: If enabled, the browser provides a unique ID to plugins in order to run protected content. The value of this preference is of type boolean, and the default value is <code>true</code>.",
         "unsupported": true
-      }, 
+      },
       "referrersEnabled": {
-        "$ref": "types.Setting", 
+        "$ref": "types.Setting",
         "description": "If enabled, the browser sends <code>referer</code> headers with your requests. Yes, the name of this preference doesn't match the misspelled header. No, we're not going to change it. The value of this preference is of type boolean, and the default value is <code>true</code>."
-      }, 
+      },
       "resistFingerprinting": {
-        "$ref": "types.Setting", 
+        "$ref": "types.Setting",
         "description": "If enabled, the browser attempts to appear similar to other users by reporting generic information to websites. This can prevent websites from uniquely identifying users. Examples of data that is spoofed include number of CPU cores, precision of JavaScript timers, the local timezone, and disabling features such as GamePad support, and the WebSpeech and Navigator APIs. The value of this preference is of type boolean, and the default value is <code>false</code>."
-      }, 
+      },
       "thirdPartyCookiesAllowed": {
-        "$ref": "types.Setting", 
-        "description": "If disabled, the browser blocks third-party sites from setting cookies. The value of this preference is of type boolean, and the default value is <code>true</code>.", 
+        "$ref": "types.Setting",
+        "description": "If disabled, the browser blocks third-party sites from setting cookies. The value of this preference is of type boolean, and the default value is <code>true</code>.",
         "unsupported": true
-      }, 
+      },
       "trackingProtectionMode": {
-        "$ref": "types.Setting", 
+        "$ref": "types.Setting",
         "description": "Allow users to specify the mode for tracking protection. This setting's value is of type TrackingProtectionModeOption, defaulting to <code>private_browsing_only</code>."
       }
-    }, 
+    },
     "types": [
       {
-        "description": "The mode for tracking protection.", 
+        "description": "The mode for tracking protection.",
         "enum": [
-          "always", 
-          "never", 
+          "always",
+          "never",
           "private_browsing"
-        ], 
-        "id": "TrackingProtectionModeOption", 
+        ],
+        "id": "TrackingProtectionModeOption",
         "type": "string"
+      },
+      {
+        "description": "The settings for cookies.",
+        "id": "CookieConfig",
+        "properties": {
+          "behavior": {
+            "description": "The type of cookies to allow.",
+            "enum": [
+              "allow_all",
+              "reject_all",
+              "reject_third_party",
+              "allow_visited",
+              "reject_trackers"
+            ],
+            "optional": true,
+            "type": "string"
+          },
+          "nonPersistentCookies": {
+            "default": false,
+            "description": "Whether to create all cookies as nonPersistent (i.e., session) cookies.",
+            "optional": true,
+            "type": "boolean"
+          }
+        },
+        "type": "object"
       }
     ]
-  }, 
+  },
   {
-    "description": "Use the browser.proxy API to register proxy scripts in Firefox. Proxy scripts in Firefox are proxy auto-config files with extra contextual information and support for additional return types.", 
+    "description": "Use the browser.proxy API to register proxy scripts in Firefox. Proxy scripts in Firefox are proxy auto-config files with extra contextual information and support for additional return types.",
     "events": [
       {
-        "description": "Notifies about proxy script errors.", 
-        "name": "onProxyError", 
+        "description": "Fired when proxy data is needed for a request.",
+        "extraParameters": [
+          {
+            "$ref": "webRequest.RequestFilter",
+            "description": "A set of filters that restricts the events that will be sent to this listener.",
+            "name": "filter"
+          },
+          {
+            "description": "Array of extra information that should be passed to the listener function.",
+            "items": {
+              "enum": [
+                "requestHeaders"
+              ],
+              "type": "string"
+            },
+            "name": "extraInfoSpec",
+            "optional": true,
+            "type": "array"
+          }
+        ],
+        "name": "onRequest",
         "parameters": [
           {
-            "name": "error", 
+            "name": "details",
+            "properties": {
+              "cookieStoreId": {
+                "description": "The cookie store ID of the contextual identity.",
+                "optional": true,
+                "type": "string"
+              },
+              "documentUrl": {
+                "description": "URL of the page into which the requested resource will be loaded.",
+                "optional": true,
+                "type": "string"
+              },
+              "frameId": {
+                "description": "The value 0 indicates that the request happens in the main frame; a positive value indicates the ID of a subframe in which the request happens. If the document of a (sub-)frame is loaded (<code>type</code> is <code>main_frame</code> or <code>sub_frame</code>), <code>frameId</code> indicates the ID of this frame, not the ID of the outer frame. Frame IDs are unique within a tab.",
+                "type": "integer"
+              },
+              "fromCache": {
+                "description": "Indicates if this response was fetched from disk cache.",
+                "type": "boolean"
+              },
+              "incognito": {
+                "description": "True for private browsing requests.",
+                "optional": true,
+                "type": "boolean"
+              },
+              "ip": {
+                "description": "The server IP address that the request was actually sent to. Note that it may be a literal IPv6 address.",
+                "optional": true,
+                "type": "string"
+              },
+              "method": {
+                "description": "Standard HTTP method.",
+                "type": "string"
+              },
+              "originUrl": {
+                "description": "URL of the resource that triggered this request.",
+                "optional": true,
+                "type": "string"
+              },
+              "parentFrameId": {
+                "description": "ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists.",
+                "type": "integer"
+              },
+              "requestHeaders": {
+                "$ref": "webRequest.HttpHeaders",
+                "description": "The HTTP request headers that are going to be sent out with this request.",
+                "optional": true
+              },
+              "requestId": {
+                "description": "The ID of the request. Request IDs are unique within a browser session. As a result, they could be used to relate different events of the same request.",
+                "type": "string"
+              },
+              "tabId": {
+                "description": "The ID of the tab in which the request takes place. Set to -1 if the request isn't related to a tab.",
+                "type": "integer"
+              },
+              "timeStamp": {
+                "description": "The time when this signal is triggered, in milliseconds since the epoch.",
+                "type": "number"
+              },
+              "type": {
+                "$ref": "webRequest.ResourceType",
+                "description": "How the requested resource will be used."
+              },
+              "url": {
+                "type": "string"
+              }
+            },
             "type": "object"
           }
-        ], 
+        ],
+        "type": "function"
+      },
+      {
+        "description": "Notifies about errors caused by the invalid use of the proxy API.",
+        "name": "onError",
+        "parameters": [
+          {
+            "name": "error",
+            "type": "object"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "deprecated": "proxy.onProxyError has been deprecated and will be removed in Firefox 71. Use proxy.onError instead.",
+        "description": "Please use $(ref:proxy.onError).",
+        "name": "onProxyError",
+        "parameters": [
+          {
+            "name": "error",
+            "type": "object"
+          }
+        ],
         "type": "function"
       }
-    ], 
+    ],
     "functions": [
       {
-        "async": true, 
-        "description": "Registers the proxy script for the extension.", 
-        "name": "register", 
+        "async": true,
+        "deprecated": "proxy.register has been deprecated and will be removed in Firefox 71.",
+        "description": "Registers the proxy script for the extension.",
+        "name": "register",
         "parameters": [
           {
-            "format": "strictRelativeUrl", 
-            "name": "url", 
+            "format": "strictRelativeUrl",
+            "name": "url",
             "type": "string"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": true, 
-        "description": "Unregisters the proxy script for the extension.", 
-        "name": "unregister", 
-        "parameters": [], 
+        "async": true,
+        "deprecated": "proxy.unregister has been deprecated and will be removed in Firefox 71.",
+        "description": "Unregisters the proxy script for the extension.",
+        "name": "unregister",
+        "parameters": [],
         "type": "function"
-      }, 
+      },
       {
-        "async": true, 
-        "deprecated": "Please use $(ref:proxy.register)", 
-        "description": "Registers the proxy script for the extension.", 
-        "name": "registerProxyScript", 
+        "async": true,
+        "deprecated": "proxy.registerProxyScript has been deprecated and will be removed in Firefox 71.",
+        "description": "Registers the proxy script for the extension. This is an alias for proxy.register.",
+        "name": "registerProxyScript",
         "parameters": [
           {
-            "format": "strictRelativeUrl", 
-            "name": "url", 
+            "format": "strictRelativeUrl",
+            "name": "url",
             "type": "string"
           }
-        ], 
+        ],
         "type": "function"
       }
-    ], 
-    "namespace": "proxy", 
+    ],
+    "namespace": "proxy",
     "permissions": [
       "proxy"
+    ],
+    "properties": {
+      "settings": {
+        "$ref": "types.Setting",
+        "description": "Configures proxy settings. This setting's value is an object of type ProxyConfig."
+      }
+    },
+    "types": [
+      {
+        "description": "An object which describes proxy settings.",
+        "id": "ProxyConfig",
+        "properties": {
+          "autoConfigUrl": {
+            "description": "A URL to use to configure the proxy.",
+            "optional": true,
+            "type": "string"
+          },
+          "autoLogin": {
+            "description": "Do not prompt for authentication if password is saved.",
+            "optional": true,
+            "type": "boolean"
+          },
+          "ftp": {
+            "description": "The address of the ftp proxy, can include a port.",
+            "optional": true,
+            "type": "string"
+          },
+          "http": {
+            "description": "The address of the http proxy, can include a port.",
+            "optional": true,
+            "type": "string"
+          },
+          "httpProxyAll": {
+            "description": "Use the http proxy server for all protocols.",
+            "optional": true,
+            "type": "boolean"
+          },
+          "passthrough": {
+            "description": "A list of hosts which should not be proxied.",
+            "optional": true,
+            "type": "string"
+          },
+          "proxyDNS": {
+            "description": "Proxy DNS when using SOCKS v5.",
+            "optional": true,
+            "type": "boolean"
+          },
+          "proxyType": {
+            "description": "The type of proxy to use.",
+            "enum": [
+              "none",
+              "autoDetect",
+              "system",
+              "manual",
+              "autoConfig"
+            ],
+            "optional": true,
+            "type": "string"
+          },
+          "socks": {
+            "description": "The address of the socks proxy, can include a port.",
+            "optional": true,
+            "type": "string"
+          },
+          "socksVersion": {
+            "description": "The version of the socks proxy.",
+            "maximum": 5,
+            "minimum": 4,
+            "optional": true,
+            "type": "integer"
+          },
+          "ssl": {
+            "description": "The address of the ssl proxy, can include a port.",
+            "optional": true,
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }
     ]
-  }, 
+  },
   {
     "allowedContexts": [
-      "content", 
-      "devtools", 
+      "content",
+      "devtools",
       "proxy"
-    ], 
-    "description": "Use the <code>browser.runtime</code> API to retrieve the background page, return details about the manifest, and listen for and respond to events in the app or extension lifecycle. You can also use this API to convert the relative path of URLs to fully-qualified URLs.", 
+    ],
+    "description": "Use the <code>browser.runtime</code> API to retrieve the background page, return details about the manifest, and listen for and respond to events in the app or extension lifecycle. You can also use this API to convert the relative path of URLs to fully-qualified URLs.",
     "events": [
       {
-        "description": "Fired when a profile that has this extension installed first starts up. This event is not fired for incognito profiles.", 
-        "name": "onStartup", 
+        "description": "Fired when a profile that has this extension installed first starts up. This event is not fired for incognito profiles.",
+        "name": "onStartup",
         "type": "function"
-      }, 
+      },
       {
-        "description": "Fired when the extension is first installed, when the extension is updated to a new version, and when the browser is updated to a new version.", 
-        "name": "onInstalled", 
+        "description": "Fired when the extension is first installed, when the extension is updated to a new version, and when the browser is updated to a new version.",
+        "name": "onInstalled",
         "parameters": [
           {
-            "name": "details", 
+            "name": "details",
             "properties": {
               "id": {
-                "description": "Indicates the ID of the imported shared module extension which updated. This is present only if 'reason' is 'shared_module_update'.", 
-                "optional": true, 
-                "type": "string", 
+                "description": "Indicates the ID of the imported shared module extension which updated. This is present only if 'reason' is 'shared_module_update'.",
+                "optional": true,
+                "type": "string",
                 "unsupported": true
-              }, 
+              },
               "previousVersion": {
-                "description": "Indicates the previous version of the extension, which has just been updated. This is present only if 'reason' is 'update'.", 
-                "optional": true, 
+                "description": "Indicates the previous version of the extension, which has just been updated. This is present only if 'reason' is 'update'.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "reason": {
-                "$ref": "OnInstalledReason", 
+                "$ref": "OnInstalledReason",
                 "description": "The reason that this event is being dispatched."
-              }, 
+              },
               "temporary": {
-                "description": "Indicates whether the addon is installed as a temporary extension.", 
+                "description": "Indicates whether the addon is installed as a temporary extension.",
                 "type": "boolean"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Sent to the event page just before it is unloaded. This gives the extension opportunity to do some clean up. Note that since the page is unloading, any asynchronous operations started while handling this event are not guaranteed to complete. If more activity for the event page occurs before it gets unloaded the onSuspendCanceled event will be sent and the page won't be unloaded. ", 
-        "name": "onSuspend", 
-        "type": "function", 
+        "description": "Sent to the event page just before it is unloaded. This gives the extension opportunity to do some clean up. Note that since the page is unloading, any asynchronous operations started while handling this event are not guaranteed to complete. If more activity for the event page occurs before it gets unloaded the onSuspendCanceled event will be sent and the page won't be unloaded. ",
+        "name": "onSuspend",
+        "type": "function",
         "unsupported": true
-      }, 
+      },
       {
-        "description": "Sent after onSuspend to indicate that the app won't be unloaded after all.", 
-        "name": "onSuspendCanceled", 
-        "type": "function", 
+        "description": "Sent after onSuspend to indicate that the app won't be unloaded after all.",
+        "name": "onSuspendCanceled",
+        "type": "function",
         "unsupported": true
-      }, 
+      },
       {
-        "description": "Fired when an update is available, but isn't installed immediately because the app is currently running. If you do nothing, the update will be installed the next time the background page gets unloaded, if you want it to be installed sooner you can explicitly call $(ref:runtime.reload). If your extension is using a persistent background page, the background page of course never gets unloaded, so unless you call $(ref:runtime.reload) manually in response to this event the update will not get installed until the next time the browser itself restarts. If no handlers are listening for this event, and your extension has a persistent background page, it behaves as if $(ref:runtime.reload) is called in response to this event.", 
-        "name": "onUpdateAvailable", 
+        "description": "Fired when an update is available, but isn't installed immediately because the app is currently running. If you do nothing, the update will be installed the next time the background page gets unloaded, if you want it to be installed sooner you can explicitly call $(ref:runtime.reload). If your extension is using a persistent background page, the background page of course never gets unloaded, so unless you call $(ref:runtime.reload) manually in response to this event the update will not get installed until the next time the browser itself restarts. If no handlers are listening for this event, and your extension has a persistent background page, it behaves as if $(ref:runtime.reload) is called in response to this event.",
+        "name": "onUpdateAvailable",
         "parameters": [
           {
             "additionalProperties": {
               "type": "any"
-            }, 
-            "description": "The manifest details of the available update.", 
-            "name": "details", 
+            },
+            "description": "The manifest details of the available update.",
+            "name": "details",
             "properties": {
               "version": {
-                "description": "The version number of the available update.", 
+                "description": "The version number of the available update.",
                 "type": "string"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "deprecated": "Please use $(ref:runtime.onRestartRequired).", 
-        "description": "Fired when an update for the browser is available, but isn't installed immediately because a browser restart is required.", 
-        "name": "onBrowserUpdateAvailable", 
-        "parameters": [], 
-        "type": "function", 
+        "deprecated": "Please use $(ref:runtime.onRestartRequired).",
+        "description": "Fired when an update for the browser is available, but isn't installed immediately because a browser restart is required.",
+        "name": "onBrowserUpdateAvailable",
+        "parameters": [],
+        "type": "function",
         "unsupported": true
-      }, 
+      },
       {
         "allowedContexts": [
-          "content", 
+          "content",
           "devtools"
-        ], 
-        "description": "Fired when a connection is made from either an extension process or a content script.", 
-        "name": "onConnect", 
+        ],
+        "description": "Fired when a connection is made from either an extension process or a content script.",
+        "name": "onConnect",
         "parameters": [
           {
-            "$ref": "Port", 
+            "$ref": "Port",
             "name": "port"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Fired when a connection is made from another extension.", 
-        "name": "onConnectExternal", 
+        "description": "Fired when a connection is made from another extension.",
+        "name": "onConnectExternal",
         "parameters": [
           {
-            "$ref": "Port", 
+            "$ref": "Port",
             "name": "port"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
         "allowedContexts": [
-          "content", 
-          "devtools", 
+          "content",
+          "devtools",
           "proxy"
-        ], 
-        "description": "Fired when a message is sent from either an extension process or a content script.", 
-        "name": "onMessage", 
+        ],
+        "description": "Fired when a message is sent from either an extension process or a content script.",
+        "name": "onMessage",
         "parameters": [
           {
-            "description": "The message sent by the calling script.", 
-            "name": "message", 
-            "optional": true, 
+            "description": "The message sent by the calling script.",
+            "name": "message",
+            "optional": true,
             "type": "any"
-          }, 
+          },
           {
-            "$ref": "MessageSender", 
+            "$ref": "MessageSender",
             "name": "sender"
-          }, 
+          },
           {
-            "description": "Function to call (at most once) when you have a response. The argument should be any JSON-ifiable object. If you have more than one <code>onMessage</code> listener in the same document, then only one may send a response. This function becomes invalid when the event listener returns, unless you return true from the event listener to indicate you wish to send a response asynchronously (this will keep the message channel open to the other end until <code>sendResponse</code> is called).", 
-            "name": "sendResponse", 
+            "description": "Function to call (at most once) when you have a response. The argument should be any JSON-ifiable object. If you have more than one <code>onMessage</code> listener in the same document, then only one may send a response. This function becomes invalid when the event listener returns, unless you return true from the event listener to indicate you wish to send a response asynchronously (this will keep the message channel open to the other end until <code>sendResponse</code> is called).",
+            "name": "sendResponse",
             "type": "function"
           }
-        ], 
+        ],
         "returns": {
-          "description": "Return true from the event listener if you wish to call <code>sendResponse</code> after the event listener returns.", 
-          "optional": true, 
+          "description": "Return true from the event listener if you wish to call <code>sendResponse</code> after the event listener returns.",
+          "optional": true,
           "type": "boolean"
-        }, 
+        },
         "type": "function"
-      }, 
+      },
       {
-        "description": "Fired when a message is sent from another extension/app. Cannot be used in a content script.", 
-        "name": "onMessageExternal", 
+        "description": "Fired when a message is sent from another extension/app. Cannot be used in a content script.",
+        "name": "onMessageExternal",
         "parameters": [
           {
-            "description": "The message sent by the calling script.", 
-            "name": "message", 
-            "optional": true, 
+            "description": "The message sent by the calling script.",
+            "name": "message",
+            "optional": true,
             "type": "any"
-          }, 
+          },
           {
-            "$ref": "MessageSender", 
+            "$ref": "MessageSender",
             "name": "sender"
-          }, 
+          },
           {
-            "description": "Function to call (at most once) when you have a response. The argument should be any JSON-ifiable object. If you have more than one <code>onMessage</code> listener in the same document, then only one may send a response. This function becomes invalid when the event listener returns, unless you return true from the event listener to indicate you wish to send a response asynchronously (this will keep the message channel open to the other end until <code>sendResponse</code> is called).", 
-            "name": "sendResponse", 
+            "description": "Function to call (at most once) when you have a response. The argument should be any JSON-ifiable object. If you have more than one <code>onMessage</code> listener in the same document, then only one may send a response. This function becomes invalid when the event listener returns, unless you return true from the event listener to indicate you wish to send a response asynchronously (this will keep the message channel open to the other end until <code>sendResponse</code> is called).",
+            "name": "sendResponse",
             "type": "function"
           }
-        ], 
+        ],
         "returns": {
-          "description": "Return true from the event listener if you wish to call <code>sendResponse</code> after the event listener returns.", 
-          "optional": true, 
+          "description": "Return true from the event listener if you wish to call <code>sendResponse</code> after the event listener returns.",
+          "optional": true,
           "type": "boolean"
-        }, 
+        },
         "type": "function"
-      }, 
+      },
       {
-        "description": "Fired when an app or the device that it runs on needs to be restarted. The app should close all its windows at its earliest convenient time to let the restart to happen. If the app does nothing, a restart will be enforced after a 24-hour grace period has passed. Currently, this event is only fired for Chrome OS kiosk apps.", 
-        "name": "onRestartRequired", 
+        "description": "Fired when an app or the device that it runs on needs to be restarted. The app should close all its windows at its earliest convenient time to let the restart to happen. If the app does nothing, a restart will be enforced after a 24-hour grace period has passed. Currently, this event is only fired for Chrome OS kiosk apps.",
+        "name": "onRestartRequired",
         "parameters": [
           {
-            "$ref": "OnRestartRequiredReason", 
-            "description": "The reason that the event is being dispatched.", 
+            "$ref": "OnRestartRequiredReason",
+            "description": "The reason that the event is being dispatched.",
             "name": "reason"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
       }
-    ], 
+    ],
     "functions": [
       {
-        "async": "callback", 
-        "description": "Retrieves the JavaScript 'window' object for the background page running inside the current extension/app. If the background page is an event page, the system will ensure it is loaded before calling the callback. If there is no background page, an error is set.", 
-        "name": "getBackgroundPage", 
+        "async": "callback",
+        "description": "Retrieves the JavaScript 'window' object for the background page running inside the current extension/app. If the background page is an event page, the system will ensure it is loaded before calling the callback. If there is no background page, an error is set.",
+        "name": "getBackgroundPage",
         "parameters": [
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
                 "additionalProperties": {
                   "type": "any"
-                }, 
-                "description": "The JavaScript 'window' object for the background page.", 
-                "isInstanceOf": "Window", 
-                "name": "backgroundPage", 
-                "optional": true, 
+                },
+                "description": "The JavaScript 'window' object for the background page.",
+                "isInstanceOf": "Window",
+                "name": "backgroundPage",
+                "optional": true,
                 "type": "object"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "<p>Open your Extension's options page, if possible.</p><p>The precise behavior may depend on your manifest's <code>$(topic:optionsV2)[options_ui]</code> or <code>$(topic:options)[options_page]</code> key, or what the browser happens to support at the time.</p><p>If your Extension does not declare an options page, or the browser failed to create one for some other reason, the callback will set $(ref:lastError).</p>", 
-        "name": "openOptionsPage", 
+        "async": "callback",
+        "description": "<p>Open your Extension's options page, if possible.</p><p>The precise behavior may depend on your manifest's <code>$(topic:optionsV2)[options_ui]</code> or <code>$(topic:options)[options_page]</code> key, or what the browser happens to support at the time.</p><p>If your Extension does not declare an options page, or the browser failed to create one for some other reason, the callback will set $(ref:lastError).</p>",
+        "name": "openOptionsPage",
         "parameters": [
           {
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
         "allowedContexts": [
-          "content", 
+          "content",
           "devtools"
-        ], 
-        "description": "Returns details about the app or extension from the manifest. The object returned is a serialization of the full $(topic:manifest)[manifest file].", 
-        "name": "getManifest", 
-        "parameters": [], 
+        ],
+        "description": "Returns details about the app or extension from the manifest. The object returned is a serialization of the full $(topic:manifest)[manifest file].",
+        "name": "getManifest",
+        "parameters": [],
         "returns": {
           "additionalProperties": {
             "type": "any"
-          }, 
-          "description": "The manifest details.", 
-          "properties": {}, 
+          },
+          "description": "The manifest details.",
+          "properties": {},
           "type": "object"
-        }, 
+        },
         "type": "function"
-      }, 
+      },
       {
         "allowedContexts": [
-          "content", 
+          "content",
           "devtools"
-        ], 
-        "description": "Converts a relative path within an app/extension install directory to a fully-qualified URL.", 
-        "name": "getURL", 
+        ],
+        "description": "Converts a relative path within an app/extension install directory to a fully-qualified URL.",
+        "name": "getURL",
         "parameters": [
           {
-            "description": "A path to a resource within an app/extension expressed relative to its install directory.", 
-            "name": "path", 
+            "description": "A path to a resource within an app/extension expressed relative to its install directory.",
+            "name": "path",
             "type": "string"
           }
-        ], 
+        ],
         "returns": {
-          "description": "The fully-qualified URL to the resource.", 
+          "description": "The fully-qualified URL to the resource.",
           "type": "string"
-        }, 
+        },
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Sets the URL to be visited upon uninstallation. This may be used to clean up server-side data, do analytics, and implement surveys. Maximum 255 characters.", 
-        "name": "setUninstallURL", 
+        "async": "callback",
+        "description": "Sets the URL to be visited upon uninstallation. This may be used to clean up server-side data, do analytics, and implement surveys. Maximum 255 characters.",
+        "name": "setUninstallURL",
         "parameters": [
           {
-            "description": "URL to be opened after the extension is uninstalled. This URL must have an http: or https: scheme. Set an empty string to not open a new tab upon uninstallation.", 
-            "maxLength": 255, 
-            "name": "url", 
+            "description": "URL to be opened after the extension is uninstalled. This URL must have an http: or https: scheme. Set an empty string to not open a new tab upon uninstallation.",
+            "maxLength": 255,
+            "name": "url",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           {
-            "description": "Called when the uninstall URL is set. If the given URL is invalid, $(ref:runtime.lastError) will be set.", 
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "description": "Called when the uninstall URL is set. If the given URL is invalid, $(ref:runtime.lastError) will be set.",
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Reloads the app or extension.", 
-        "name": "reload", 
-        "parameters": [], 
+        "description": "Reloads the app or extension.",
+        "name": "reload",
+        "parameters": [],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Requests an update check for this app/extension.", 
-        "name": "requestUpdateCheck", 
+        "async": "callback",
+        "description": "Requests an update check for this app/extension.",
+        "name": "requestUpdateCheck",
         "parameters": [
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
-                "$ref": "RequestUpdateCheckStatus", 
-                "description": "Result of the update check.", 
+                "$ref": "RequestUpdateCheckStatus",
+                "description": "Result of the update check.",
                 "name": "status"
-              }, 
+              },
               {
-                "description": "If an update is available, this contains more information about the available update.", 
-                "name": "details", 
-                "optional": true, 
+                "description": "If an update is available, this contains more information about the available update.",
+                "name": "details",
+                "optional": true,
                 "properties": {
                   "version": {
-                    "description": "The version of the available update.", 
+                    "description": "The version of the available update.",
                     "type": "string"
                   }
-                }, 
+                },
                 "type": "object"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
-      }, 
+      },
       {
-        "description": "Restart the device when the app runs in kiosk mode. Otherwise, it's no-op.", 
-        "name": "restart", 
-        "parameters": [], 
-        "type": "function", 
+        "description": "Restart the device when the app runs in kiosk mode. Otherwise, it's no-op.",
+        "name": "restart",
+        "parameters": [],
+        "type": "function",
         "unsupported": true
-      }, 
+      },
       {
         "allowedContexts": [
-          "content", 
+          "content",
           "devtools"
-        ], 
-        "description": "Attempts to connect to connect listeners within an extension/app (such as the background page), or other extensions/apps. This is useful for content scripts connecting to their extension processes, inter-app/extension communication, and $(topic:manifest/externally_connectable)[web messaging]. Note that this does not connect to any listeners in a content script. Extensions may connect to content scripts embedded in tabs via $(ref:tabs.connect).", 
-        "name": "connect", 
+        ],
+        "description": "Attempts to connect to connect listeners within an extension/app (such as the background page), or other extensions/apps. This is useful for content scripts connecting to their extension processes, inter-app/extension communication, and $(topic:manifest/externally_connectable)[web messaging]. Note that this does not connect to any listeners in a content script. Extensions may connect to content scripts embedded in tabs via $(ref:tabs.connect).",
+        "name": "connect",
         "parameters": [
           {
-            "description": "The ID of the extension or app to connect to. If omitted, a connection will be attempted with your own extension. Required if sending messages from a web page for $(topic:manifest/externally_connectable)[web messaging].", 
-            "name": "extensionId", 
-            "optional": true, 
+            "description": "The ID of the extension or app to connect to. If omitted, a connection will be attempted with your own extension. Required if sending messages from a web page for $(topic:manifest/externally_connectable)[web messaging].",
+            "name": "extensionId",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           {
-            "name": "connectInfo", 
-            "optional": true, 
+            "name": "connectInfo",
+            "optional": true,
             "properties": {
               "includeTlsChannelId": {
-                "description": "Whether the TLS channel ID will be passed into onConnectExternal for processes that are listening for the connection event.", 
-                "optional": true, 
+                "description": "Whether the TLS channel ID will be passed into onConnectExternal for processes that are listening for the connection event.",
+                "optional": true,
                 "type": "boolean"
-              }, 
+              },
               "name": {
-                "description": "Will be passed into onConnect for processes that are listening for the connection event.", 
-                "optional": true, 
+                "description": "Will be passed into onConnect for processes that are listening for the connection event.",
+                "optional": true,
                 "type": "string"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "returns": {
-          "$ref": "Port", 
+          "$ref": "Port",
           "description": "Port through which messages can be sent and received. The port's $(ref:runtime.Port onDisconnect) event is fired if the extension/app does not exist. "
-        }, 
+        },
         "type": "function"
-      }, 
+      },
       {
-        "description": "Connects to a native application in the host machine.", 
-        "name": "connectNative", 
+        "allowedContexts": [
+          "content"
+        ],
+        "description": "Connects to a native application in the host machine.",
+        "name": "connectNative",
         "parameters": [
           {
-            "description": "The name of the registered application to connect to.", 
-            "name": "application", 
-            "pattern": "^\\w+(\\.\\w+)*$", 
+            "description": "The name of the registered application to connect to.",
+            "name": "application",
+            "pattern": "^\\w+(\\.\\w+)*$",
             "type": "string"
           }
-        ], 
+        ],
         "permissions": [
           "nativeMessaging"
-        ], 
+        ],
         "returns": {
-          "$ref": "Port", 
+          "$ref": "Port",
           "description": "Port through which messages can be sent and received with the application"
-        }, 
+        },
         "type": "function"
-      }, 
+      },
       {
-        "allowAmbiguousOptionalArguments": true, 
+        "allowAmbiguousOptionalArguments": true,
         "allowedContexts": [
-          "content", 
-          "devtools", 
+          "content",
+          "devtools",
           "proxy"
-        ], 
-        "async": "responseCallback", 
-        "description": "Sends a single message to event listeners within your extension/app or a different extension/app. Similar to $(ref:runtime.connect) but only sends a single message, with an optional response. If sending to your extension, the $(ref:runtime.onMessage) event will be fired in each page, or $(ref:runtime.onMessageExternal), if a different extension. Note that extensions cannot send messages to content scripts using this method. To send messages to content scripts, use $(ref:tabs.sendMessage).", 
-        "name": "sendMessage", 
+        ],
+        "async": "responseCallback",
+        "description": "Sends a single message to event listeners within your extension/app or a different extension/app. Similar to $(ref:runtime.connect) but only sends a single message, with an optional response. If sending to your extension, the $(ref:runtime.onMessage) event will be fired in each page, or $(ref:runtime.onMessageExternal), if a different extension. Note that extensions cannot send messages to content scripts using this method. To send messages to content scripts, use $(ref:tabs.sendMessage).",
+        "name": "sendMessage",
         "parameters": [
           {
-            "description": "The ID of the extension/app to send the message to. If omitted, the message will be sent to your own extension/app. Required if sending messages from a web page for $(topic:manifest/externally_connectable)[web messaging].", 
-            "name": "extensionId", 
-            "optional": true, 
+            "description": "The ID of the extension/app to send the message to. If omitted, the message will be sent to your own extension/app. Required if sending messages from a web page for $(topic:manifest/externally_connectable)[web messaging].",
+            "name": "extensionId",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           {
-            "name": "message", 
+            "name": "message",
             "type": "any"
-          }, 
+          },
           {
-            "name": "options", 
-            "optional": true, 
+            "name": "options",
+            "optional": true,
             "properties": {
               "includeTlsChannelId": {
-                "description": "Whether the TLS channel ID will be passed into onMessageExternal for processes that are listening for the connection event.", 
-                "optional": true, 
-                "type": "boolean", 
+                "description": "Whether the TLS channel ID will be passed into onMessageExternal for processes that are listening for the connection event.",
+                "optional": true,
+                "type": "boolean",
                 "unsupported": true
-              }, 
+              },
               "toProxyScript": {
-                "description": "If true, the message will be directed to the extension's proxy sandbox.", 
-                "optional": true, 
+                "description": "If true, the message will be directed to the extension's proxy sandbox.",
+                "optional": true,
                 "type": "boolean"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "name": "responseCallback", 
-            "optional": true, 
+            "name": "responseCallback",
+            "optional": true,
             "parameters": [
               {
-                "description": "The JSON response object sent by the handler of the message. If an error occurs while connecting to the extension, the callback will be called with no arguments and $(ref:runtime.lastError) will be set to the error message.", 
-                "name": "response", 
+                "description": "The JSON response object sent by the handler of the message. If an error occurs while connecting to the extension, the callback will be called with no arguments and $(ref:runtime.lastError) will be set to the error message.",
+                "name": "response",
                 "type": "any"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "responseCallback", 
-        "description": "Send a single message to a native application.", 
-        "name": "sendNativeMessage", 
+        "allowedContexts": [
+          "content"
+        ],
+        "async": "responseCallback",
+        "description": "Send a single message to a native application.",
+        "name": "sendNativeMessage",
         "parameters": [
           {
-            "description": "The name of the native messaging host.", 
-            "name": "application", 
-            "pattern": "^\\w+(\\.\\w+)*$", 
+            "description": "The name of the native messaging host.",
+            "name": "application",
+            "pattern": "^\\w+(\\.\\w+)*$",
             "type": "string"
-          }, 
+          },
           {
-            "description": "The message that will be passed to the native messaging host.", 
-            "name": "message", 
+            "description": "The message that will be passed to the native messaging host.",
+            "name": "message",
             "type": "any"
-          }, 
+          },
           {
-            "name": "responseCallback", 
-            "optional": true, 
+            "name": "responseCallback",
+            "optional": true,
             "parameters": [
               {
-                "description": "The response message sent by the native messaging host. If an error occurs while connecting to the native messaging host, the callback will be called with no arguments and $(ref:runtime.lastError) will be set to the error message.", 
-                "name": "response", 
+                "description": "The response message sent by the native messaging host. If an error occurs while connecting to the native messaging host, the callback will be called with no arguments and $(ref:runtime.lastError) will be set to the error message.",
+                "name": "response",
                 "type": "any"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "permissions": [
           "nativeMessaging"
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Returns information about the current browser.", 
-        "name": "getBrowserInfo", 
+        "async": "callback",
+        "description": "Returns information about the current browser.",
+        "name": "getBrowserInfo",
         "parameters": [
           {
-            "description": "Called with results", 
-            "name": "callback", 
+            "description": "Called with results",
+            "name": "callback",
             "parameters": [
               {
-                "$ref": "BrowserInfo", 
+                "$ref": "BrowserInfo",
                 "name": "browserInfo"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Returns information about the current platform.", 
-        "name": "getPlatformInfo", 
+        "async": "callback",
+        "description": "Returns information about the current platform.",
+        "name": "getPlatformInfo",
         "parameters": [
           {
-            "description": "Called with results", 
-            "name": "callback", 
+            "description": "Called with results",
+            "name": "callback",
             "parameters": [
               {
-                "$ref": "PlatformInfo", 
+                "$ref": "PlatformInfo",
                 "name": "platformInfo"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Returns a DirectoryEntry for the package directory.", 
-        "name": "getPackageDirectoryEntry", 
+        "async": "callback",
+        "description": "Returns a DirectoryEntry for the package directory.",
+        "name": "getPackageDirectoryEntry",
         "parameters": [
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
                 "additionalProperties": {
                   "type": "any"
-                }, 
-                "isInstanceOf": "DirectoryEntry", 
-                "name": "directoryEntry", 
+                },
+                "isInstanceOf": "DirectoryEntry",
+                "name": "directoryEntry",
                 "type": "object"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
       }
-    ], 
-    "namespace": "runtime", 
+    ],
+    "namespace": "runtime",
     "properties": {
       "id": {
         "allowedContexts": [
-          "content", 
+          "content",
           "devtools"
-        ], 
-        "description": "The ID of the extension/app.", 
+        ],
+        "description": "The ID of the extension/app.",
         "type": "string"
-      }, 
+      },
       "lastError": {
         "additionalProperties": {
           "type": "any"
-        }, 
+        },
         "allowedContexts": [
-          "content", 
+          "content",
           "devtools"
-        ], 
-        "description": "This will be defined during an API method callback if there was an error", 
-        "optional": true, 
+        ],
+        "description": "This will be defined during an API method callback if there was an error",
+        "optional": true,
         "properties": {
           "message": {
-            "description": "Details about the error which occurred.", 
-            "optional": true, 
+            "description": "Details about the error which occurred.",
+            "optional": true,
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
       }
-    }, 
+    },
     "types": [
       {
         "additionalProperties": {
           "type": "any"
-        }, 
+        },
         "allowedContexts": [
-          "content", 
+          "content",
           "devtools"
-        ], 
-        "description": "An object which allows two way communication with other pages.", 
-        "id": "Port", 
+        ],
+        "description": "An object which allows two way communication with other pages.",
+        "id": "Port",
         "properties": {
           "disconnect": {
             "type": "function"
-          }, 
+          },
           "name": {
             "type": "string"
-          }, 
+          },
           "onDisconnect": {
             "$ref": "events.Event"
-          }, 
+          },
           "onMessage": {
             "$ref": "events.Event"
-          }, 
+          },
           "postMessage": {
             "type": "function"
-          }, 
+          },
           "sender": {
-            "$ref": "MessageSender", 
-            "description": "This property will <b>only</b> be present on ports passed to onConnect/onConnectExternal listeners.", 
+            "$ref": "MessageSender",
+            "description": "This property will <b>only</b> be present on ports passed to onConnect/onConnectExternal listeners.",
             "optional": true
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       {
         "allowedContexts": [
-          "content", 
+          "content",
           "devtools"
-        ], 
-        "description": "An object containing information about the script context that sent a message or request.", 
-        "id": "MessageSender", 
+        ],
+        "description": "An object containing information about the script context that sent a message or request.",
+        "id": "MessageSender",
         "properties": {
           "frameId": {
-            "description": "The $(topic:frame_ids)[frame] that opened the connection. 0 for top-level frames, positive for child frames. This will only be set when <code>tab</code> is set.", 
-            "optional": true, 
+            "description": "The $(topic:frame_ids)[frame] that opened the connection. 0 for top-level frames, positive for child frames. This will only be set when <code>tab</code> is set.",
+            "optional": true,
             "type": "integer"
-          }, 
+          },
           "id": {
-            "description": "The ID of the extension or app that opened the connection, if any.", 
-            "optional": true, 
+            "description": "The ID of the extension or app that opened the connection, if any.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "tab": {
-            "$ref": "tabs.Tab", 
-            "description": "The $(ref:tabs.Tab) which opened the connection, if any. This property will <strong>only</strong> be present when the connection was opened from a tab (including content scripts), and <strong>only</strong> if the receiver is an extension, not an app.", 
+            "$ref": "tabs.Tab",
+            "description": "The $(ref:tabs.Tab) which opened the connection, if any. This property will <strong>only</strong> be present when the connection was opened from a tab (including content scripts), and <strong>only</strong> if the receiver is an extension, not an app.",
             "optional": true
-          }, 
+          },
           "tlsChannelId": {
-            "description": "The TLS channel ID of the page or frame that opened the connection, if requested by the extension or app, and if available.", 
-            "optional": true, 
-            "type": "string", 
+            "description": "The TLS channel ID of the page or frame that opened the connection, if requested by the extension or app, and if available.",
+            "optional": true,
+            "type": "string",
             "unsupported": true
-          }, 
+          },
           "url": {
-            "description": "The URL of the page or frame that opened the connection. If the sender is in an iframe, it will be iframe's URL not the URL of the page which hosts it.", 
-            "optional": true, 
+            "description": "The URL of the page or frame that opened the connection. If the sender is in an iframe, it will be iframe's URL not the URL of the page which hosts it.",
+            "optional": true,
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       {
         "allowedContexts": [
-          "content", 
+          "content",
           "devtools"
-        ], 
-        "description": "The operating system the browser is running on.", 
+        ],
+        "description": "The operating system the browser is running on.",
         "enum": [
-          "mac", 
-          "win", 
-          "android", 
-          "cros", 
-          "linux", 
+          "mac",
+          "win",
+          "android",
+          "cros",
+          "linux",
           "openbsd"
-        ], 
-        "id": "PlatformOs", 
+        ],
+        "id": "PlatformOs",
         "type": "string"
-      }, 
+      },
       {
         "allowedContexts": [
-          "content", 
+          "content",
           "devtools"
-        ], 
-        "description": "The machine's processor architecture.", 
+        ],
+        "description": "The machine's processor architecture.",
         "enum": [
-          "arm", 
-          "x86-32", 
+          "arm",
+          "x86-32",
           "x86-64"
-        ], 
-        "id": "PlatformArch", 
+        ],
+        "id": "PlatformArch",
         "type": "string"
-      }, 
+      },
       {
         "allowedContexts": [
-          "content", 
+          "content",
           "devtools"
-        ], 
-        "description": "An object containing information about the current platform.", 
-        "id": "PlatformInfo", 
+        ],
+        "description": "An object containing information about the current platform.",
+        "id": "PlatformInfo",
         "properties": {
           "arch": {
-            "$ref": "PlatformArch", 
+            "$ref": "PlatformArch",
             "description": "The machine's processor architecture."
-          }, 
+          },
           "nacl_arch": {
-            "$ref": "PlatformNaclArch", 
-            "description": "The native client architecture. This may be different from arch on some platforms.", 
+            "$ref": "PlatformNaclArch",
+            "description": "The native client architecture. This may be different from arch on some platforms.",
             "unsupported": true
-          }, 
+          },
           "os": {
-            "$ref": "PlatformOs", 
+            "$ref": "PlatformOs",
             "description": "The operating system the browser is running on."
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       {
-        "description": "An object containing information about the current browser.", 
-        "id": "BrowserInfo", 
+        "description": "An object containing information about the current browser.",
+        "id": "BrowserInfo",
         "properties": {
           "buildID": {
-            "description": "The browser's build ID/date, for example '20160101'.", 
+            "description": "The browser's build ID/date, for example '20160101'.",
             "type": "string"
-          }, 
+          },
           "name": {
-            "description": "The name of the browser, for example 'Firefox'.", 
+            "description": "The name of the browser, for example 'Firefox'.",
             "type": "string"
-          }, 
+          },
           "vendor": {
-            "description": "The name of the browser vendor, for example 'Mozilla'.", 
+            "description": "The name of the browser vendor, for example 'Mozilla'.",
             "type": "string"
-          }, 
+          },
           "version": {
-            "description": "The browser's version, for example '42.0.0' or '0.8.1pre'.", 
+            "description": "The browser's version, for example '42.0.0' or '0.8.1pre'.",
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       {
         "allowedContexts": [
-          "content", 
+          "content",
           "devtools"
-        ], 
-        "description": "Result of the update check.", 
+        ],
+        "description": "Result of the update check.",
         "enum": [
-          "throttled", 
-          "no_update", 
+          "throttled",
+          "no_update",
           "update_available"
-        ], 
-        "id": "RequestUpdateCheckStatus", 
+        ],
+        "id": "RequestUpdateCheckStatus",
         "type": "string"
-      }, 
+      },
       {
         "allowedContexts": [
-          "content", 
+          "content",
           "devtools"
-        ], 
-        "description": "The reason that this event is being dispatched.", 
+        ],
+        "description": "The reason that this event is being dispatched.",
         "enum": [
-          "install", 
-          "update", 
+          "install",
+          "update",
           "browser_update"
-        ], 
-        "id": "OnInstalledReason", 
+        ],
+        "id": "OnInstalledReason",
         "type": "string"
-      }, 
+      },
       {
         "allowedContexts": [
-          "content", 
+          "content",
           "devtools"
-        ], 
-        "description": "The reason that the event is being dispatched. 'app_update' is used when the restart is needed because the application is updated to a newer version. 'os_update' is used when the restart is needed because the browser/OS is updated to a newer version. 'periodic' is used when the system runs for more than the permitted uptime set in the enterprise policy.", 
+        ],
+        "description": "The reason that the event is being dispatched. 'app_update' is used when the restart is needed because the application is updated to a newer version. 'os_update' is used when the restart is needed because the browser/OS is updated to a newer version. 'periodic' is used when the system runs for more than the permitted uptime set in the enterprise policy.",
         "enum": [
-          "app_update", 
-          "os_update", 
+          "app_update",
+          "os_update",
           "periodic"
-        ], 
-        "id": "OnRestartRequiredReason", 
+        ],
+        "id": "OnRestartRequiredReason",
         "type": "string"
       }
     ]
-  }, 
+  },
   {
-    "description": "Use the <code>chrome.sessions</code> API to query and restore tabs and windows from a browsing session.", 
-    "events": [
-      {
-        "description": "Fired when recently closed tabs and/or windows are changed. This event does not monitor synced sessions changes.", 
-        "name": "onChanged", 
-        "type": "function"
-      }
-    ], 
+    "description": "Use browser.search to interact with search engines.",
     "functions": [
       {
-        "async": true, 
-        "description": "Forget a recently closed tab.", 
-        "name": "forgetClosedTab", 
-        "parameters": [
-          {
-            "description": "The windowId of the window to which the recently closed tab to be forgotten belongs.", 
-            "name": "windowId", 
-            "type": "integer"
-          }, 
-          {
-            "description": "The sessionId (closedId) of the recently closed tab to be forgotten.", 
-            "name": "sessionId", 
-            "type": "string"
-          }
-        ], 
+        "async": true,
+        "description": "Gets a list of search engines.",
+        "name": "get",
+        "parameters": [],
         "type": "function"
-      }, 
+      },
       {
-        "async": true, 
-        "description": "Forget a recently closed window.", 
-        "name": "forgetClosedWindow", 
+        "async": true,
+        "description": "Perform a search.",
+        "name": "search",
         "parameters": [
           {
-            "description": "The sessionId (closedId) of the recently closed window to be forgotten.", 
-            "name": "sessionId", 
-            "type": "string"
-          }
-        ], 
-        "type": "function"
-      }, 
-      {
-        "async": "callback", 
-        "description": "Gets the list of recently closed tabs and/or windows.", 
-        "name": "getRecentlyClosed", 
-        "parameters": [
-          {
-            "$ref": "Filter", 
-            "default": {}, 
-            "name": "filter", 
-            "optional": true
-          }, 
-          {
-            "name": "callback", 
-            "parameters": [
-              {
-                "description": "The list of closed entries in reverse order that they were closed (the most recently closed tab or window will be at index <code>0</code>). The entries may contain either tabs or windows.", 
-                "items": {
-                  "$ref": "Session"
-                }, 
-                "name": "sessions", 
-                "type": "array"
+            "name": "searchProperties",
+            "properties": {
+              "engine": {
+                "description": "Search engine to use. Uses the default if not specified.",
+                "optional": true,
+                "type": "string"
+              },
+              "query": {
+                "description": "Terms to search for.",
+                "type": "string"
+              },
+              "tabId": {
+                "description": "The ID of the tab for the search results. If not specified, a new tab is created.",
+                "optional": true,
+                "type": "integer"
               }
-            ], 
-            "type": "function"
+            },
+            "type": "object"
           }
-        ], 
-        "type": "function"
-      }, 
-      {
-        "async": "callback", 
-        "description": "Retrieves all devices with synced sessions.", 
-        "name": "getDevices", 
-        "parameters": [
-          {
-            "$ref": "Filter", 
-            "name": "filter", 
-            "optional": true
-          }, 
-          {
-            "name": "callback", 
-            "parameters": [
-              {
-                "description": "The list of $(ref:sessions.Device) objects for each synced session, sorted in order from device with most recently modified session to device with least recently modified session. $(ref:tabs.Tab) objects are sorted by recency in the $(ref:windows.Window) of the $(ref:sessions.Session) objects.", 
-                "items": {
-                  "$ref": "Device"
-                }, 
-                "name": "devices", 
-                "type": "array"
-              }
-            ], 
-            "type": "function"
-          }
-        ], 
-        "type": "function", 
-        "unsupported": true
-      }, 
-      {
-        "async": "callback", 
-        "description": "Reopens a $(ref:windows.Window) or $(ref:tabs.Tab), with an optional callback to run when the entry has been restored.", 
-        "name": "restore", 
-        "parameters": [
-          {
-            "description": "The $(ref:windows.Window.sessionId), or $(ref:tabs.Tab.sessionId) to restore. If this parameter is not specified, the most recently closed session is restored.", 
-            "name": "sessionId", 
-            "optional": true, 
-            "type": "string"
-          }, 
-          {
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [
-              {
-                "$ref": "Session", 
-                "description": "A $(ref:sessions.Session) containing the restored $(ref:windows.Window) or $(ref:tabs.Tab) object.", 
-                "name": "restoredSession"
-              }
-            ], 
-            "type": "function"
-          }
-        ], 
-        "type": "function"
-      }, 
-      {
-        "async": true, 
-        "description": "Set a key/value pair on a given tab.", 
-        "name": "setTabValue", 
-        "parameters": [
-          {
-            "description": "The id of the tab that the key/value pair is being set on.", 
-            "minimum": 0, 
-            "name": "tabId", 
-            "type": "integer"
-          }, 
-          {
-            "description": "The key which corresponds to the value being set.", 
-            "name": "key", 
-            "type": "string"
-          }, 
-          {
-            "description": "The value being set.", 
-            "name": "value", 
-            "type": "any"
-          }
-        ], 
-        "type": "function"
-      }, 
-      {
-        "async": true, 
-        "description": "Retrieve a value that was set for a given key on a given tab.", 
-        "name": "getTabValue", 
-        "parameters": [
-          {
-            "description": "The id of the tab whose value is being retrieved from.", 
-            "minimum": 0, 
-            "name": "tabId", 
-            "type": "integer"
-          }, 
-          {
-            "description": "The key which corresponds to the value.", 
-            "name": "key", 
-            "type": "string"
-          }
-        ], 
-        "type": "function"
-      }, 
-      {
-        "async": true, 
-        "description": "Remove a key/value pair that was set on a given tab.", 
-        "name": "removeTabValue", 
-        "parameters": [
-          {
-            "description": "The id of the tab whose key/value pair is being removed.", 
-            "minimum": 0, 
-            "name": "tabId", 
-            "type": "integer"
-          }, 
-          {
-            "description": "The key which corresponds to the value.", 
-            "name": "key", 
-            "type": "string"
-          }
-        ], 
-        "type": "function"
-      }, 
-      {
-        "async": true, 
-        "description": "Set a key/value pair on a given window.", 
-        "name": "setWindowValue", 
-        "parameters": [
-          {
-            "description": "The id of the window that the key/value pair is being set on.", 
-            "minimum": -2, 
-            "name": "windowId", 
-            "type": "integer"
-          }, 
-          {
-            "description": "The key which corresponds to the value being set.", 
-            "name": "key", 
-            "type": "string"
-          }, 
-          {
-            "description": "The value being set.", 
-            "name": "value", 
-            "type": "any"
-          }
-        ], 
-        "type": "function"
-      }, 
-      {
-        "async": true, 
-        "description": "Retrieve a value that was set for a given key on a given window.", 
-        "name": "getWindowValue", 
-        "parameters": [
-          {
-            "description": "The id of the window whose value is being retrieved from.", 
-            "minimum": -2, 
-            "name": "windowId", 
-            "type": "integer"
-          }, 
-          {
-            "description": "The key which corresponds to the value.", 
-            "name": "key", 
-            "type": "string"
-          }
-        ], 
-        "type": "function"
-      }, 
-      {
-        "async": true, 
-        "description": "Remove a key/value pair that was set on a given window.", 
-        "name": "removeWindowValue", 
-        "parameters": [
-          {
-            "description": "The id of the window whose key/value pair is being removed.", 
-            "minimum": -2, 
-            "name": "windowId", 
-            "type": "integer"
-          }, 
-          {
-            "description": "The key which corresponds to the value.", 
-            "name": "key", 
-            "type": "string"
-          }
-        ], 
+        ],
         "type": "function"
       }
-    ], 
-    "namespace": "sessions", 
+    ],
+    "namespace": "search",
     "permissions": [
-      "sessions"
-    ], 
-    "properties": {
-      "MAX_SESSION_RESULTS": {
-        "description": "The maximum number of $(ref:sessions.Session) that will be included in a requested list.", 
-        "value": 25
-      }
-    }, 
+      "search"
+    ],
     "types": [
       {
-        "id": "Filter", 
+        "description": "An object encapsulating a search engine",
+        "id": "SearchEngine",
         "properties": {
-          "maxResults": {
-            "description": "The maximum number of entries to be fetched in the requested list. Omit this parameter to fetch the maximum number of entries ($(ref:sessions.MAX_SESSION_RESULTS)).", 
-            "maximum": 25, 
-            "minimum": 0, 
-            "optional": true, 
-            "type": "integer"
-          }
-        }, 
-        "type": "object"
-      }, 
-      {
-        "id": "Session", 
-        "properties": {
-          "lastModified": {
-            "description": "The time when the window or tab was closed or modified, represented in milliseconds since the epoch.", 
-            "type": "integer"
-          }, 
-          "tab": {
-            "$ref": "tabs.Tab", 
-            "description": "The $(ref:tabs.Tab), if this entry describes a tab. Either this or $(ref:sessions.Session.window) will be set.", 
-            "optional": true
-          }, 
-          "window": {
-            "$ref": "windows.Window", 
-            "description": "The $(ref:windows.Window), if this entry describes a window. Either this or $(ref:sessions.Session.tab) will be set.", 
-            "optional": true
-          }
-        }, 
-        "type": "object"
-      }, 
-      {
-        "id": "Device", 
-        "properties": {
-          "deviceName": {
-            "description": "The name of the foreign device.", 
+          "alias": {
+            "optional": true,
             "type": "string"
-          }, 
-          "info": {
+          },
+          "favIconUrl": {
+            "format": "url",
+            "optional": true,
             "type": "string"
-          }, 
-          "sessions": {
-            "description": "A list of open window sessions for the foreign device, sorted from most recently to least recently modified session.", 
-            "items": {
-              "$ref": "Session"
-            }, 
-            "type": "array"
+          },
+          "isDefault": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
           }
-        }, 
+        },
         "type": "object"
       }
     ]
-  }, 
+  },
   {
-    "description": "Use sidebar actions to add a sidebar to Firefox.", 
+    "description": "Use the <code>chrome.sessions</code> API to query and restore tabs and windows from a browsing session.",
+    "events": [
+      {
+        "description": "Fired when recently closed tabs and/or windows are changed. This event does not monitor synced sessions changes.",
+        "name": "onChanged",
+        "type": "function"
+      }
+    ],
     "functions": [
       {
-        "async": true, 
-        "description": "Sets the title of the sidebar action. This shows up in the tooltip.", 
-        "name": "setTitle", 
+        "async": true,
+        "description": "Forget a recently closed tab.",
+        "name": "forgetClosedTab",
         "parameters": [
           {
-            "name": "details", 
+            "description": "The windowId of the window to which the recently closed tab to be forgotten belongs.",
+            "name": "windowId",
+            "type": "integer"
+          },
+          {
+            "description": "The sessionId (closedId) of the recently closed tab to be forgotten.",
+            "name": "sessionId",
+            "type": "string"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": true,
+        "description": "Forget a recently closed window.",
+        "name": "forgetClosedWindow",
+        "parameters": [
+          {
+            "description": "The sessionId (closedId) of the recently closed window to be forgotten.",
+            "name": "sessionId",
+            "type": "string"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": "callback",
+        "description": "Gets the list of recently closed tabs and/or windows.",
+        "name": "getRecentlyClosed",
+        "parameters": [
+          {
+            "$ref": "Filter",
+            "default": {},
+            "name": "filter",
+            "optional": true
+          },
+          {
+            "name": "callback",
+            "parameters": [
+              {
+                "description": "The list of closed entries in reverse order that they were closed (the most recently closed tab or window will be at index <code>0</code>). The entries may contain either tabs or windows.",
+                "items": {
+                  "$ref": "Session"
+                },
+                "name": "sessions",
+                "type": "array"
+              }
+            ],
+            "type": "function"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": "callback",
+        "description": "Retrieves all devices with synced sessions.",
+        "name": "getDevices",
+        "parameters": [
+          {
+            "$ref": "Filter",
+            "name": "filter",
+            "optional": true
+          },
+          {
+            "name": "callback",
+            "parameters": [
+              {
+                "description": "The list of $(ref:sessions.Device) objects for each synced session, sorted in order from device with most recently modified session to device with least recently modified session. $(ref:tabs.Tab) objects are sorted by recency in the $(ref:windows.Window) of the $(ref:sessions.Session) objects.",
+                "items": {
+                  "$ref": "Device"
+                },
+                "name": "devices",
+                "type": "array"
+              }
+            ],
+            "type": "function"
+          }
+        ],
+        "type": "function",
+        "unsupported": true
+      },
+      {
+        "async": "callback",
+        "description": "Reopens a $(ref:windows.Window) or $(ref:tabs.Tab), with an optional callback to run when the entry has been restored.",
+        "name": "restore",
+        "parameters": [
+          {
+            "description": "The $(ref:windows.Window.sessionId), or $(ref:tabs.Tab.sessionId) to restore. If this parameter is not specified, the most recently closed session is restored.",
+            "name": "sessionId",
+            "optional": true,
+            "type": "string"
+          },
+          {
+            "name": "callback",
+            "optional": true,
+            "parameters": [
+              {
+                "$ref": "Session",
+                "description": "A $(ref:sessions.Session) containing the restored $(ref:windows.Window) or $(ref:tabs.Tab) object.",
+                "name": "restoredSession"
+              }
+            ],
+            "type": "function"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": true,
+        "description": "Set a key/value pair on a given tab.",
+        "name": "setTabValue",
+        "parameters": [
+          {
+            "description": "The id of the tab that the key/value pair is being set on.",
+            "minimum": 0,
+            "name": "tabId",
+            "type": "integer"
+          },
+          {
+            "description": "The key which corresponds to the value being set.",
+            "name": "key",
+            "type": "string"
+          },
+          {
+            "description": "The value being set.",
+            "name": "value",
+            "type": "any"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": true,
+        "description": "Retrieve a value that was set for a given key on a given tab.",
+        "name": "getTabValue",
+        "parameters": [
+          {
+            "description": "The id of the tab whose value is being retrieved from.",
+            "minimum": 0,
+            "name": "tabId",
+            "type": "integer"
+          },
+          {
+            "description": "The key which corresponds to the value.",
+            "name": "key",
+            "type": "string"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": true,
+        "description": "Remove a key/value pair that was set on a given tab.",
+        "name": "removeTabValue",
+        "parameters": [
+          {
+            "description": "The id of the tab whose key/value pair is being removed.",
+            "minimum": 0,
+            "name": "tabId",
+            "type": "integer"
+          },
+          {
+            "description": "The key which corresponds to the value.",
+            "name": "key",
+            "type": "string"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": true,
+        "description": "Set a key/value pair on a given window.",
+        "name": "setWindowValue",
+        "parameters": [
+          {
+            "description": "The id of the window that the key/value pair is being set on.",
+            "minimum": -2,
+            "name": "windowId",
+            "type": "integer"
+          },
+          {
+            "description": "The key which corresponds to the value being set.",
+            "name": "key",
+            "type": "string"
+          },
+          {
+            "description": "The value being set.",
+            "name": "value",
+            "type": "any"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": true,
+        "description": "Retrieve a value that was set for a given key on a given window.",
+        "name": "getWindowValue",
+        "parameters": [
+          {
+            "description": "The id of the window whose value is being retrieved from.",
+            "minimum": -2,
+            "name": "windowId",
+            "type": "integer"
+          },
+          {
+            "description": "The key which corresponds to the value.",
+            "name": "key",
+            "type": "string"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": true,
+        "description": "Remove a key/value pair that was set on a given window.",
+        "name": "removeWindowValue",
+        "parameters": [
+          {
+            "description": "The id of the window whose key/value pair is being removed.",
+            "minimum": -2,
+            "name": "windowId",
+            "type": "integer"
+          },
+          {
+            "description": "The key which corresponds to the value.",
+            "name": "key",
+            "type": "string"
+          }
+        ],
+        "type": "function"
+      }
+    ],
+    "namespace": "sessions",
+    "permissions": [
+      "sessions"
+    ],
+    "properties": {
+      "MAX_SESSION_RESULTS": {
+        "description": "The maximum number of $(ref:sessions.Session) that will be included in a requested list.",
+        "value": 25
+      }
+    },
+    "types": [
+      {
+        "id": "Filter",
+        "properties": {
+          "maxResults": {
+            "description": "The maximum number of entries to be fetched in the requested list. Omit this parameter to fetch the maximum number of entries ($(ref:sessions.MAX_SESSION_RESULTS)).",
+            "maximum": 25,
+            "minimum": 0,
+            "optional": true,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      {
+        "id": "Session",
+        "properties": {
+          "lastModified": {
+            "description": "The time when the window or tab was closed or modified, represented in milliseconds since the epoch.",
+            "type": "integer"
+          },
+          "tab": {
+            "$ref": "tabs.Tab",
+            "description": "The $(ref:tabs.Tab), if this entry describes a tab. Either this or $(ref:sessions.Session.window) will be set.",
+            "optional": true
+          },
+          "window": {
+            "$ref": "windows.Window",
+            "description": "The $(ref:windows.Window), if this entry describes a window. Either this or $(ref:sessions.Session.tab) will be set.",
+            "optional": true
+          }
+        },
+        "type": "object"
+      },
+      {
+        "id": "Device",
+        "properties": {
+          "deviceName": {
+            "description": "The name of the foreign device.",
+            "type": "string"
+          },
+          "info": {
+            "type": "string"
+          },
+          "sessions": {
+            "description": "A list of open window sessions for the foreign device, sorted from most recently to least recently modified session.",
+            "items": {
+              "$ref": "Session"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      }
+    ]
+  },
+  {
+    "description": "Use sidebar actions to add a sidebar to Firefox.",
+    "functions": [
+      {
+        "async": true,
+        "description": "Sets the title of the sidebar action. This shows up in the tooltip.",
+        "name": "setTitle",
+        "parameters": [
+          {
+            "name": "details",
             "properties": {
               "tabId": {
-                "description": "Sets the sidebar title for the tab specified by tabId. Automatically resets when the tab is closed.", 
-                "optional": true, 
+                "description": "Sets the sidebar title for the tab specified by tabId. Automatically resets when the tab is closed.",
+                "optional": true,
                 "type": "integer"
-              }, 
+              },
               "title": {
-                "description": "The string the sidebar action should display when moused over.", 
-                "type": "string"
-              }
-            }, 
-            "type": "object"
-          }
-        ], 
-        "type": "function"
-      }, 
-      {
-        "async": true, 
-        "description": "Gets the title of the sidebar action.", 
-        "name": "getTitle", 
-        "parameters": [
-          {
-            "name": "details", 
-            "properties": {
-              "tabId": {
-                "description": "Specify the tab to get the title from. If no tab is specified, the non-tab-specific title is returned.", 
-                "optional": true, 
+                "choices": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "The string the sidebar action should display when moused over."
+              },
+              "windowId": {
+                "description": "Sets the sidebar title for the window specified by windowId.",
+                "minimum": -2,
+                "optional": true,
                 "type": "integer"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": true, 
-        "description": "Sets the icon for the sidebar action. The icon can be specified either as the path to an image file or as the pixel data from a canvas element, or as dictionary of either one of those. Either the <strong>path</strong> or the <strong>imageData</strong> property must be specified.", 
-        "name": "setIcon", 
+        "async": true,
+        "description": "Gets the title of the sidebar action.",
+        "name": "getTitle",
         "parameters": [
           {
-            "name": "details", 
+            "name": "details",
+            "properties": {
+              "tabId": {
+                "description": "Specify the tab to get the title from. If no tab nor window is specified, the global title is returned.",
+                "optional": true,
+                "type": "integer"
+              },
+              "windowId": {
+                "description": "Specify the window to get the title from. If no tab nor window is specified, the global title is returned.",
+                "minimum": -2,
+                "optional": true,
+                "type": "integer"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": true,
+        "description": "Sets the icon for the sidebar action. The icon can be specified either as the path to an image file or as the pixel data from a canvas element, or as dictionary of either one of those. Either the <strong>path</strong> or the <strong>imageData</strong> property must be specified.",
+        "name": "setIcon",
+        "parameters": [
+          {
+            "name": "details",
             "properties": {
               "imageData": {
                 "choices": [
                   {
                     "$ref": "ImageDataType"
-                  }, 
+                  },
                   {
-                    "additionalProperties": false, 
+                    "additionalProperties": false,
                     "patternProperties": {
                       "^[1-9]\\d*$": {
                         "$ref": "ImageDataType"
                       }
-                    }, 
+                    },
                     "type": "object"
                   }
-                ], 
-                "description": "Either an ImageData object or a dictionary {size -> ImageData} representing icon to be set. If the icon is specified as a dictionary, the actual image to be used is chosen depending on screen's pixel density. If the number of image pixels that fit into one screen space unit equals <code>scale</code>, then image with size <code>scale</code> * 19 will be selected. Initially only scales 1 and 2 will be supported. At least one image must be specified. Note that 'details.imageData = foo' is equivalent to 'details.imageData = {'19': foo}'", 
+                ],
+                "description": "Either an ImageData object or a dictionary {size -> ImageData} representing icon to be set. If the icon is specified as a dictionary, the actual image to be used is chosen depending on screen's pixel density. If the number of image pixels that fit into one screen space unit equals <code>scale</code>, then image with size <code>scale</code> * 19 will be selected. Initially only scales 1 and 2 will be supported. At least one image must be specified. Note that 'details.imageData = foo' is equivalent to 'details.imageData = {'19': foo}'",
                 "optional": true
-              }, 
+              },
               "path": {
                 "choices": [
                   {
                     "type": "string"
-                  }, 
+                  },
                   {
                     "additionalProperties": {
                       "type": "string"
-                    }, 
+                    },
                     "type": "object"
                   }
-                ], 
-                "description": "Either a relative image path or a dictionary {size -> relative image path} pointing to icon to be set. If the icon is specified as a dictionary, the actual image to be used is chosen depending on screen's pixel density. If the number of image pixels that fit into one screen space unit equals <code>scale</code>, then image with size <code>scale</code> * 19 will be selected. Initially only scales 1 and 2 will be supported. At least one image must be specified. Note that 'details.path = foo' is equivalent to 'details.imageData = {'19': foo}'", 
+                ],
+                "description": "Either a relative image path or a dictionary {size -> relative image path} pointing to icon to be set. If the icon is specified as a dictionary, the actual image to be used is chosen depending on screen's pixel density. If the number of image pixels that fit into one screen space unit equals <code>scale</code>, then image with size <code>scale</code> * 19 will be selected. Initially only scales 1 and 2 will be supported. At least one image must be specified. Note that 'details.path = foo' is equivalent to 'details.imageData = {'19': foo}'",
                 "optional": true
-              }, 
+              },
               "tabId": {
-                "description": "Sets the sidebar icon for the tab specified by tabId. Automatically resets when the tab is closed.", 
-                "optional": true, 
+                "description": "Sets the sidebar icon for the tab specified by tabId. Automatically resets when the tab is closed.",
+                "optional": true,
+                "type": "integer"
+              },
+              "windowId": {
+                "description": "Sets the sidebar icon for the window specified by windowId.",
+                "minimum": -2,
+                "optional": true,
                 "type": "integer"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": true, 
-        "description": "Sets the url to the html document to be opened in the sidebar when the user clicks on the sidebar action's icon.", 
-        "name": "setPanel", 
+        "async": true,
+        "description": "Sets the url to the html document to be opened in the sidebar when the user clicks on the sidebar action's icon.",
+        "name": "setPanel",
         "parameters": [
           {
-            "name": "details", 
+            "name": "details",
             "properties": {
               "panel": {
-                "description": "The url to the html file to show in a sidebar.  If set to the empty string (''), no sidebar is shown.", 
-                "type": "string"
-              }, 
+                "choices": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "The url to the html file to show in a sidebar.  If set to the empty string (''), no sidebar is shown."
+              },
               "tabId": {
-                "description": "Sets the sidebar url for the tab specified by tabId. Automatically resets when the tab is closed.", 
-                "minimum": 0, 
-                "optional": true, 
+                "description": "Sets the sidebar url for the tab specified by tabId. Automatically resets when the tab is closed.",
+                "minimum": 0,
+                "optional": true,
+                "type": "integer"
+              },
+              "windowId": {
+                "description": "Sets the sidebar url for the window specified by windowId.",
+                "minimum": -2,
+                "optional": true,
                 "type": "integer"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": true, 
-        "description": "Gets the url to the html document set as the panel for this sidebar action.", 
-        "name": "getPanel", 
+        "async": true,
+        "description": "Gets the url to the html document set as the panel for this sidebar action.",
+        "name": "getPanel",
         "parameters": [
           {
-            "name": "details", 
+            "name": "details",
             "properties": {
               "tabId": {
-                "description": "Specify the tab to get the sidebar from. If no tab is specified, the non-tab-specific sidebar is returned.", 
-                "optional": true, 
+                "description": "Specify the tab to get the panel from. If no tab nor window is specified, the global panel is returned.",
+                "optional": true,
+                "type": "integer"
+              },
+              "windowId": {
+                "description": "Specify the window to get the panel from. If no tab nor window is specified, the global panel is returned.",
+                "minimum": -2,
+                "optional": true,
                 "type": "integer"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": true, 
-        "description": "Opens the extension sidebar in the active window.", 
-        "name": "open", 
-        "parameters": [], 
-        "requireUserInput": true, 
+        "async": true,
+        "description": "Opens the extension sidebar in the active window.",
+        "name": "open",
+        "parameters": [],
+        "requireUserInput": true,
         "type": "function"
-      }, 
+      },
       {
-        "async": true, 
-        "description": "Closes the extension sidebar in the active window if the sidebar belongs to the extension.", 
-        "name": "close", 
-        "parameters": [], 
-        "requireUserInput": true, 
+        "async": true,
+        "description": "Closes the extension sidebar in the active window if the sidebar belongs to the extension.",
+        "name": "close",
+        "parameters": [],
+        "requireUserInput": true,
+        "type": "function"
+      },
+      {
+        "async": true,
+        "description": "Checks whether the sidebar action is open.",
+        "name": "isOpen",
+        "parameters": [
+          {
+            "name": "details",
+            "properties": {
+              "windowId": {
+                "description": "Specify the window to get the openness from.",
+                "minimum": -2,
+                "optional": true,
+                "type": "integer"
+              }
+            },
+            "type": "object"
+          }
+        ],
         "type": "function"
       }
-    ], 
-    "namespace": "sidebarAction", 
+    ],
+    "namespace": "sidebarAction",
     "permissions": [
       "manifest:sidebar_action"
-    ], 
+    ],
     "types": [
       {
         "additionalProperties": {
           "type": "any"
-        }, 
-        "description": "Pixel data for an image. Must be an ImageData object (for example, from a <code>canvas</code> element).", 
-        "id": "ImageDataType", 
-        "isInstanceOf": "ImageData", 
-        "postprocess": "convertImageDataToURL", 
+        },
+        "description": "Pixel data for an image. Must be an ImageData object (for example, from a <code>canvas</code> element).",
+        "id": "ImageDataType",
+        "isInstanceOf": "ImageData",
+        "postprocess": "convertImageDataToURL",
         "type": "object"
       }
     ]
-  }, 
+  },
   {
     "allowedContexts": [
-      "content", 
+      "content",
       "devtools"
-    ], 
+    ],
     "defaultContexts": [
-      "content", 
+      "content",
       "devtools"
-    ], 
-    "description": "Use the <code>browser.storage</code> API to store, retrieve, and track changes to user data.", 
+    ],
+    "description": "Use the <code>browser.storage</code> API to store, retrieve, and track changes to user data.",
     "events": [
       {
-        "description": "Fired when one or more items change.", 
-        "name": "onChanged", 
+        "description": "Fired when one or more items change.",
+        "name": "onChanged",
         "parameters": [
           {
             "additionalProperties": {
               "$ref": "StorageChange"
-            }, 
-            "description": "Object mapping each key that changed to its corresponding $(ref:storage.StorageChange) for that item.", 
-            "name": "changes", 
+            },
+            "description": "Object mapping each key that changed to its corresponding $(ref:storage.StorageChange) for that item.",
+            "name": "changes",
             "type": "object"
-          }, 
+          },
           {
-            "description": "The name of the storage area (<code>\"sync\"</code>, <code>\"local\"</code> or <code>\"managed\"</code>) the changes are for.", 
-            "name": "areaName", 
+            "description": "The name of the storage area (<code>\"sync\"</code>, <code>\"local\"</code> or <code>\"managed\"</code>) the changes are for.",
+            "name": "areaName",
             "type": "string"
           }
-        ], 
+        ],
         "type": "function"
       }
-    ], 
-    "namespace": "storage", 
+    ],
+    "namespace": "storage",
     "permissions": [
       "storage"
-    ], 
+    ],
     "properties": {
       "local": {
-        "$ref": "StorageArea", 
-        "description": "Items in the <code>local</code> storage area are local to each machine.", 
+        "$ref": "StorageArea",
+        "description": "Items in the <code>local</code> storage area are local to each machine.",
         "properties": {
           "QUOTA_BYTES": {
-            "description": "The maximum amount (in bytes) of data that can be stored in local storage, as measured by the JSON stringification of every value plus every key's length. This value will be ignored if the extension has the <code>unlimitedStorage</code> permission. Updates that would cause this limit to be exceeded fail immediately and set $(ref:runtime.lastError).", 
+            "description": "The maximum amount (in bytes) of data that can be stored in local storage, as measured by the JSON stringification of every value plus every key's length. This value will be ignored if the extension has the <code>unlimitedStorage</code> permission. Updates that would cause this limit to be exceeded fail immediately and set $(ref:runtime.lastError).",
             "value": 5242880
           }
         }
-      }, 
+      },
       "managed": {
-        "$ref": "StorageArea", 
-        "description": "Items in the <code>managed</code> storage area are set by administrators or native applications, and are read-only for the extension; trying to modify this namespace results in an error.", 
+        "$ref": "StorageArea",
+        "description": "Items in the <code>managed</code> storage area are set by administrators or native applications, and are read-only for the extension; trying to modify this namespace results in an error.",
         "properties": {
           "QUOTA_BYTES": {
-            "description": "The maximum size (in bytes) of the managed storage JSON manifest file. Files larger than this limit will fail to load.", 
+            "description": "The maximum size (in bytes) of the managed storage JSON manifest file. Files larger than this limit will fail to load.",
             "value": 5242880
           }
         }
-      }, 
+      },
       "sync": {
-        "$ref": "StorageArea", 
-        "description": "Items in the <code>sync</code> storage area are synced by the browser.", 
+        "$ref": "StorageArea",
+        "description": "Items in the <code>sync</code> storage area are synced by the browser.",
         "properties": {
           "MAX_ITEMS": {
-            "description": "The maximum number of items that can be stored in sync storage. Updates that would cause this limit to be exceeded will fail immediately and set $(ref:runtime.lastError).", 
+            "description": "The maximum number of items that can be stored in sync storage. Updates that would cause this limit to be exceeded will fail immediately and set $(ref:runtime.lastError).",
             "value": 512
-          }, 
+          },
           "MAX_SUSTAINED_WRITE_OPERATIONS_PER_MINUTE": {
-            "deprecated": "The storage.sync API no longer has a sustained write operation quota.", 
-            "description": "", 
+            "deprecated": "The storage.sync API no longer has a sustained write operation quota.",
+            "description": "",
             "value": 1000000
-          }, 
+          },
           "MAX_WRITE_OPERATIONS_PER_HOUR": {
-            "description": "<p>The maximum number of <code>set</code>, <code>remove</code>, or <code>clear</code> operations that can be performed each hour. This is 1 every 2 seconds, a lower ceiling than the short term higher writes-per-minute limit.</p><p>Updates that would cause this limit to be exceeded fail immediately and set $(ref:runtime.lastError).</p>", 
+            "description": "<p>The maximum number of <code>set</code>, <code>remove</code>, or <code>clear</code> operations that can be performed each hour. This is 1 every 2 seconds, a lower ceiling than the short term higher writes-per-minute limit.</p><p>Updates that would cause this limit to be exceeded fail immediately and set $(ref:runtime.lastError).</p>",
             "value": 1800
-          }, 
+          },
           "MAX_WRITE_OPERATIONS_PER_MINUTE": {
-            "description": "<p>The maximum number of <code>set</code>, <code>remove</code>, or <code>clear</code> operations that can be performed each minute. This is 2 per second, providing higher throughput than writes-per-hour over a shorter period of time.</p><p>Updates that would cause this limit to be exceeded fail immediately and set $(ref:runtime.lastError).</p>", 
+            "description": "<p>The maximum number of <code>set</code>, <code>remove</code>, or <code>clear</code> operations that can be performed each minute. This is 2 per second, providing higher throughput than writes-per-hour over a shorter period of time.</p><p>Updates that would cause this limit to be exceeded fail immediately and set $(ref:runtime.lastError).</p>",
             "value": 120
-          }, 
+          },
           "QUOTA_BYTES": {
-            "description": "The maximum total amount (in bytes) of data that can be stored in sync storage, as measured by the JSON stringification of every value plus every key's length. Updates that would cause this limit to be exceeded fail immediately and set $(ref:runtime.lastError).", 
+            "description": "The maximum total amount (in bytes) of data that can be stored in sync storage, as measured by the JSON stringification of every value plus every key's length. Updates that would cause this limit to be exceeded fail immediately and set $(ref:runtime.lastError).",
             "value": 102400
-          }, 
+          },
           "QUOTA_BYTES_PER_ITEM": {
-            "description": "The maximum size (in bytes) of each individual item in sync storage, as measured by the JSON stringification of its value plus its key length. Updates containing items larger than this limit will fail immediately and set $(ref:runtime.lastError).", 
+            "description": "The maximum size (in bytes) of each individual item in sync storage, as measured by the JSON stringification of its value plus its key length. Updates containing items larger than this limit will fail immediately and set $(ref:runtime.lastError).",
             "value": 8192
           }
         }
       }
-    }, 
+    },
     "types": [
       {
-        "id": "StorageChange", 
+        "id": "StorageChange",
         "properties": {
           "newValue": {
-            "description": "The new value of the item, if there is a new value.", 
-            "optional": true, 
+            "description": "The new value of the item, if there is a new value.",
+            "optional": true,
             "type": "any"
-          }, 
+          },
           "oldValue": {
-            "description": "The old value of the item, if there was an old value.", 
-            "optional": true, 
+            "description": "The old value of the item, if there was an old value.",
+            "optional": true,
             "type": "any"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       {
         "functions": [
           {
-            "async": "callback", 
-            "description": "Gets one or more items from storage.", 
-            "name": "get", 
+            "async": "callback",
+            "description": "Gets one or more items from storage.",
+            "name": "get",
             "parameters": [
               {
                 "choices": [
                   {
                     "type": "string"
-                  }, 
+                  },
                   {
                     "items": {
                       "type": "string"
-                    }, 
+                    },
                     "type": "array"
-                  }, 
+                  },
                   {
                     "additionalProperties": {
                       "type": "any"
-                    }, 
-                    "description": "Storage items to return in the callback, where the values are replaced with those from storage if they exist.", 
+                    },
+                    "description": "Storage items to return in the callback, where the values are replaced with those from storage if they exist.",
                     "type": "object"
                   }
-                ], 
-                "description": "A single key to get, list of keys to get, or a dictionary specifying default values (see description of the object).  An empty list or object will return an empty result object.  Pass in <code>null</code> to get the entire contents of storage.", 
-                "name": "keys", 
+                ],
+                "description": "A single key to get, list of keys to get, or a dictionary specifying default values (see description of the object).  An empty list or object will return an empty result object.  Pass in <code>null</code> to get the entire contents of storage.",
+                "name": "keys",
                 "optional": true
-              }, 
+              },
               {
-                "description": "Callback with storage items, or on failure (in which case $(ref:runtime.lastError) will be set).", 
-                "name": "callback", 
+                "description": "Callback with storage items, or on failure (in which case $(ref:runtime.lastError) will be set).",
+                "name": "callback",
                 "parameters": [
                   {
                     "additionalProperties": {
                       "type": "any"
-                    }, 
-                    "description": "Object with items in their key-value mappings.", 
-                    "name": "items", 
+                    },
+                    "description": "Object with items in their key-value mappings.",
+                    "name": "items",
                     "type": "object"
                   }
-                ], 
+                ],
                 "type": "function"
               }
-            ], 
+            ],
             "type": "function"
-          }, 
+          },
           {
-            "async": "callback", 
-            "description": "Gets the amount of space (in bytes) being used by one or more items.", 
-            "name": "getBytesInUse", 
+            "async": "callback",
+            "description": "Gets the amount of space (in bytes) being used by one or more items.",
+            "name": "getBytesInUse",
             "parameters": [
               {
                 "choices": [
                   {
                     "type": "string"
-                  }, 
+                  },
                   {
                     "items": {
                       "type": "string"
-                    }, 
+                    },
                     "type": "array"
                   }
-                ], 
-                "description": "A single key or list of keys to get the total usage for. An empty list will return 0. Pass in <code>null</code> to get the total usage of all of storage.", 
-                "name": "keys", 
+                ],
+                "description": "A single key or list of keys to get the total usage for. An empty list will return 0. Pass in <code>null</code> to get the total usage of all of storage.",
+                "name": "keys",
                 "optional": true
-              }, 
+              },
               {
-                "description": "Callback with the amount of space being used by storage, or on failure (in which case $(ref:runtime.lastError) will be set).", 
-                "name": "callback", 
+                "description": "Callback with the amount of space being used by storage, or on failure (in which case $(ref:runtime.lastError) will be set).",
+                "name": "callback",
                 "parameters": [
                   {
-                    "description": "Amount of space being used in storage, in bytes.", 
-                    "name": "bytesInUse", 
+                    "description": "Amount of space being used in storage, in bytes.",
+                    "name": "bytesInUse",
                     "type": "integer"
                   }
-                ], 
+                ],
                 "type": "function"
               }
-            ], 
-            "type": "function", 
+            ],
+            "type": "function",
             "unsupported": true
-          }, 
+          },
           {
-            "async": "callback", 
-            "description": "Sets multiple items.", 
-            "name": "set", 
+            "async": "callback",
+            "description": "Sets multiple items.",
+            "name": "set",
             "parameters": [
               {
                 "additionalProperties": {
                   "type": "any"
-                }, 
-                "description": "<p>An object which gives each key/value pair to update storage with. Any other key/value pairs in storage will not be affected.</p><p>Primitive values such as numbers will serialize as expected. Values with a <code>typeof</code> <code>\"object\"</code> and <code>\"function\"</code> will typically serialize to <code>{}</code>, with the exception of <code>Array</code> (serializes as expected), <code>Date</code>, and <code>Regex</code> (serialize using their <code>String</code> representation).</p>", 
-                "name": "items", 
+                },
+                "description": "<p>An object which gives each key/value pair to update storage with. Any other key/value pairs in storage will not be affected.</p><p>Primitive values such as numbers will serialize as expected. Values with a <code>typeof</code> <code>\"object\"</code> and <code>\"function\"</code> will typically serialize to <code>{}</code>, with the exception of <code>Array</code> (serializes as expected), <code>Date</code>, and <code>Regex</code> (serialize using their <code>String</code> representation).</p>",
+                "name": "items",
                 "type": "object"
-              }, 
+              },
               {
-                "description": "Callback on success, or on failure (in which case $(ref:runtime.lastError) will be set).", 
-                "name": "callback", 
-                "optional": true, 
-                "parameters": [], 
+                "description": "Callback on success, or on failure (in which case $(ref:runtime.lastError) will be set).",
+                "name": "callback",
+                "optional": true,
+                "parameters": [],
                 "type": "function"
               }
-            ], 
+            ],
             "type": "function"
-          }, 
+          },
           {
-            "async": "callback", 
-            "description": "Removes one or more items from storage.", 
-            "name": "remove", 
+            "async": "callback",
+            "description": "Removes one or more items from storage.",
+            "name": "remove",
             "parameters": [
               {
                 "choices": [
                   {
                     "type": "string"
-                  }, 
+                  },
                   {
                     "items": {
                       "type": "string"
-                    }, 
+                    },
                     "type": "array"
                   }
-                ], 
-                "description": "A single key or a list of keys for items to remove.", 
+                ],
+                "description": "A single key or a list of keys for items to remove.",
                 "name": "keys"
-              }, 
+              },
               {
-                "description": "Callback on success, or on failure (in which case $(ref:runtime.lastError) will be set).", 
-                "name": "callback", 
-                "optional": true, 
-                "parameters": [], 
+                "description": "Callback on success, or on failure (in which case $(ref:runtime.lastError) will be set).",
+                "name": "callback",
+                "optional": true,
+                "parameters": [],
                 "type": "function"
               }
-            ], 
+            ],
             "type": "function"
-          }, 
+          },
           {
-            "async": "callback", 
-            "description": "Removes all items from storage.", 
-            "name": "clear", 
+            "async": "callback",
+            "description": "Removes all items from storage.",
+            "name": "clear",
             "parameters": [
               {
-                "description": "Callback on success, or on failure (in which case $(ref:runtime.lastError) will be set).", 
-                "name": "callback", 
-                "optional": true, 
-                "parameters": [], 
+                "description": "Callback on success, or on failure (in which case $(ref:runtime.lastError) will be set).",
+                "name": "callback",
+                "optional": true,
+                "parameters": [],
                 "type": "function"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
-        "id": "StorageArea", 
+        ],
+        "id": "StorageArea",
         "type": "object"
       }
     ]
-  }, 
+  },
   {
-    "description": "Use the <code>browser.tabs</code> API to interact with the browser's tab system. You can use this API to create, modify, and rearrange tabs in the browser.", 
+    "description": "Use the <code>browser.tabs</code> API to interact with the browser's tab system. You can use this API to create, modify, and rearrange tabs in the browser.",
     "events": [
       {
-        "description": "Fired when a tab is created. Note that the tab's URL may not be set at the time this event fired, but you can listen to onUpdated events to be notified when a URL is set.", 
-        "name": "onCreated", 
+        "description": "Fired when a tab is created. Note that the tab's URL may not be set at the time this event fired, but you can listen to onUpdated events to be notified when a URL is set.",
+        "name": "onCreated",
         "parameters": [
           {
-            "$ref": "Tab", 
-            "description": "Details of the tab that was created.", 
+            "$ref": "Tab",
+            "description": "Details of the tab that was created.",
             "name": "tab"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Fired when a tab is updated.", 
-        "name": "onUpdated", 
+        "description": "Fired when a tab is updated.",
+        "extraParameters": [
+          {
+            "$ref": "UpdateFilter",
+            "description": "A set of filters that restricts the events that will be sent to this listener.",
+            "name": "filter",
+            "optional": true
+          }
+        ],
+        "name": "onUpdated",
         "parameters": [
           {
-            "minimum": 0, 
-            "name": "tabId", 
+            "minimum": 0,
+            "name": "tabId",
             "type": "integer"
-          }, 
+          },
           {
-            "description": "Lists the changes to the state of the tab that was updated.", 
-            "name": "changeInfo", 
+            "description": "Lists the changes to the state of the tab that was updated.",
+            "name": "changeInfo",
             "properties": {
+              "attention": {
+                "description": "The tab's new attention state.",
+                "optional": true,
+                "type": "boolean"
+              },
               "audible": {
-                "description": "The tab's new audible state.", 
-                "optional": true, 
+                "description": "The tab's new audible state.",
+                "optional": true,
                 "type": "boolean"
-              }, 
+              },
               "discarded": {
-                "description": "True while the tab is not loaded with content.", 
-                "optional": true, 
+                "description": "True while the tab is not loaded with content.",
+                "optional": true,
                 "type": "boolean"
-              }, 
+              },
               "favIconUrl": {
-                "description": "The tab's new favicon URL.", 
-                "optional": true, 
+                "description": "The tab's new favicon URL. This property is only present if the extension's manifest includes the <code>\"tabs\"</code> permission.",
+                "optional": true,
+                "permissions": [
+                  "tabs"
+                ],
                 "type": "string"
-              }, 
-              "mutedInfo": {
-                "$ref": "MutedInfo", 
-                "description": "The tab's new muted state and the reason for the change.", 
-                "optional": true
-              }, 
-              "pinned": {
-                "description": "The tab's new pinned state.", 
-                "optional": true, 
+              },
+              "hidden": {
+                "description": "The tab's new hidden state.",
+                "optional": true,
                 "type": "boolean"
-              }, 
+              },
+              "isArticle": {
+                "description": "Whether the document in the tab can be rendered in reader mode.",
+                "optional": true,
+                "type": "boolean"
+              },
+              "mutedInfo": {
+                "$ref": "MutedInfo",
+                "description": "The tab's new muted state and the reason for the change.",
+                "optional": true
+              },
+              "pinned": {
+                "description": "The tab's new pinned state.",
+                "optional": true,
+                "type": "boolean"
+              },
+              "sharingState": {
+                "$ref": "SharingState",
+                "description": "The tab's new sharing state for screen, microphone and camera.",
+                "optional": true
+              },
               "status": {
-                "description": "The status of the tab. Can be either <em>loading</em> or <em>complete</em>.", 
-                "optional": true, 
+                "description": "The status of the tab. Can be either <em>loading</em> or <em>complete</em>.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
+              "title": {
+                "description": "The title of the tab if it has changed. This property is only present if the extension's manifest includes the <code>\"tabs\"</code> permission.",
+                "optional": true,
+                "permissions": [
+                  "tabs"
+                ],
+                "type": "string"
+              },
               "url": {
-                "description": "The tab's URL if it has changed.", 
-                "optional": true, 
+                "description": "The tab's URL if it has changed. This property is only present if the extension's manifest includes the <code>\"tabs\"</code> permission.",
+                "optional": true,
+                "permissions": [
+                  "tabs"
+                ],
                 "type": "string"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "$ref": "Tab", 
-            "description": "Gives the state of the tab that was updated.", 
+            "$ref": "Tab",
+            "description": "Gives the state of the tab that was updated.",
             "name": "tab"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Fired when a tab is moved within a window. Only one move event is fired, representing the tab the user directly moved. Move events are not fired for the other tabs that must move in response. This event is not fired when a tab is moved between windows. For that, see $(ref:tabs.onDetached).", 
-        "name": "onMoved", 
+        "description": "Fired when a tab is moved within a window. Only one move event is fired, representing the tab the user directly moved. Move events are not fired for the other tabs that must move in response. This event is not fired when a tab is moved between windows. For that, see $(ref:tabs.onDetached).",
+        "name": "onMoved",
         "parameters": [
           {
-            "minimum": 0, 
-            "name": "tabId", 
+            "minimum": 0,
+            "name": "tabId",
             "type": "integer"
-          }, 
+          },
           {
-            "name": "moveInfo", 
+            "name": "moveInfo",
             "properties": {
               "fromIndex": {
-                "minimum": 0, 
+                "minimum": 0,
                 "type": "integer"
-              }, 
+              },
               "toIndex": {
-                "minimum": 0, 
+                "minimum": 0,
                 "type": "integer"
-              }, 
+              },
               "windowId": {
-                "minimum": 0, 
+                "minimum": 0,
                 "type": "integer"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "deprecated": "Please use $(ref:tabs.onActivated).", 
-        "description": "Fires when the selected tab in a window changes.", 
-        "name": "onSelectionChanged", 
+        "deprecated": "Please use $(ref:tabs.onActivated).",
+        "description": "Fires when the selected tab in a window changes.",
+        "name": "onSelectionChanged",
         "parameters": [
           {
-            "description": "The ID of the tab that has become active.", 
-            "minimum": 0, 
-            "name": "tabId", 
+            "description": "The ID of the tab that has become active.",
+            "minimum": 0,
+            "name": "tabId",
             "type": "integer"
-          }, 
+          },
           {
-            "name": "selectInfo", 
+            "name": "selectInfo",
             "properties": {
               "windowId": {
-                "description": "The ID of the window the selected tab changed inside of.", 
-                "minimum": 0, 
+                "description": "The ID of the window the selected tab changed inside of.",
+                "minimum": 0,
                 "type": "integer"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
-      }, 
+      },
       {
-        "deprecated": "Please use $(ref:tabs.onActivated).", 
-        "description": "Fires when the selected tab in a window changes. Note that the tab's URL may not be set at the time this event fired, but you can listen to $(ref:tabs.onUpdated) events to be notified when a URL is set.", 
-        "name": "onActiveChanged", 
+        "deprecated": "Please use $(ref:tabs.onActivated).",
+        "description": "Fires when the selected tab in a window changes. Note that the tab's URL may not be set at the time this event fired, but you can listen to $(ref:tabs.onUpdated) events to be notified when a URL is set.",
+        "name": "onActiveChanged",
         "parameters": [
           {
-            "description": "The ID of the tab that has become active.", 
-            "minimum": 0, 
-            "name": "tabId", 
+            "description": "The ID of the tab that has become active.",
+            "minimum": 0,
+            "name": "tabId",
             "type": "integer"
-          }, 
+          },
           {
-            "name": "selectInfo", 
+            "name": "selectInfo",
             "properties": {
               "windowId": {
-                "description": "The ID of the window the selected tab changed inside of.", 
-                "minimum": 0, 
+                "description": "The ID of the window the selected tab changed inside of.",
+                "minimum": 0,
                 "type": "integer"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
-      }, 
+      },
       {
-        "description": "Fires when the active tab in a window changes. Note that the tab's URL may not be set at the time this event fired, but you can listen to onUpdated events to be notified when a URL is set.", 
-        "name": "onActivated", 
+        "description": "Fires when the active tab in a window changes. Note that the tab's URL may not be set at the time this event fired, but you can listen to onUpdated events to be notified when a URL is set.",
+        "name": "onActivated",
         "parameters": [
           {
-            "name": "activeInfo", 
+            "name": "activeInfo",
             "properties": {
+              "previousTabId": {
+                "description": "The ID of the tab that was previously active, if that tab is still open.",
+                "minimum": 0,
+                "optional": true,
+                "type": "integer"
+              },
               "tabId": {
-                "description": "The ID of the tab that has become active.", 
-                "minimum": 0, 
+                "description": "The ID of the tab that has become active.",
+                "minimum": 0,
                 "type": "integer"
-              }, 
+              },
               "windowId": {
-                "description": "The ID of the window the active tab changed inside of.", 
-                "minimum": 0, 
+                "description": "The ID of the window the active tab changed inside of.",
+                "minimum": 0,
                 "type": "integer"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "deprecated": "Please use $(ref:tabs.onHighlighted).", 
-        "description": "Fired when the highlighted or selected tabs in a window changes.", 
-        "name": "onHighlightChanged", 
+        "deprecated": "Please use $(ref:tabs.onHighlighted).",
+        "description": "Fired when the highlighted or selected tabs in a window changes.",
+        "name": "onHighlightChanged",
         "parameters": [
           {
-            "name": "selectInfo", 
+            "name": "selectInfo",
             "properties": {
               "tabIds": {
-                "description": "All highlighted tabs in the window.", 
+                "description": "All highlighted tabs in the window.",
                 "items": {
-                  "minimum": 0, 
+                  "minimum": 0,
                   "type": "integer"
-                }, 
+                },
                 "type": "array"
-              }, 
+              },
               "windowId": {
-                "description": "The window whose tabs changed.", 
-                "minimum": 0, 
+                "description": "The window whose tabs changed.",
+                "minimum": 0,
                 "type": "integer"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
-      }, 
+      },
       {
-        "description": "Fired when the highlighted or selected tabs in a window changes.", 
-        "name": "onHighlighted", 
+        "description": "Fired when the highlighted or selected tabs in a window changes.",
+        "name": "onHighlighted",
         "parameters": [
           {
-            "name": "highlightInfo", 
+            "name": "highlightInfo",
             "properties": {
               "tabIds": {
-                "description": "All highlighted tabs in the window.", 
+                "description": "All highlighted tabs in the window.",
                 "items": {
-                  "minimum": 0, 
+                  "minimum": 0,
                   "type": "integer"
-                }, 
+                },
                 "type": "array"
-              }, 
+              },
               "windowId": {
-                "description": "The window whose tabs changed.", 
-                "minimum": 0, 
+                "description": "The window whose tabs changed.",
+                "minimum": 0,
                 "type": "integer"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Fired when a tab is detached from a window, for example because it is being moved between windows.", 
-        "name": "onDetached", 
+        "description": "Fired when a tab is detached from a window, for example because it is being moved between windows.",
+        "name": "onDetached",
         "parameters": [
           {
-            "minimum": 0, 
-            "name": "tabId", 
+            "minimum": 0,
+            "name": "tabId",
             "type": "integer"
-          }, 
+          },
           {
-            "name": "detachInfo", 
+            "name": "detachInfo",
             "properties": {
               "oldPosition": {
-                "minimum": 0, 
+                "minimum": 0,
                 "type": "integer"
-              }, 
+              },
               "oldWindowId": {
-                "minimum": 0, 
+                "minimum": 0,
                 "type": "integer"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Fired when a tab is attached to a window, for example because it was moved between windows.", 
-        "name": "onAttached", 
+        "description": "Fired when a tab is attached to a window, for example because it was moved between windows.",
+        "name": "onAttached",
         "parameters": [
           {
-            "minimum": 0, 
-            "name": "tabId", 
+            "minimum": 0,
+            "name": "tabId",
             "type": "integer"
-          }, 
+          },
           {
-            "name": "attachInfo", 
+            "name": "attachInfo",
             "properties": {
               "newPosition": {
-                "minimum": 0, 
+                "minimum": 0,
                 "type": "integer"
-              }, 
+              },
               "newWindowId": {
-                "minimum": 0, 
+                "minimum": 0,
                 "type": "integer"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Fired when a tab is closed.", 
-        "name": "onRemoved", 
+        "description": "Fired when a tab is closed.",
+        "name": "onRemoved",
         "parameters": [
           {
-            "minimum": 0, 
-            "name": "tabId", 
+            "minimum": 0,
+            "name": "tabId",
             "type": "integer"
-          }, 
+          },
           {
-            "name": "removeInfo", 
+            "name": "removeInfo",
             "properties": {
               "isWindowClosing": {
-                "description": "True when the tab is being closed because its window is being closed.", 
+                "description": "True when the tab is being closed because its window is being closed.",
                 "type": "boolean"
-              }, 
+              },
               "windowId": {
-                "description": "The window whose tab is closed.", 
-                "minimum": 0, 
+                "description": "The window whose tab is closed.",
+                "minimum": 0,
                 "type": "integer"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Fired when a tab is replaced with another tab due to prerendering or instant.", 
-        "name": "onReplaced", 
+        "description": "Fired when a tab is replaced with another tab due to prerendering or instant.",
+        "name": "onReplaced",
         "parameters": [
           {
-            "minimum": 0, 
-            "name": "addedTabId", 
+            "minimum": 0,
+            "name": "addedTabId",
             "type": "integer"
-          }, 
+          },
           {
-            "minimum": 0, 
-            "name": "removedTabId", 
+            "minimum": 0,
+            "name": "removedTabId",
             "type": "integer"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Fired when a tab is zoomed.", 
-        "name": "onZoomChange", 
+        "description": "Fired when a tab is zoomed.",
+        "name": "onZoomChange",
         "parameters": [
           {
-            "name": "ZoomChangeInfo", 
+            "name": "ZoomChangeInfo",
             "properties": {
               "newZoomFactor": {
                 "type": "number"
-              }, 
+              },
               "oldZoomFactor": {
                 "type": "number"
-              }, 
+              },
               "tabId": {
-                "minimum": 0, 
+                "minimum": 0,
                 "type": "integer"
-              }, 
+              },
               "zoomSettings": {
                 "$ref": "ZoomSettings"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "type": "function"
       }
-    ], 
+    ],
     "functions": [
       {
-        "async": "callback", 
-        "description": "Retrieves details about the specified tab.", 
-        "name": "get", 
+        "async": "callback",
+        "description": "Retrieves details about the specified tab.",
+        "name": "get",
         "parameters": [
           {
-            "minimum": 0, 
-            "name": "tabId", 
+            "minimum": 0,
+            "name": "tabId",
             "type": "integer"
-          }, 
+          },
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
-                "$ref": "Tab", 
+                "$ref": "Tab",
                 "name": "tab"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Gets the tab that this script call is being made from. May be undefined if called from a non-tab context (for example: a background page or popup view).", 
-        "name": "getCurrent", 
+        "async": "callback",
+        "description": "Gets the tab that this script call is being made from. May be undefined if called from a non-tab context (for example: a background page or popup view).",
+        "name": "getCurrent",
         "parameters": [
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
-                "$ref": "Tab", 
-                "name": "tab", 
+                "$ref": "Tab",
+                "name": "tab",
                 "optional": true
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Connects to the content script(s) in the specified tab. The $(ref:runtime.onConnect) event is fired in each content script running in the specified tab for the current extension. For more details, see $(topic:messaging)[Content Script Messaging].", 
-        "name": "connect", 
+        "description": "Connects to the content script(s) in the specified tab. The $(ref:runtime.onConnect) event is fired in each content script running in the specified tab for the current extension. For more details, see $(topic:messaging)[Content Script Messaging].",
+        "name": "connect",
         "parameters": [
           {
-            "minimum": 0, 
-            "name": "tabId", 
+            "minimum": 0,
+            "name": "tabId",
             "type": "integer"
-          }, 
+          },
           {
-            "name": "connectInfo", 
-            "optional": true, 
+            "name": "connectInfo",
+            "optional": true,
             "properties": {
               "frameId": {
-                "description": "Open a port to a specific $(topic:frame_ids)[frame] identified by <code>frameId</code> instead of all frames in the tab.", 
-                "minimum": 0, 
-                "optional": true, 
+                "description": "Open a port to a specific $(topic:frame_ids)[frame] identified by <code>frameId</code> instead of all frames in the tab.",
+                "minimum": 0,
+                "optional": true,
                 "type": "integer"
-              }, 
+              },
               "name": {
-                "description": "Will be passed into onConnect for content scripts that are listening for the connection event.", 
-                "optional": true, 
+                "description": "Will be passed into onConnect for content scripts that are listening for the connection event.",
+                "optional": true,
                 "type": "string"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "returns": {
-          "$ref": "runtime.Port", 
+          "$ref": "runtime.Port",
           "description": "A port that can be used to communicate with the content scripts running in the specified tab. The port's $(ref:runtime.Port) event is fired if the tab closes or does not exist. "
-        }, 
+        },
         "type": "function"
-      }, 
+      },
       {
-        "deprecated": "Please use $(ref:runtime.sendMessage).", 
-        "description": "Sends a single request to the content script(s) in the specified tab, with an optional callback to run when a response is sent back.  The $(ref:extension.onRequest) event is fired in each content script running in the specified tab for the current extension.", 
-        "name": "sendRequest", 
+        "deprecated": "Please use $(ref:runtime.sendMessage).",
+        "description": "Sends a single request to the content script(s) in the specified tab, with an optional callback to run when a response is sent back.  The $(ref:extension.onRequest) event is fired in each content script running in the specified tab for the current extension.",
+        "name": "sendRequest",
         "parameters": [
           {
-            "minimum": 0, 
-            "name": "tabId", 
+            "minimum": 0,
+            "name": "tabId",
             "type": "integer"
-          }, 
+          },
           {
-            "name": "request", 
+            "name": "request",
             "type": "any"
-          }, 
+          },
           {
-            "name": "responseCallback", 
-            "optional": true, 
+            "name": "responseCallback",
+            "optional": true,
             "parameters": [
               {
-                "description": "The JSON response object sent by the handler of the request. If an error occurs while connecting to the specified tab, the callback will be called with no arguments and $(ref:runtime.lastError) will be set to the error message.", 
-                "name": "response", 
+                "description": "The JSON response object sent by the handler of the request. If an error occurs while connecting to the specified tab, the callback will be called with no arguments and $(ref:runtime.lastError) will be set to the error message.",
+                "name": "response",
                 "type": "any"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
-      }, 
+      },
       {
-        "async": "responseCallback", 
-        "description": "Sends a single message to the content script(s) in the specified tab, with an optional callback to run when a response is sent back.  The $(ref:runtime.onMessage) event is fired in each content script running in the specified tab for the current extension.", 
-        "name": "sendMessage", 
+        "async": "responseCallback",
+        "description": "Sends a single message to the content script(s) in the specified tab, with an optional callback to run when a response is sent back.  The $(ref:runtime.onMessage) event is fired in each content script running in the specified tab for the current extension.",
+        "name": "sendMessage",
         "parameters": [
           {
-            "minimum": 0, 
-            "name": "tabId", 
+            "minimum": 0,
+            "name": "tabId",
             "type": "integer"
-          }, 
+          },
           {
-            "name": "message", 
+            "name": "message",
             "type": "any"
-          }, 
+          },
           {
-            "name": "options", 
-            "optional": true, 
+            "name": "options",
+            "optional": true,
             "properties": {
               "frameId": {
-                "description": "Send a message to a specific $(topic:frame_ids)[frame] identified by <code>frameId</code> instead of all frames in the tab.", 
-                "minimum": 0, 
-                "optional": true, 
+                "description": "Send a message to a specific $(topic:frame_ids)[frame] identified by <code>frameId</code> instead of all frames in the tab.",
+                "minimum": 0,
+                "optional": true,
                 "type": "integer"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "name": "responseCallback", 
-            "optional": true, 
+            "name": "responseCallback",
+            "optional": true,
             "parameters": [
               {
-                "description": "The JSON response object sent by the handler of the message. If an error occurs while connecting to the specified tab, the callback will be called with no arguments and $(ref:runtime.lastError) will be set to the error message.", 
-                "name": "response", 
+                "description": "The JSON response object sent by the handler of the message. If an error occurs while connecting to the specified tab, the callback will be called with no arguments and $(ref:runtime.lastError) will be set to the error message.",
+                "name": "response",
                 "type": "any"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "deprecated": "Please use $(ref:tabs.query) <code>{active: true}</code>.", 
-        "description": "Gets the tab that is selected in the specified window.", 
-        "name": "getSelected", 
+        "async": "callback",
+        "deprecated": "Please use $(ref:tabs.query) <code>{active: true}</code>.",
+        "description": "Gets the tab that is selected in the specified window.",
+        "name": "getSelected",
         "parameters": [
           {
-            "description": "Defaults to the $(topic:current-window)[current window].", 
-            "minimum": -2, 
-            "name": "windowId", 
-            "optional": true, 
+            "description": "Defaults to the $(topic:current-window)[current window].",
+            "minimum": -2,
+            "name": "windowId",
+            "optional": true,
             "type": "integer"
-          }, 
+          },
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
-                "$ref": "Tab", 
+                "$ref": "Tab",
                 "name": "tab"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
-      }, 
+      },
       {
-        "async": "callback", 
-        "deprecated": "Please use $(ref:tabs.query) <code>{windowId: windowId}</code>.", 
-        "description": "Gets details about all tabs in the specified window.", 
-        "name": "getAllInWindow", 
+        "async": "callback",
+        "deprecated": "Please use $(ref:tabs.query) <code>{windowId: windowId}</code>.",
+        "description": "Gets details about all tabs in the specified window.",
+        "name": "getAllInWindow",
         "parameters": [
           {
-            "description": "Defaults to the $(topic:current-window)[current window].", 
-            "minimum": -2, 
-            "name": "windowId", 
-            "optional": true, 
+            "description": "Defaults to the $(topic:current-window)[current window].",
+            "minimum": -2,
+            "name": "windowId",
+            "optional": true,
             "type": "integer"
-          }, 
+          },
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
                 "items": {
                   "$ref": "Tab"
-                }, 
-                "name": "tabs", 
+                },
+                "name": "tabs",
                 "type": "array"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Creates a new tab.", 
-        "name": "create", 
+        "async": "callback",
+        "description": "Creates a new tab.",
+        "name": "create",
         "parameters": [
           {
-            "name": "createProperties", 
+            "name": "createProperties",
             "properties": {
               "active": {
-                "description": "Whether the tab should become the active tab in the window. Does not affect whether the window is focused (see $(ref:windows.update)). Defaults to <var>true</var>.", 
-                "optional": true, 
+                "description": "Whether the tab should become the active tab in the window. Does not affect whether the window is focused (see $(ref:windows.update)). Defaults to <var>true</var>.",
+                "optional": true,
                 "type": "boolean"
-              }, 
+              },
               "cookieStoreId": {
-                "description": "The CookieStoreId for the tab that opened this tab.", 
-                "optional": true, 
+                "description": "The CookieStoreId for the tab that opened this tab.",
+                "optional": true,
                 "type": "string"
-              }, 
-              "index": {
-                "description": "The position the tab should take in the window. The provided value will be clamped to between zero and the number of tabs in the window.", 
-                "minimum": 0, 
-                "optional": true, 
-                "type": "integer"
-              }, 
-              "openInReaderMode": {
-                "description": "Whether the document in the tab should be opened in reader mode.", 
-                "optional": true, 
-                "type": "boolean"
-              }, 
-              "openerTabId": {
-                "description": "The ID of the tab that opened this tab. If specified, the opener tab must be in the same window as the newly created tab.", 
-                "minimum": 0, 
-                "optional": true, 
-                "type": "integer"
-              }, 
-              "pinned": {
-                "description": "Whether the tab should be pinned. Defaults to <var>false</var>", 
-                "optional": true, 
-                "type": "boolean"
-              }, 
-              "selected": {
-                "deprecated": "Please use <em>active</em>.", 
-                "description": "Whether the tab should become the selected tab in the window. Defaults to <var>true</var>", 
-                "optional": true, 
-                "type": "boolean", 
-                "unsupported": true
-              }, 
-              "url": {
-                "description": "The URL to navigate the tab to initially. Fully-qualified URLs must include a scheme (i.e. 'http://www.google.com', not 'www.google.com'). Relative URLs will be relative to the current page within the extension. Defaults to the New Tab Page.", 
-                "optional": true, 
-                "type": "string"
-              }, 
-              "windowId": {
-                "description": "The window to create the new tab in. Defaults to the $(topic:current-window)[current window].", 
-                "minimum": -2, 
-                "optional": true, 
-                "type": "integer"
-              }
-            }, 
-            "type": "object"
-          }, 
-          {
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [
-              {
-                "$ref": "Tab", 
-                "description": "Details about the created tab. Will contain the ID of the new tab.", 
-                "name": "tab", 
-                "optional": true
-              }
-            ], 
-            "type": "function"
-          }
-        ], 
-        "type": "function"
-      }, 
-      {
-        "async": "callback", 
-        "description": "Duplicates a tab.", 
-        "name": "duplicate", 
-        "parameters": [
-          {
-            "description": "The ID of the tab which is to be duplicated.", 
-            "minimum": 0, 
-            "name": "tabId", 
-            "type": "integer"
-          }, 
-          {
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [
-              {
-                "$ref": "Tab", 
-                "description": "Details about the duplicated tab. The $(ref:tabs.Tab) object doesn't contain <code>url</code>, <code>title</code> and <code>favIconUrl</code> if the <code>\"tabs\"</code> permission has not been requested.", 
-                "name": "tab", 
-                "optional": true
-              }
-            ], 
-            "type": "function"
-          }
-        ], 
-        "type": "function"
-      }, 
-      {
-        "async": "callback", 
-        "description": "Gets all tabs that have the specified properties, or all tabs if no properties are specified.", 
-        "name": "query", 
-        "parameters": [
-          {
-            "name": "queryInfo", 
-            "properties": {
-              "active": {
-                "description": "Whether the tabs are active in their windows.", 
-                "optional": true, 
-                "type": "boolean"
-              }, 
-              "audible": {
-                "description": "Whether the tabs are audible.", 
-                "optional": true, 
-                "type": "boolean"
-              }, 
-              "cookieStoreId": {
-                "description": "The CookieStoreId used for the tab.", 
-                "optional": true, 
-                "type": "string"
-              }, 
-              "currentWindow": {
-                "description": "Whether the tabs are in the $(topic:current-window)[current window].", 
-                "optional": true, 
-                "type": "boolean"
-              }, 
+              },
               "discarded": {
-                "description": "True while the tabs are not loaded with content.", 
-                "optional": true, 
+                "description": "Whether the tab is marked as 'discarded' when created.",
+                "optional": true,
                 "type": "boolean"
-              }, 
-              "highlighted": {
-                "description": "Whether the tabs are highlighted.  Works as an alias of active.", 
-                "optional": true, 
-                "type": "boolean"
-              }, 
+              },
               "index": {
-                "description": "The position of the tabs within their windows.", 
-                "minimum": 0, 
-                "optional": true, 
+                "description": "The position the tab should take in the window. The provided value will be clamped to between zero and the number of tabs in the window.",
+                "minimum": 0,
+                "optional": true,
                 "type": "integer"
-              }, 
-              "lastFocusedWindow": {
-                "description": "Whether the tabs are in the last focused window.", 
-                "optional": true, 
+              },
+              "openInReaderMode": {
+                "description": "Whether the document in the tab should be opened in reader mode.",
+                "optional": true,
                 "type": "boolean"
-              }, 
-              "muted": {
-                "description": "Whether the tabs are muted.", 
-                "optional": true, 
-                "type": "boolean"
-              }, 
+              },
               "openerTabId": {
-                "description": "The ID of the tab that opened this tab. If specified, the opener tab must be in the same window as this tab.", 
-                "minimum": 0, 
-                "optional": true, 
+                "description": "The ID of the tab that opened this tab. If specified, the opener tab must be in the same window as the newly created tab.",
+                "minimum": 0,
+                "optional": true,
                 "type": "integer"
-              }, 
+              },
               "pinned": {
-                "description": "Whether the tabs are pinned.", 
-                "optional": true, 
+                "description": "Whether the tab should be pinned. Defaults to <var>false</var>",
+                "optional": true,
                 "type": "boolean"
-              }, 
-              "status": {
-                "$ref": "TabStatus", 
-                "description": "Whether the tabs have completed loading.", 
-                "optional": true
-              }, 
+              },
+              "selected": {
+                "deprecated": "Please use <em>active</em>.",
+                "description": "Whether the tab should become the selected tab in the window. Defaults to <var>true</var>",
+                "optional": true,
+                "type": "boolean",
+                "unsupported": true
+              },
               "title": {
-                "description": "Match page titles against a pattern.", 
-                "optional": true, 
+                "description": "The title used for display if the tab is created in discarded mode.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
+              "url": {
+                "description": "The URL to navigate the tab to initially. Fully-qualified URLs must include a scheme (i.e. 'http://www.google.com', not 'www.google.com'). Relative URLs will be relative to the current page within the extension. Defaults to the New Tab Page.",
+                "optional": true,
+                "type": "string"
+              },
+              "windowId": {
+                "description": "The window to create the new tab in. Defaults to the $(topic:current-window)[current window].",
+                "minimum": -2,
+                "optional": true,
+                "type": "integer"
+              }
+            },
+            "type": "object"
+          },
+          {
+            "name": "callback",
+            "optional": true,
+            "parameters": [
+              {
+                "$ref": "Tab",
+                "description": "Details about the created tab. Will contain the ID of the new tab.",
+                "name": "tab",
+                "optional": true
+              }
+            ],
+            "type": "function"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": "callback",
+        "description": "Duplicates a tab.",
+        "name": "duplicate",
+        "parameters": [
+          {
+            "description": "The ID of the tab which is to be duplicated.",
+            "minimum": 0,
+            "name": "tabId",
+            "type": "integer"
+          },
+          {
+            "name": "callback",
+            "optional": true,
+            "parameters": [
+              {
+                "$ref": "Tab",
+                "description": "Details about the duplicated tab. The $(ref:tabs.Tab) object doesn't contain <code>url</code>, <code>title</code> and <code>favIconUrl</code> if the <code>\"tabs\"</code> permission has not been requested.",
+                "name": "tab",
+                "optional": true
+              }
+            ],
+            "type": "function"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": "callback",
+        "description": "Gets all tabs that have the specified properties, or all tabs if no properties are specified.",
+        "name": "query",
+        "parameters": [
+          {
+            "name": "queryInfo",
+            "properties": {
+              "active": {
+                "description": "Whether the tabs are active in their windows.",
+                "optional": true,
+                "type": "boolean"
+              },
+              "attention": {
+                "description": "Whether the tabs are drawing attention.",
+                "optional": true,
+                "type": "boolean"
+              },
+              "audible": {
+                "description": "Whether the tabs are audible.",
+                "optional": true,
+                "type": "boolean"
+              },
+              "camera": {
+                "description": "True if the tab is using the camera.",
+                "optional": true,
+                "type": "boolean"
+              },
+              "cookieStoreId": {
+                "description": "The CookieStoreId used for the tab.",
+                "optional": true,
+                "type": "string"
+              },
+              "currentWindow": {
+                "description": "Whether the tabs are in the $(topic:current-window)[current window].",
+                "optional": true,
+                "type": "boolean"
+              },
+              "discarded": {
+                "description": "True while the tabs are not loaded with content.",
+                "optional": true,
+                "type": "boolean"
+              },
+              "hidden": {
+                "description": "True while the tabs are hidden.",
+                "optional": true,
+                "type": "boolean"
+              },
+              "highlighted": {
+                "description": "Whether the tabs are highlighted.  Works as an alias of active.",
+                "optional": true,
+                "type": "boolean"
+              },
+              "index": {
+                "description": "The position of the tabs within their windows.",
+                "minimum": 0,
+                "optional": true,
+                "type": "integer"
+              },
+              "lastFocusedWindow": {
+                "description": "Whether the tabs are in the last focused window.",
+                "optional": true,
+                "type": "boolean"
+              },
+              "microphone": {
+                "description": "True if the tab is using the microphone.",
+                "optional": true,
+                "type": "boolean"
+              },
+              "muted": {
+                "description": "Whether the tabs are muted.",
+                "optional": true,
+                "type": "boolean"
+              },
+              "openerTabId": {
+                "description": "The ID of the tab that opened this tab. If specified, the opener tab must be in the same window as this tab.",
+                "minimum": 0,
+                "optional": true,
+                "type": "integer"
+              },
+              "pinned": {
+                "description": "Whether the tabs are pinned.",
+                "optional": true,
+                "type": "boolean"
+              },
+              "screen": {
+                "choices": [
+                  {
+                    "enum": [
+                      "Screen",
+                      "Window",
+                      "Application"
+                    ],
+                    "type": "string"
+                  },
+                  {
+                    "type": "boolean"
+                  }
+                ],
+                "description": "True for any screen sharing, or a string to specify type of screen sharing.",
+                "optional": true
+              },
+              "status": {
+                "$ref": "TabStatus",
+                "description": "Whether the tabs have completed loading.",
+                "optional": true
+              },
+              "title": {
+                "description": "Match page titles against a pattern.",
+                "optional": true,
+                "type": "string"
+              },
               "url": {
                 "choices": [
                   {
                     "type": "string"
-                  }, 
+                  },
                   {
                     "items": {
                       "type": "string"
-                    }, 
+                    },
                     "type": "array"
                   }
-                ], 
-                "description": "Match tabs against one or more $(topic:match_patterns)[URL patterns]. Note that fragment identifiers are not matched.", 
+                ],
+                "description": "Match tabs against one or more $(topic:match_patterns)[URL patterns]. Note that fragment identifiers are not matched.",
                 "optional": true
-              }, 
+              },
               "windowId": {
-                "description": "The ID of the parent window, or $(ref:windows.WINDOW_ID_CURRENT) for the $(topic:current-window)[current window].", 
-                "minimum": -2, 
-                "optional": true, 
+                "description": "The ID of the parent window, or $(ref:windows.WINDOW_ID_CURRENT) for the $(topic:current-window)[current window].",
+                "minimum": -2,
+                "optional": true,
                 "type": "integer"
-              }, 
+              },
               "windowType": {
-                "$ref": "WindowType", 
-                "description": "The type of window the tabs are in.", 
+                "$ref": "WindowType",
+                "description": "The type of window the tabs are in.",
                 "optional": true
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
                 "items": {
                   "$ref": "Tab"
-                }, 
-                "name": "result", 
+                },
+                "name": "result",
                 "type": "array"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Highlights the given tabs.", 
-        "name": "highlight", 
+        "async": "callback",
+        "description": "Highlights the given tabs.",
+        "name": "highlight",
         "parameters": [
           {
-            "name": "highlightInfo", 
+            "name": "highlightInfo",
             "properties": {
+              "populate": {
+                "default": true,
+                "description": "If true, the $(ref:windows.Window) returned will have a <var>tabs</var> property that contains a list of the $(ref:tabs.Tab) objects. The <code>Tab</code> objects only contain the <code>url</code>, <code>title</code> and <code>favIconUrl</code> properties if the extension's manifest file includes the <code>\"tabs\"</code> permission. If false, the $(ref:windows.Window) won't have the <var>tabs</var> property.",
+                "optional": true,
+                "type": "boolean"
+              },
               "tabs": {
                 "choices": [
                   {
                     "items": {
-                      "minimum": 0, 
+                      "minimum": 0,
                       "type": "integer"
-                    }, 
+                    },
                     "type": "array"
-                  }, 
+                  },
                   {
                     "type": "integer"
                   }
-                ], 
+                ],
                 "description": "One or more tab indices to highlight."
-              }, 
+              },
               "windowId": {
-                "description": "The window that contains the tabs.", 
-                "minimum": -2, 
-                "optional": true, 
+                "description": "The window that contains the tabs.",
+                "minimum": -2,
+                "optional": true,
                 "type": "integer"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
+            "name": "callback",
+            "optional": true,
             "parameters": [
               {
-                "$ref": "windows.Window", 
-                "description": "Contains details about the window whose tabs were highlighted.", 
+                "$ref": "windows.Window",
+                "description": "Contains details about the window whose tabs were highlighted.",
                 "name": "window"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
-        "type": "function", 
-        "unsupported": "true"
-      }, 
+        ],
+        "type": "function"
+      },
       {
-        "async": "callback", 
-        "description": "Modifies the properties of a tab. Properties that are not specified in <var>updateProperties</var> are not modified.", 
-        "name": "update", 
+        "async": "callback",
+        "description": "Modifies the properties of a tab. Properties that are not specified in <var>updateProperties</var> are not modified.",
+        "name": "update",
         "parameters": [
           {
-            "description": "Defaults to the selected tab of the $(topic:current-window)[current window].", 
-            "minimum": 0, 
-            "name": "tabId", 
-            "optional": true, 
+            "description": "Defaults to the selected tab of the $(topic:current-window)[current window].",
+            "minimum": 0,
+            "name": "tabId",
+            "optional": true,
             "type": "integer"
-          }, 
+          },
           {
-            "name": "updateProperties", 
+            "name": "updateProperties",
             "properties": {
               "active": {
-                "description": "Whether the tab should be active. Does not affect whether the window is focused (see $(ref:windows.update)).", 
-                "optional": true, 
+                "description": "Whether the tab should be active. Does not affect whether the window is focused (see $(ref:windows.update)).",
+                "optional": true,
                 "type": "boolean"
-              }, 
+              },
               "highlighted": {
-                "description": "Adds or removes the tab from the current selection.", 
-                "optional": true, 
-                "type": "boolean", 
-                "unsupported": true
-              }, 
+                "description": "Adds or removes the tab from the current selection.",
+                "optional": true,
+                "type": "boolean"
+              },
               "loadReplace": {
-                "description": "Whether the load should replace the current history entry for the tab.", 
-                "optional": true, 
+                "description": "Whether the load should replace the current history entry for the tab.",
+                "optional": true,
                 "type": "boolean"
-              }, 
+              },
               "muted": {
-                "description": "Whether the tab should be muted.", 
-                "optional": true, 
+                "description": "Whether the tab should be muted.",
+                "optional": true,
                 "type": "boolean"
-              }, 
+              },
               "openerTabId": {
-                "description": "The ID of the tab that opened this tab. If specified, the opener tab must be in the same window as this tab.", 
-                "minimum": 0, 
-                "optional": true, 
+                "description": "The ID of the tab that opened this tab. If specified, the opener tab must be in the same window as this tab.",
+                "minimum": 0,
+                "optional": true,
                 "type": "integer"
-              }, 
+              },
               "pinned": {
-                "description": "Whether the tab should be pinned.", 
-                "optional": true, 
+                "description": "Whether the tab should be pinned.",
+                "optional": true,
                 "type": "boolean"
-              }, 
+              },
               "selected": {
-                "deprecated": "Please use <em>highlighted</em>.", 
-                "description": "Whether the tab should be selected.", 
-                "optional": true, 
-                "type": "boolean", 
+                "deprecated": "Please use <em>highlighted</em>.",
+                "description": "Whether the tab should be selected.",
+                "optional": true,
+                "type": "boolean",
                 "unsupported": true
-              }, 
+              },
+              "successorTabId": {
+                "description": "The ID of this tab's successor. If specified, the successor tab must be in the same window as this tab.",
+                "minimum": -1,
+                "optional": true,
+                "type": "integer"
+              },
               "url": {
-                "description": "A URL to navigate the tab to.", 
-                "optional": true, 
+                "description": "A URL to navigate the tab to.",
+                "optional": true,
                 "type": "string"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
+            "name": "callback",
+            "optional": true,
             "parameters": [
               {
-                "$ref": "Tab", 
-                "description": "Details about the updated tab. The $(ref:tabs.Tab) object doesn't contain <code>url</code>, <code>title</code> and <code>favIconUrl</code> if the <code>\"tabs\"</code> permission has not been requested.", 
-                "name": "tab", 
+                "$ref": "Tab",
+                "description": "Details about the updated tab. The $(ref:tabs.Tab) object doesn't contain <code>url</code>, <code>title</code> and <code>favIconUrl</code> if the <code>\"tabs\"</code> permission has not been requested.",
+                "name": "tab",
                 "optional": true
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Moves one or more tabs to a new position within its window, or to a new window. Note that tabs can only be moved to and from normal (window.type === \"normal\") windows.", 
-        "name": "move", 
+        "async": "callback",
+        "description": "Moves one or more tabs to a new position within its window, or to a new window. Note that tabs can only be moved to and from normal (window.type === \"normal\") windows.",
+        "name": "move",
         "parameters": [
           {
             "choices": [
               {
-                "minimum": 0, 
+                "minimum": 0,
                 "type": "integer"
-              }, 
+              },
               {
                 "items": {
-                  "minimum": 0, 
+                  "minimum": 0,
                   "type": "integer"
-                }, 
+                },
                 "type": "array"
               }
-            ], 
-            "description": "The tab or list of tabs to move.", 
+            ],
+            "description": "The tab or list of tabs to move.",
             "name": "tabIds"
-          }, 
+          },
           {
-            "name": "moveProperties", 
+            "name": "moveProperties",
             "properties": {
               "index": {
-                "description": "The position to move the window to. -1 will place the tab at the end of the window.", 
-                "minimum": -1, 
+                "description": "The position to move the window to. -1 will place the tab at the end of the window.",
+                "minimum": -1,
                 "type": "integer"
-              }, 
+              },
               "windowId": {
-                "description": "Defaults to the window the tab is currently in.", 
-                "minimum": -2, 
-                "optional": true, 
+                "description": "Defaults to the window the tab is currently in.",
+                "minimum": -2,
+                "optional": true,
                 "type": "integer"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
+            "name": "callback",
+            "optional": true,
             "parameters": [
               {
                 "choices": [
                   {
                     "$ref": "Tab"
-                  }, 
+                  },
                   {
                     "items": {
                       "$ref": "Tab"
-                    }, 
+                    },
                     "type": "array"
                   }
-                ], 
-                "description": "Details about the moved tabs.", 
+                ],
+                "description": "Details about the moved tabs.",
                 "name": "tabs"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Reload a tab.", 
-        "name": "reload", 
+        "async": "callback",
+        "description": "Reload a tab.",
+        "name": "reload",
         "parameters": [
           {
-            "description": "The ID of the tab to reload; defaults to the selected tab of the current window.", 
-            "minimum": 0, 
-            "name": "tabId", 
-            "optional": true, 
+            "description": "The ID of the tab to reload; defaults to the selected tab of the current window.",
+            "minimum": 0,
+            "name": "tabId",
+            "optional": true,
             "type": "integer"
-          }, 
+          },
           {
-            "name": "reloadProperties", 
-            "optional": true, 
+            "name": "reloadProperties",
+            "optional": true,
             "properties": {
               "bypassCache": {
-                "description": "Whether using any local cache. Default is false.", 
-                "optional": true, 
+                "description": "Whether using any local cache. Default is false.",
+                "optional": true,
                 "type": "boolean"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Closes one or more tabs.", 
-        "name": "remove", 
+        "async": "callback",
+        "description": "Closes one or more tabs.",
+        "name": "remove",
         "parameters": [
           {
             "choices": [
               {
-                "minimum": 0, 
+                "minimum": 0,
                 "type": "integer"
-              }, 
+              },
               {
                 "items": {
-                  "minimum": 0, 
+                  "minimum": 0,
                   "type": "integer"
-                }, 
+                },
                 "type": "array"
               }
-            ], 
-            "description": "The tab or list of tabs to close.", 
+            ],
+            "description": "The tab or list of tabs to close.",
             "name": "tabIds"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": true, 
-        "description": "discards one or more tabs.", 
-        "name": "discard", 
+        "async": true,
+        "description": "discards one or more tabs.",
+        "name": "discard",
         "parameters": [
           {
             "choices": [
               {
-                "minimum": 0, 
+                "minimum": 0,
                 "type": "integer"
-              }, 
+              },
               {
                 "items": {
-                  "minimum": 0, 
+                  "minimum": 0,
                   "type": "integer"
-                }, 
+                },
                 "type": "array"
               }
-            ], 
-            "description": "The tab or list of tabs to discard.", 
+            ],
+            "description": "The tab or list of tabs to discard.",
             "name": "tabIds"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Detects the primary language of the content in a tab.", 
-        "name": "detectLanguage", 
+        "async": "callback",
+        "description": "Detects the primary language of the content in a tab.",
+        "name": "detectLanguage",
         "parameters": [
           {
-            "description": "Defaults to the active tab of the $(topic:current-window)[current window].", 
-            "minimum": 0, 
-            "name": "tabId", 
-            "optional": true, 
+            "description": "Defaults to the active tab of the $(topic:current-window)[current window].",
+            "minimum": 0,
+            "name": "tabId",
+            "optional": true,
             "type": "integer"
-          }, 
+          },
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
-                "description": "An ISO language code such as <code>en</code> or <code>fr</code>. For a complete list of languages supported by this method, see <a href='http://src.chromium.org/viewvc/chrome/trunk/src/third_party/cld/languages/internal/languages.cc'>kLanguageInfoTable</a>. The 2nd to 4th columns will be checked and the first non-NULL value will be returned except for Simplified Chinese for which zh-CN will be returned. For an unknown language, <code>und</code> will be returned.", 
-                "name": "language", 
+                "description": "An ISO language code such as <code>en</code> or <code>fr</code>. For a complete list of languages supported by this method, see <a href='http://src.chromium.org/viewvc/chrome/trunk/src/third_party/cld/languages/internal/languages.cc'>kLanguageInfoTable</a>. The 2nd to 4th columns will be checked and the first non-NULL value will be returned except for Simplified Chinese for which zh-CN will be returned. For an unknown language, <code>und</code> will be returned.",
+                "name": "language",
                 "type": "string"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": true, 
-        "description": "Toggles reader mode for the document in the tab.", 
-        "name": "toggleReaderMode", 
+        "async": true,
+        "description": "Toggles reader mode for the document in the tab.",
+        "name": "toggleReaderMode",
         "parameters": [
           {
-            "description": "Defaults to the active tab of the $(topic:current-window)[current window].", 
-            "minimum": 0, 
-            "name": "tabId", 
-            "optional": true, 
+            "description": "Defaults to the active tab of the $(topic:current-window)[current window].",
+            "minimum": 0,
+            "name": "tabId",
+            "optional": true,
             "type": "integer"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Captures the visible area of the currently active tab in the specified window. You must have $(topic:declare_permissions)[&lt;all_urls&gt;] permission to use this method.", 
-        "name": "captureVisibleTab", 
+        "async": true,
+        "description": "Captures the visible area of a specified tab. You must have $(topic:declare_permissions)[&lt;all_urls&gt;] permission to use this method.",
+        "name": "captureTab",
         "parameters": [
           {
-            "description": "The target window. Defaults to the $(topic:current-window)[current window].", 
-            "minimum": -2, 
-            "name": "windowId", 
-            "optional": true, 
+            "description": "The tab to capture. Defaults to the active tab of the current window.",
+            "minimum": 0,
+            "name": "tabId",
+            "optional": true,
             "type": "integer"
-          }, 
+          },
           {
-            "$ref": "extensionTypes.ImageDetails", 
-            "name": "options", 
+            "$ref": "extensionTypes.ImageDetails",
+            "name": "options",
             "optional": true
-          }, 
-          {
-            "name": "callback", 
-            "parameters": [
-              {
-                "description": "A data URL which encodes an image of the visible area of the captured tab. May be assigned to the 'src' property of an HTML Image element for display.", 
-                "name": "dataUrl", 
-                "type": "string"
-              }
-            ], 
-            "type": "function"
           }
-        ], 
+        ],
         "permissions": [
           "<all_urls>"
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Injects JavaScript code into a page. For details, see the $(topic:content_scripts)[programmatic injection] section of the content scripts doc.", 
-        "name": "executeScript", 
+        "async": "callback",
+        "description": "Captures the visible area of the currently active tab in the specified window. You must have $(topic:declare_permissions)[&lt;all_urls&gt;] permission to use this method.",
+        "name": "captureVisibleTab",
         "parameters": [
           {
-            "description": "The ID of the tab in which to run the script; defaults to the active tab of the current window.", 
-            "minimum": 0, 
-            "name": "tabId", 
-            "optional": true, 
+            "description": "The target window. Defaults to the $(topic:current-window)[current window].",
+            "minimum": -2,
+            "name": "windowId",
+            "optional": true,
             "type": "integer"
-          }, 
+          },
           {
-            "$ref": "extensionTypes.InjectDetails", 
-            "description": "Details of the script to run.", 
-            "name": "details"
-          }, 
+            "$ref": "extensionTypes.ImageDetails",
+            "name": "options",
+            "optional": true
+          },
           {
-            "description": "Called after all the JavaScript has been executed.", 
-            "name": "callback", 
-            "optional": true, 
+            "name": "callback",
             "parameters": [
               {
-                "description": "The result of the script in every injected frame.", 
-                "items": {
-                  "type": "any"
-                }, 
-                "name": "result", 
-                "optional": true, 
-                "type": "array"
-              }
-            ], 
-            "type": "function"
-          }
-        ], 
-        "type": "function"
-      }, 
-      {
-        "async": "callback", 
-        "description": "Injects CSS into a page. For details, see the $(topic:content_scripts)[programmatic injection] section of the content scripts doc.", 
-        "name": "insertCSS", 
-        "parameters": [
-          {
-            "description": "The ID of the tab in which to insert the CSS; defaults to the active tab of the current window.", 
-            "minimum": 0, 
-            "name": "tabId", 
-            "optional": true, 
-            "type": "integer"
-          }, 
-          {
-            "$ref": "extensionTypes.InjectDetails", 
-            "description": "Details of the CSS text to insert.", 
-            "name": "details"
-          }, 
-          {
-            "description": "Called when all the CSS has been inserted.", 
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
-            "type": "function"
-          }
-        ], 
-        "type": "function"
-      }, 
-      {
-        "async": "callback", 
-        "description": "Removes injected CSS from a page. For details, see the $(topic:content_scripts)[programmatic injection] section of the content scripts doc.", 
-        "name": "removeCSS", 
-        "parameters": [
-          {
-            "description": "The ID of the tab from which to remove the injected CSS; defaults to the active tab of the current window.", 
-            "minimum": 0, 
-            "name": "tabId", 
-            "optional": true, 
-            "type": "integer"
-          }, 
-          {
-            "$ref": "extensionTypes.InjectDetails", 
-            "description": "Details of the CSS text to remove.", 
-            "name": "details"
-          }, 
-          {
-            "description": "Called when all the CSS has been removed.", 
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
-            "type": "function"
-          }
-        ], 
-        "type": "function"
-      }, 
-      {
-        "async": "callback", 
-        "description": "Zooms a specified tab.", 
-        "name": "setZoom", 
-        "parameters": [
-          {
-            "description": "The ID of the tab to zoom; defaults to the active tab of the current window.", 
-            "minimum": 0, 
-            "name": "tabId", 
-            "optional": true, 
-            "type": "integer"
-          }, 
-          {
-            "description": "The new zoom factor. Use a value of 0 here to set the tab to its current default zoom factor. Values greater than zero specify a (possibly non-default) zoom factor for the tab.", 
-            "name": "zoomFactor", 
-            "type": "number"
-          }, 
-          {
-            "description": "Called after the zoom factor has been changed.", 
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
-            "type": "function"
-          }
-        ], 
-        "type": "function"
-      }, 
-      {
-        "async": "callback", 
-        "description": "Gets the current zoom factor of a specified tab.", 
-        "name": "getZoom", 
-        "parameters": [
-          {
-            "description": "The ID of the tab to get the current zoom factor from; defaults to the active tab of the current window.", 
-            "minimum": 0, 
-            "name": "tabId", 
-            "optional": true, 
-            "type": "integer"
-          }, 
-          {
-            "description": "Called with the tab's current zoom factor after it has been fetched.", 
-            "name": "callback", 
-            "parameters": [
-              {
-                "description": "The tab's current zoom factor.", 
-                "name": "zoomFactor", 
-                "type": "number"
-              }
-            ], 
-            "type": "function"
-          }
-        ], 
-        "type": "function"
-      }, 
-      {
-        "async": "callback", 
-        "description": "Sets the zoom settings for a specified tab, which define how zoom changes are handled. These settings are reset to defaults upon navigating the tab.", 
-        "name": "setZoomSettings", 
-        "parameters": [
-          {
-            "description": "The ID of the tab to change the zoom settings for; defaults to the active tab of the current window.", 
-            "minimum": 0, 
-            "name": "tabId", 
-            "optional": true, 
-            "type": "integer"
-          }, 
-          {
-            "$ref": "ZoomSettings", 
-            "description": "Defines how zoom changes are handled and at what scope.", 
-            "name": "zoomSettings"
-          }, 
-          {
-            "description": "Called after the zoom settings have been changed.", 
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
-            "type": "function"
-          }
-        ], 
-        "type": "function"
-      }, 
-      {
-        "async": "callback", 
-        "description": "Gets the current zoom settings of a specified tab.", 
-        "name": "getZoomSettings", 
-        "parameters": [
-          {
-            "description": "The ID of the tab to get the current zoom settings from; defaults to the active tab of the current window.", 
-            "minimum": 0, 
-            "name": "tabId", 
-            "optional": true, 
-            "type": "integer"
-          }, 
-          {
-            "description": "Called with the tab's current zoom settings.", 
-            "name": "callback", 
-            "parameters": [
-              {
-                "$ref": "ZoomSettings", 
-                "description": "The tab's current zoom settings.", 
-                "name": "zoomSettings"
-              }
-            ], 
-            "type": "function"
-          }
-        ], 
-        "type": "function"
-      }, 
-      {
-        "description": "Prints page in active tab.", 
-        "name": "print", 
-        "parameters": [], 
-        "type": "function"
-      }, 
-      {
-        "async": "callback", 
-        "description": "Shows print preview for page in active tab.", 
-        "name": "printPreview", 
-        "parameters": [
-          {
-            "description": "Called after print preview entered.", 
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
-            "type": "function"
-          }
-        ], 
-        "type": "function"
-      }, 
-      {
-        "async": "callback", 
-        "description": "Saves page in active tab as a PDF file.", 
-        "name": "saveAsPDF", 
-        "parameters": [
-          {
-            "$ref": "PageSettings", 
-            "description": "The page settings used to save the PDF file.", 
-            "name": "pageSettings"
-          }, 
-          {
-            "description": "Called after save as dialog closed.", 
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [
-              {
-                "description": "Save status: saved, replaced, canceled, not_saved, not_replaced.", 
-                "name": "status", 
+                "description": "A data URL which encodes an image of the visible area of the captured tab. May be assigned to the 'src' property of an HTML Image element for display.",
+                "name": "dataUrl",
                 "type": "string"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
+        "permissions": [
+          "<all_urls>"
+        ],
+        "type": "function"
+      },
+      {
+        "async": "callback",
+        "description": "Injects JavaScript code into a page. For details, see the $(topic:content_scripts)[programmatic injection] section of the content scripts doc.",
+        "name": "executeScript",
+        "parameters": [
+          {
+            "description": "The ID of the tab in which to run the script; defaults to the active tab of the current window.",
+            "minimum": 0,
+            "name": "tabId",
+            "optional": true,
+            "type": "integer"
+          },
+          {
+            "$ref": "extensionTypes.InjectDetails",
+            "description": "Details of the script to run.",
+            "name": "details"
+          },
+          {
+            "description": "Called after all the JavaScript has been executed.",
+            "name": "callback",
+            "optional": true,
+            "parameters": [
+              {
+                "description": "The result of the script in every injected frame.",
+                "items": {
+                  "type": "any"
+                },
+                "name": "result",
+                "optional": true,
+                "type": "array"
+              }
+            ],
+            "type": "function"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": "callback",
+        "description": "Injects CSS into a page. For details, see the $(topic:content_scripts)[programmatic injection] section of the content scripts doc.",
+        "name": "insertCSS",
+        "parameters": [
+          {
+            "description": "The ID of the tab in which to insert the CSS; defaults to the active tab of the current window.",
+            "minimum": 0,
+            "name": "tabId",
+            "optional": true,
+            "type": "integer"
+          },
+          {
+            "$ref": "extensionTypes.InjectDetails",
+            "description": "Details of the CSS text to insert.",
+            "name": "details"
+          },
+          {
+            "description": "Called when all the CSS has been inserted.",
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
+            "type": "function"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": "callback",
+        "description": "Removes injected CSS from a page. For details, see the $(topic:content_scripts)[programmatic injection] section of the content scripts doc.",
+        "name": "removeCSS",
+        "parameters": [
+          {
+            "description": "The ID of the tab from which to remove the injected CSS; defaults to the active tab of the current window.",
+            "minimum": 0,
+            "name": "tabId",
+            "optional": true,
+            "type": "integer"
+          },
+          {
+            "$ref": "extensionTypes.InjectDetails",
+            "description": "Details of the CSS text to remove.",
+            "name": "details"
+          },
+          {
+            "description": "Called when all the CSS has been removed.",
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
+            "type": "function"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": "callback",
+        "description": "Zooms a specified tab.",
+        "name": "setZoom",
+        "parameters": [
+          {
+            "description": "The ID of the tab to zoom; defaults to the active tab of the current window.",
+            "minimum": 0,
+            "name": "tabId",
+            "optional": true,
+            "type": "integer"
+          },
+          {
+            "description": "The new zoom factor. Use a value of 0 here to set the tab to its current default zoom factor. Values greater than zero specify a (possibly non-default) zoom factor for the tab.",
+            "name": "zoomFactor",
+            "type": "number"
+          },
+          {
+            "description": "Called after the zoom factor has been changed.",
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
+            "type": "function"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": "callback",
+        "description": "Gets the current zoom factor of a specified tab.",
+        "name": "getZoom",
+        "parameters": [
+          {
+            "description": "The ID of the tab to get the current zoom factor from; defaults to the active tab of the current window.",
+            "minimum": 0,
+            "name": "tabId",
+            "optional": true,
+            "type": "integer"
+          },
+          {
+            "description": "Called with the tab's current zoom factor after it has been fetched.",
+            "name": "callback",
+            "parameters": [
+              {
+                "description": "The tab's current zoom factor.",
+                "name": "zoomFactor",
+                "type": "number"
+              }
+            ],
+            "type": "function"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": "callback",
+        "description": "Sets the zoom settings for a specified tab, which define how zoom changes are handled. These settings are reset to defaults upon navigating the tab.",
+        "name": "setZoomSettings",
+        "parameters": [
+          {
+            "description": "The ID of the tab to change the zoom settings for; defaults to the active tab of the current window.",
+            "minimum": 0,
+            "name": "tabId",
+            "optional": true,
+            "type": "integer"
+          },
+          {
+            "$ref": "ZoomSettings",
+            "description": "Defines how zoom changes are handled and at what scope.",
+            "name": "zoomSettings"
+          },
+          {
+            "description": "Called after the zoom settings have been changed.",
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
+            "type": "function"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": "callback",
+        "description": "Gets the current zoom settings of a specified tab.",
+        "name": "getZoomSettings",
+        "parameters": [
+          {
+            "description": "The ID of the tab to get the current zoom settings from; defaults to the active tab of the current window.",
+            "minimum": 0,
+            "name": "tabId",
+            "optional": true,
+            "type": "integer"
+          },
+          {
+            "description": "Called with the tab's current zoom settings.",
+            "name": "callback",
+            "parameters": [
+              {
+                "$ref": "ZoomSettings",
+                "description": "The tab's current zoom settings.",
+                "name": "zoomSettings"
+              }
+            ],
+            "type": "function"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "description": "Prints page in active tab.",
+        "name": "print",
+        "parameters": [],
+        "type": "function"
+      },
+      {
+        "async": "callback",
+        "description": "Shows print preview for page in active tab.",
+        "name": "printPreview",
+        "parameters": [
+          {
+            "description": "Called after print preview entered.",
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
+            "type": "function"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": "callback",
+        "description": "Saves page in active tab as a PDF file.",
+        "name": "saveAsPDF",
+        "parameters": [
+          {
+            "$ref": "PageSettings",
+            "description": "The page settings used to save the PDF file.",
+            "name": "pageSettings"
+          },
+          {
+            "description": "Called after save as dialog closed.",
+            "name": "callback",
+            "optional": true,
+            "parameters": [
+              {
+                "description": "Save status: saved, replaced, canceled, not_saved, not_replaced.",
+                "name": "status",
+                "type": "string"
+              }
+            ],
+            "type": "function"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": true,
+        "description": "Shows one or more tabs.",
+        "name": "show",
+        "parameters": [
+          {
+            "choices": [
+              {
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "items": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "type": "array"
+              }
+            ],
+            "description": "The TAB ID or list of TAB IDs to show.",
+            "name": "tabIds"
+          }
+        ],
+        "permissions": [
+          "tabHide"
+        ],
+        "type": "function"
+      },
+      {
+        "async": true,
+        "description": "Hides one or more tabs. The <code>\"tabHide\"</code> permission is required to hide tabs.  Not all tabs are hidable.  Returns an array of hidden tabs.",
+        "name": "hide",
+        "parameters": [
+          {
+            "choices": [
+              {
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "items": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "type": "array"
+              }
+            ],
+            "description": "The TAB ID or list of TAB IDs to hide.",
+            "name": "tabIds"
+          }
+        ],
+        "permissions": [
+          "tabHide"
+        ],
+        "type": "function"
+      },
+      {
+        "async": true,
+        "description": "Removes an array of tabs from their lines of succession and prepends or appends them in a chain to another tab.",
+        "name": "moveInSuccession",
+        "parameters": [
+          {
+            "description": "An array of tab IDs to move in the line of succession. For each tab in the array, the tab's current predecessors will have their successor set to the tab's current successor, and each tab will then be set to be the successor of the previous tab in the array. Any tabs not in the same window as the tab indicated by the second argument (or the first tab in the array, if no second argument) will be skipped.",
+            "items": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "minItems": 1,
+            "name": "tabIds",
+            "type": "array"
+          },
+          {
+            "default": -1,
+            "description": "The ID of a tab to set as the successor of the last tab in the array, or $(ref:tabs.TAB_ID_NONE) to leave the last tab without a successor. If options.append is true, then this tab is made the predecessor of the first tab in the array instead.",
+            "minimum": -1,
+            "name": "tabId",
+            "optional": true,
+            "type": "integer"
+          },
+          {
+            "name": "options",
+            "optional": true,
+            "properties": {
+              "append": {
+                "default": false,
+                "description": "Whether to move the tabs before (false) or after (true) tabId in the succession. Defaults to false.",
+                "optional": true,
+                "type": "boolean"
+              },
+              "insert": {
+                "default": false,
+                "description": "Whether to link up the current predecessors or successor (depending on options.append) of tabId to the other side of the chain after it is prepended or appended. If true, one of the following happens: if options.append is false, the first tab in the array is set as the successor of any current predecessors of tabId; if options.append is true, the current successor of tabId is set as the successor of the last tab in the array. Defaults to false.",
+                "optional": true,
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          }
+        ],
         "type": "function"
       }
-    ], 
-    "namespace": "tabs", 
+    ],
+    "namespace": "tabs",
     "properties": {
       "TAB_ID_NONE": {
-        "description": "An ID which represents the absence of a browser tab.", 
+        "description": "An ID which represents the absence of a browser tab.",
         "value": -1
       }
-    }, 
+    },
     "types": [
       {
-        "description": "An event that caused a muted state change.", 
+        "description": "An event that caused a muted state change.",
         "enum": [
           {
-            "description": "A user input action has set/overridden the muted state.", 
+            "description": "A user input action has set/overridden the muted state.",
             "name": "user"
-          }, 
+          },
           {
-            "description": "Tab capture started, forcing a muted state change.", 
+            "description": "Tab capture started, forcing a muted state change.",
             "name": "capture"
-          }, 
+          },
           {
-            "description": "An extension, identified by the extensionId field, set the muted state.", 
+            "description": "An extension, identified by the extensionId field, set the muted state.",
             "name": "extension"
           }
-        ], 
-        "id": "MutedInfoReason", 
+        ],
+        "id": "MutedInfoReason",
         "type": "string"
-      }, 
+      },
       {
-        "description": "Tab muted state and the reason for the last state change.", 
-        "id": "MutedInfo", 
+        "description": "Tab muted state and the reason for the last state change.",
+        "id": "MutedInfo",
         "properties": {
           "extensionId": {
-            "description": "The ID of the extension that changed the muted state. Not set if an extension was not the reason the muted state last changed.", 
-            "optional": true, 
+            "description": "The ID of the extension that changed the muted state. Not set if an extension was not the reason the muted state last changed.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "muted": {
-            "description": "Whether the tab is prevented from playing sound (but hasn't necessarily recently produced sound). Equivalent to whether the muted audio indicator is showing.", 
+            "description": "Whether the tab is prevented from playing sound (but hasn't necessarily recently produced sound). Equivalent to whether the muted audio indicator is showing.",
             "type": "boolean"
-          }, 
+          },
           "reason": {
-            "$ref": "MutedInfoReason", 
-            "description": "The reason the tab was muted or unmuted. Not set if the tab's mute state has never been changed.", 
+            "$ref": "MutedInfoReason",
+            "description": "The reason the tab was muted or unmuted. Not set if the tab's mute state has never been changed.",
             "optional": true
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       {
-        "id": "Tab", 
+        "description": "Tab sharing state for screen, microphone and camera.",
+        "id": "SharingState",
+        "properties": {
+          "camera": {
+            "description": "True if the tab is using the camera.",
+            "type": "boolean"
+          },
+          "microphone": {
+            "description": "True if the tab is using the microphone.",
+            "type": "boolean"
+          },
+          "screen": {
+            "description": "If the tab is sharing the screen the value will be one of \"Screen\", \"Window\", or \"Application\", or undefined if not screen sharing.",
+            "optional": true,
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      {
+        "id": "Tab",
         "properties": {
           "active": {
-            "description": "Whether the tab is active in its window. (Does not necessarily mean the window is focused.)", 
+            "description": "Whether the tab is active in its window. (Does not necessarily mean the window is focused.)",
             "type": "boolean"
-          }, 
+          },
+          "attention": {
+            "description": "Whether the tab is drawing attention.",
+            "optional": true,
+            "type": "boolean"
+          },
           "audible": {
-            "description": "Whether the tab has produced sound over the past couple of seconds (but it might not be heard if also muted). Equivalent to whether the speaker audio indicator is showing.", 
-            "optional": true, 
+            "description": "Whether the tab has produced sound over the past couple of seconds (but it might not be heard if also muted). Equivalent to whether the speaker audio indicator is showing.",
+            "optional": true,
             "type": "boolean"
-          }, 
+          },
           "cookieStoreId": {
-            "description": "The CookieStoreId used for the tab.", 
-            "optional": true, 
+            "description": "The CookieStoreId used for the tab.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "discarded": {
-            "description": "True while the tab is not loaded with content.", 
-            "optional": true, 
+            "description": "True while the tab is not loaded with content.",
+            "optional": true,
             "type": "boolean"
-          }, 
+          },
           "favIconUrl": {
-            "description": "The URL of the tab's favicon. This property is only present if the extension's manifest includes the <code>\"tabs\"</code> permission. It may also be an empty string if the tab is loading.", 
-            "optional": true, 
+            "description": "The URL of the tab's favicon. This property is only present if the extension's manifest includes the <code>\"tabs\"</code> permission. It may also be an empty string if the tab is loading.",
+            "optional": true,
             "permissions": [
               "tabs"
-            ], 
+            ],
             "type": "string"
-          }, 
+          },
           "height": {
-            "description": "The height of the tab in pixels.", 
-            "optional": true, 
+            "description": "The height of the tab in pixels.",
+            "optional": true,
             "type": "integer"
-          }, 
+          },
+          "hidden": {
+            "description": "True if the tab is hidden.",
+            "optional": true,
+            "type": "boolean"
+          },
           "highlighted": {
-            "description": "Whether the tab is highlighted. Works as an alias of active", 
+            "description": "Whether the tab is highlighted. Works as an alias of active",
             "type": "boolean"
-          }, 
+          },
           "id": {
-            "description": "The ID of the tab. Tab IDs are unique within a browser session. Under some circumstances a Tab may not be assigned an ID, for example when querying foreign tabs using the $(ref:sessions) API, in which case a session ID may be present. Tab ID can also be set to $(ref:tabs.TAB_ID_NONE) for apps and devtools windows.", 
-            "minimum": -1, 
-            "optional": true, 
+            "description": "The ID of the tab. Tab IDs are unique within a browser session. Under some circumstances a Tab may not be assigned an ID, for example when querying foreign tabs using the $(ref:sessions) API, in which case a session ID may be present. Tab ID can also be set to $(ref:tabs.TAB_ID_NONE) for apps and devtools windows.",
+            "minimum": -1,
+            "optional": true,
             "type": "integer"
-          }, 
+          },
           "incognito": {
-            "description": "Whether the tab is in an incognito window.", 
+            "description": "Whether the tab is in an incognito window.",
             "type": "boolean"
-          }, 
+          },
           "index": {
-            "description": "The zero-based index of the tab within its window.", 
-            "minimum": -1, 
+            "description": "The zero-based index of the tab within its window.",
+            "minimum": -1,
             "type": "integer"
-          }, 
+          },
           "isArticle": {
-            "description": "Whether the document in the tab can be rendered in reader mode.", 
-            "optional": true, 
+            "description": "Whether the document in the tab can be rendered in reader mode.",
+            "optional": true,
             "type": "boolean"
-          }, 
+          },
           "isInReaderMode": {
-            "description": "Whether the document in the tab is being rendered in reader mode.", 
-            "optional": true, 
+            "description": "Whether the document in the tab is being rendered in reader mode.",
+            "optional": true,
             "type": "boolean"
-          }, 
+          },
           "lastAccessed": {
-            "description": "The last time the tab was accessed as the number of milliseconds since epoch.", 
-            "optional": true, 
+            "description": "The last time the tab was accessed as the number of milliseconds since epoch.",
+            "optional": true,
             "type": "integer"
-          }, 
+          },
           "mutedInfo": {
-            "$ref": "MutedInfo", 
-            "description": "Current tab muted state and the reason for the last state change.", 
+            "$ref": "MutedInfo",
+            "description": "Current tab muted state and the reason for the last state change.",
             "optional": true
-          }, 
+          },
           "openerTabId": {
-            "description": "The ID of the tab that opened this tab, if any. This property is only present if the opener tab still exists.", 
-            "minimum": 0, 
-            "optional": true, 
+            "description": "The ID of the tab that opened this tab, if any. This property is only present if the opener tab still exists.",
+            "minimum": 0,
+            "optional": true,
             "type": "integer"
-          }, 
+          },
           "pinned": {
-            "description": "Whether the tab is pinned.", 
+            "description": "Whether the tab is pinned.",
             "type": "boolean"
-          }, 
+          },
           "selected": {
-            "deprecated": "Please use $(ref:tabs.Tab.highlighted).", 
-            "description": "Whether the tab is selected.", 
-            "type": "boolean", 
+            "deprecated": "Please use $(ref:tabs.Tab.highlighted).",
+            "description": "Whether the tab is selected.",
+            "type": "boolean",
             "unsupported": true
-          }, 
+          },
           "sessionId": {
-            "description": "The session ID used to uniquely identify a Tab obtained from the $(ref:sessions) API.", 
-            "optional": true, 
+            "description": "The session ID used to uniquely identify a Tab obtained from the $(ref:sessions) API.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
+          "sharingState": {
+            "$ref": "SharingState",
+            "description": "Current tab sharing state for screen, microphone and camera.",
+            "optional": true
+          },
           "status": {
-            "description": "Either <em>loading</em> or <em>complete</em>.", 
-            "optional": true, 
+            "description": "Either <em>loading</em> or <em>complete</em>.",
+            "optional": true,
             "type": "string"
-          }, 
-          "title": {
-            "description": "The title of the tab. This property is only present if the extension's manifest includes the <code>\"tabs\"</code> permission.", 
-            "optional": true, 
-            "permissions": [
-              "tabs"
-            ], 
-            "type": "string"
-          }, 
-          "url": {
-            "description": "The URL the tab is displaying. This property is only present if the extension's manifest includes the <code>\"tabs\"</code> permission.", 
-            "optional": true, 
-            "permissions": [
-              "tabs"
-            ], 
-            "type": "string"
-          }, 
-          "width": {
-            "description": "The width of the tab in pixels.", 
-            "optional": true, 
+          },
+          "successorTabId": {
+            "description": "The ID of this tab's successor, if any; $(ref:tabs.TAB_ID_NONE) otherwise.",
+            "minimum": -1,
+            "optional": true,
             "type": "integer"
-          }, 
+          },
+          "title": {
+            "description": "The title of the tab. This property is only present if the extension's manifest includes the <code>\"tabs\"</code> permission.",
+            "optional": true,
+            "permissions": [
+              "tabs"
+            ],
+            "type": "string"
+          },
+          "url": {
+            "description": "The URL the tab is displaying. This property is only present if the extension's manifest includes the <code>\"tabs\"</code> permission.",
+            "optional": true,
+            "permissions": [
+              "tabs"
+            ],
+            "type": "string"
+          },
+          "width": {
+            "description": "The width of the tab in pixels.",
+            "optional": true,
+            "type": "integer"
+          },
           "windowId": {
-            "description": "The ID of the window the tab is contained within.", 
-            "minimum": 0, 
-            "optional": true, 
+            "description": "The ID of the window the tab is contained within.",
+            "minimum": 0,
+            "optional": true,
             "type": "integer"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       {
-        "description": "Defines how zoom changes are handled, i.e. which entity is responsible for the actual scaling of the page; defaults to <code>automatic</code>.", 
+        "description": "Defines how zoom changes are handled, i.e. which entity is responsible for the actual scaling of the page; defaults to <code>automatic</code>.",
         "enum": [
           {
-            "description": "Zoom changes are handled automatically by the browser.", 
+            "description": "Zoom changes are handled automatically by the browser.",
             "name": "automatic"
-          }, 
+          },
           {
-            "description": "Overrides the automatic handling of zoom changes. The <code>onZoomChange</code> event will still be dispatched, and it is the responsibility of the extension to listen for this event and manually scale the page. This mode does not support <code>per-origin</code> zooming, and will thus ignore the <code>scope</code> zoom setting and assume <code>per-tab</code>.", 
+            "description": "Overrides the automatic handling of zoom changes. The <code>onZoomChange</code> event will still be dispatched, and it is the responsibility of the extension to listen for this event and manually scale the page. This mode does not support <code>per-origin</code> zooming, and will thus ignore the <code>scope</code> zoom setting and assume <code>per-tab</code>.",
             "name": "manual"
-          }, 
+          },
           {
-            "description": "Disables all zooming in the tab. The tab will revert to the default zoom level, and all attempted zoom changes will be ignored.", 
+            "description": "Disables all zooming in the tab. The tab will revert to the default zoom level, and all attempted zoom changes will be ignored.",
             "name": "disabled"
           }
-        ], 
-        "id": "ZoomSettingsMode", 
+        ],
+        "id": "ZoomSettingsMode",
         "type": "string"
-      }, 
+      },
       {
-        "description": "Defines whether zoom changes will persist for the page's origin, or only take effect in this tab; defaults to <code>per-origin</code> when in <code>automatic</code> mode, and <code>per-tab</code> otherwise.", 
+        "description": "Defines whether zoom changes will persist for the page's origin, or only take effect in this tab; defaults to <code>per-origin</code> when in <code>automatic</code> mode, and <code>per-tab</code> otherwise.",
         "enum": [
           {
-            "description": "Zoom changes will persist in the zoomed page's origin, i.e. all other tabs navigated to that same origin will be zoomed as well. Moreover, <code>per-origin</code> zoom changes are saved with the origin, meaning that when navigating to other pages in the same origin, they will all be zoomed to the same zoom factor. The <code>per-origin</code> scope is only available in the <code>automatic</code> mode.", 
+            "description": "Zoom changes will persist in the zoomed page's origin, i.e. all other tabs navigated to that same origin will be zoomed as well. Moreover, <code>per-origin</code> zoom changes are saved with the origin, meaning that when navigating to other pages in the same origin, they will all be zoomed to the same zoom factor. The <code>per-origin</code> scope is only available in the <code>automatic</code> mode.",
             "name": "per-origin"
-          }, 
+          },
           {
-            "description": "Zoom changes only take effect in this tab, and zoom changes in other tabs will not affect the zooming of this tab. Also, <code>per-tab</code> zoom changes are reset on navigation; navigating a tab will always load pages with their <code>per-origin</code> zoom factors.", 
+            "description": "Zoom changes only take effect in this tab, and zoom changes in other tabs will not affect the zooming of this tab. Also, <code>per-tab</code> zoom changes are reset on navigation; navigating a tab will always load pages with their <code>per-origin</code> zoom factors.",
             "name": "per-tab"
           }
-        ], 
-        "id": "ZoomSettingsScope", 
+        ],
+        "id": "ZoomSettingsScope",
         "type": "string"
-      }, 
+      },
       {
-        "description": "Defines how zoom changes in a tab are handled and at what scope.", 
-        "id": "ZoomSettings", 
+        "description": "Defines how zoom changes in a tab are handled and at what scope.",
+        "id": "ZoomSettings",
         "properties": {
           "defaultZoomFactor": {
-            "description": "Used to return the default zoom level for the current tab in calls to tabs.getZoomSettings.", 
-            "optional": true, 
+            "description": "Used to return the default zoom level for the current tab in calls to tabs.getZoomSettings.",
+            "optional": true,
             "type": "number"
-          }, 
+          },
           "mode": {
-            "$ref": "ZoomSettingsMode", 
-            "description": "Defines how zoom changes are handled, i.e. which entity is responsible for the actual scaling of the page; defaults to <code>automatic</code>.", 
+            "$ref": "ZoomSettingsMode",
+            "description": "Defines how zoom changes are handled, i.e. which entity is responsible for the actual scaling of the page; defaults to <code>automatic</code>.",
             "optional": true
-          }, 
+          },
           "scope": {
-            "$ref": "ZoomSettingsScope", 
-            "description": "Defines whether zoom changes will persist for the page's origin, or only take effect in this tab; defaults to <code>per-origin</code> when in <code>automatic</code> mode, and <code>per-tab</code> otherwise.", 
+            "$ref": "ZoomSettingsScope",
+            "description": "Defines whether zoom changes will persist for the page's origin, or only take effect in this tab; defaults to <code>per-origin</code> when in <code>automatic</code> mode, and <code>per-tab</code> otherwise.",
             "optional": true
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       {
-        "description": "The page settings including: orientation, scale, background, margins, headers, footers.", 
-        "id": "PageSettings", 
+        "description": "The page settings including: orientation, scale, background, margins, headers, footers.",
+        "id": "PageSettings",
         "properties": {
+          "edgeBottom": {
+            "description": "The spacing between the bottom of the footers and the bottom edge of the paper (inches). Default: 0.",
+            "optional": true,
+            "type": "number"
+          },
+          "edgeLeft": {
+            "description": "The spacing between the left header/footer and the left edge of the paper (inches). Default: 0.",
+            "optional": true,
+            "type": "number"
+          },
+          "edgeRight": {
+            "description": "The spacing between the right header/footer and the right edge of the paper (inches). Default: 0.",
+            "optional": true,
+            "type": "number"
+          },
+          "edgeTop": {
+            "description": "The spacing between the top of the headers and the top edge of the paper (inches). Default: 0",
+            "optional": true,
+            "type": "number"
+          },
           "footerCenter": {
-            "description": "The text for the page's center footer. Default: ''.", 
-            "optional": true, 
+            "description": "The text for the page's center footer. Default: ''.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "footerLeft": {
-            "description": "The text for the page's left footer. Default: '&PT'.", 
-            "optional": true, 
+            "description": "The text for the page's left footer. Default: '&PT'.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "footerRight": {
-            "description": "The text for the page's right footer. Default: '&D'.", 
-            "optional": true, 
+            "description": "The text for the page's right footer. Default: '&D'.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "headerCenter": {
-            "description": "The text for the page's center header. Default: ''.", 
-            "optional": true, 
+            "description": "The text for the page's center header. Default: ''.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "headerLeft": {
-            "description": "The text for the page's left header. Default: '&T'.", 
-            "optional": true, 
+            "description": "The text for the page's left header. Default: '&T'.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "headerRight": {
-            "description": "The text for the page's right header. Default: '&U'.", 
-            "optional": true, 
+            "description": "The text for the page's right header. Default: '&U'.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "marginBottom": {
-            "description": "The margin between the page content and the bottom edge of the paper (inches). Default: 0.5.", 
-            "optional": true, 
+            "description": "The margin between the page content and the bottom edge of the paper (inches). Default: 0.5.",
+            "optional": true,
             "type": "number"
-          }, 
+          },
           "marginLeft": {
-            "description": "The margin between the page content and the left edge of the paper (inches). Default: 0.5.", 
-            "optional": true, 
+            "description": "The margin between the page content and the left edge of the paper (inches). Default: 0.5.",
+            "optional": true,
             "type": "number"
-          }, 
+          },
           "marginRight": {
-            "description": "The margin between the page content and the right edge of the paper (inches). Default: 0.5.", 
-            "optional": true, 
+            "description": "The margin between the page content and the right edge of the paper (inches). Default: 0.5.",
+            "optional": true,
             "type": "number"
-          }, 
+          },
           "marginTop": {
-            "description": "The margin between the page content and the top edge of the paper (inches). Default: 0.5.", 
-            "optional": true, 
+            "description": "The margin between the page content and the top edge of the paper (inches). Default: 0.5.",
+            "optional": true,
             "type": "number"
-          }, 
+          },
           "orientation": {
-            "description": "The page content orientation: 0 = portrait, 1 = landscape. Default: 0.", 
-            "optional": true, 
+            "description": "The page content orientation: 0 = portrait, 1 = landscape. Default: 0.",
+            "optional": true,
             "type": "integer"
-          }, 
+          },
           "paperHeight": {
-            "description": "The paper height in paper size units. Default: 11.0.", 
-            "optional": true, 
+            "description": "The paper height in paper size units. Default: 11.0.",
+            "optional": true,
             "type": "number"
-          }, 
+          },
           "paperSizeUnit": {
-            "description": "The page size unit: 0 = inches, 1 = millimeters. Default: 0.", 
-            "optional": true, 
+            "description": "The page size unit: 0 = inches, 1 = millimeters. Default: 0.",
+            "optional": true,
             "type": "integer"
-          }, 
+          },
           "paperWidth": {
-            "description": "The paper width in paper size units. Default: 8.5.", 
-            "optional": true, 
+            "description": "The paper width in paper size units. Default: 8.5.",
+            "optional": true,
             "type": "number"
-          }, 
+          },
           "scaling": {
-            "description": "The page content scaling factor: 1.0 = 100% = normal size. Default: 1.0.", 
-            "optional": true, 
+            "description": "The page content scaling factor: 1.0 = 100% = normal size. Default: 1.0.",
+            "optional": true,
             "type": "number"
-          }, 
+          },
           "showBackgroundColors": {
-            "description": "Whether the page background colors should be shown. Default: false.", 
-            "optional": true, 
+            "description": "Whether the page background colors should be shown. Default: false.",
+            "optional": true,
             "type": "boolean"
-          }, 
+          },
           "showBackgroundImages": {
-            "description": "Whether the page background images should be shown. Default: false.", 
-            "optional": true, 
+            "description": "Whether the page background images should be shown. Default: false.",
+            "optional": true,
             "type": "boolean"
-          }, 
+          },
           "shrinkToFit": {
-            "description": "Whether the page content should shrink to fit the page width (overrides scaling). Default: true.", 
-            "optional": true, 
+            "description": "Whether the page content should shrink to fit the page width (overrides scaling). Default: true.",
+            "optional": true,
             "type": "boolean"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       {
-        "description": "Whether the tabs have completed loading.", 
+        "description": "Whether the tabs have completed loading.",
         "enum": [
-          "loading", 
+          "loading",
           "complete"
-        ], 
-        "id": "TabStatus", 
+        ],
+        "id": "TabStatus",
         "type": "string"
-      }, 
+      },
       {
-        "description": "The type of window.", 
+        "description": "The type of window.",
         "enum": [
-          "normal", 
-          "popup", 
-          "panel", 
-          "app", 
+          "normal",
+          "popup",
+          "panel",
+          "app",
           "devtools"
-        ], 
-        "id": "WindowType", 
+        ],
+        "id": "WindowType",
         "type": "string"
+      },
+      {
+        "description": "Event names supported in onUpdated.",
+        "enum": [
+          "attention",
+          "audible",
+          "discarded",
+          "favIconUrl",
+          "hidden",
+          "isarticle",
+          "isArticle",
+          "mutedInfo",
+          "pinned",
+          "sharingState",
+          "status",
+          "title"
+        ],
+        "id": "UpdatePropertyName",
+        "type": "string"
+      },
+      {
+        "description": "An object describing filters to apply to tabs.onUpdated events.",
+        "id": "UpdateFilter",
+        "properties": {
+          "properties": {
+            "description": "A list of property names. Events that do not match any of the names will be filtered out.",
+            "items": {
+              "$ref": "UpdatePropertyName"
+            },
+            "minItems": 1,
+            "optional": true,
+            "type": "array"
+          },
+          "tabId": {
+            "optional": true,
+            "type": "integer"
+          },
+          "urls": {
+            "description": "A list of URLs or URL patterns. Events that cannot match any of the URLs will be filtered out.  Filtering with urls requires the <code>\"tabs\"</code> or  <code>\"activeTab\"</code> permission.",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "optional": true,
+            "type": "array"
+          },
+          "windowId": {
+            "optional": true,
+            "type": "integer"
+          }
+        },
+        "type": "object"
       }
     ]
-  }, 
+  },
   {
-    "allowedContexts": [
-      "content", 
-      "devtools"
-    ], 
-    "defaultContexts": [
-      "content", 
-      "devtools"
-    ], 
-    "description": "none", 
-    "events": [
-      {
-        "description": "Used to test sending messages to extensions.", 
-        "name": "onMessage", 
-        "parameters": [
-          {
-            "name": "message", 
-            "type": "string"
-          }, 
-          {
-            "name": "argument", 
-            "type": "any"
-          }
-        ], 
-        "type": "function"
-      }
-    ], 
+    "description": "Use the <code>browser.telemetry</code> API to send telemetry data to the Mozilla Telemetry service. Restricted to Mozilla privileged webextensions.",
     "functions": [
       {
-        "description": "Notifies the browser process that test code running in the extension failed.  This is only used for internal unit testing.", 
-        "name": "notifyFail", 
+        "async": true,
+        "description": "Submits a custom ping to the Telemetry back-end. See <code>submitExternalPing</code> inside TelemetryController.jsm for more details.",
+        "name": "submitPing",
         "parameters": [
           {
-            "name": "message", 
+            "description": "The type of the ping.",
+            "name": "type",
+            "pattern": "^[a-z0-9][a-z0-9-]+[a-z0-9]$",
+            "type": "string"
+          },
+          {
+            "additionalProperties": {
+              "type": "any"
+            },
+            "description": "The data payload for the ping.",
+            "name": "message",
+            "type": "object"
+          },
+          {
+            "description": "Options object.",
+            "name": "options",
+            "properties": {
+              "addClientId": {
+                "default": false,
+                "description": "True if the ping should contain the client id.",
+                "optional": true,
+                "type": "boolean"
+              },
+              "addEnvironment": {
+                "default": false,
+                "description": "True if the ping should contain the environment data.",
+                "optional": true,
+                "type": "boolean"
+              },
+              "overrideEnvironment": {
+                "additionalProperties": {
+                  "type": "any"
+                },
+                "default": false,
+                "description": "Set to override the environment data.",
+                "optional": true,
+                "type": "object"
+              },
+              "usePingSender": {
+                "default": false,
+                "description": "If true, send the ping using the PingSender.",
+                "optional": true,
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": true,
+        "description": "Checks if Telemetry upload is enabled.",
+        "name": "canUpload",
+        "parameters": [],
+        "type": "function"
+      },
+      {
+        "async": true,
+        "description": "Adds the value to the given scalar.",
+        "name": "scalarAdd",
+        "parameters": [
+          {
+            "description": "The scalar name.",
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "description": "The numeric value to add to the scalar. Only unsigned integers supported.",
+            "minimum": 1,
+            "name": "value",
+            "type": "integer"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": true,
+        "description": "Sets the named scalar to the given value. Throws if the value type doesn't match the scalar type.",
+        "name": "scalarSet",
+        "parameters": [
+          {
+            "description": "The scalar name",
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "choices": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "additionalProperties": {
+                  "type": "any"
+                },
+                "type": "object"
+              }
+            ],
+            "description": "The value to set the scalar to",
+            "name": "value"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": true,
+        "description": "Sets the scalar to the maximum of the current and the passed value",
+        "name": "scalarSetMaximum",
+        "parameters": [
+          {
+            "description": "The scalar name.",
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "description": "The numeric value to set the scalar to. Only unsigned integers supported.",
+            "minimum": 0,
+            "name": "value",
+            "type": "integer"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": true,
+        "description": "Record an event in Telemetry. Throws when trying to record an unknown event.",
+        "name": "recordEvent",
+        "parameters": [
+          {
+            "description": "The category name.",
+            "name": "category",
+            "type": "string"
+          },
+          {
+            "description": "The method name.",
+            "name": "method",
+            "type": "string"
+          },
+          {
+            "description": "The object name.",
+            "name": "object",
+            "type": "string"
+          },
+          {
+            "description": "An optional string value to record.",
+            "name": "value",
+            "optional": true,
+            "type": "string"
+          },
+          {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "An optional object of the form (string -> string). It should only contain registered extra keys.",
+            "name": "extra",
+            "optional": true,
+            "type": "object"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": true,
+        "description": "Register new scalars to record them from addons. See nsITelemetry.idl for more details.",
+        "name": "registerScalars",
+        "parameters": [
+          {
+            "description": "The unique category the scalars are registered in.",
+            "name": "category",
+            "type": "string"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "ScalarData"
+            },
+            "description": "An object that contains registration data for multiple scalars. Each property name is the scalar name, and the corresponding property value is an object of ScalarData type.",
+            "name": "data",
+            "type": "object"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": true,
+        "description": "Register new events to record them from addons. See nsITelemetry.idl for more details.",
+        "name": "registerEvents",
+        "parameters": [
+          {
+            "description": "The unique category the events are registered in.",
+            "name": "category",
+            "type": "string"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "EventData"
+            },
+            "description": "An object that contains registration data for 1+ events. Each property name is the category name, and the corresponding property value is an object of EventData type.",
+            "name": "data",
+            "type": "object"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": true,
+        "description": "Enable recording of events in a category. Events default to recording disabled. This allows to toggle recording for all events in the specified category.",
+        "name": "setEventRecordingEnabled",
+        "parameters": [
+          {
+            "description": "The category name.",
+            "name": "category",
+            "type": "string"
+          },
+          {
+            "description": "Whether recording is enabled for events in that category.",
+            "name": "enabled",
+            "type": "boolean"
+          }
+        ],
+        "type": "function"
+      }
+    ],
+    "namespace": "telemetry",
+    "permissions": [
+      "telemetry"
+    ],
+    "types": [
+      {
+        "description": "Type of scalar: 'count' for numeric values, 'string' for string values, 'boolean' for boolean values. Maps to <code>nsITelemetry.SCALAR_TYPE_*</code>.",
+        "enum": [
+          "count",
+          "string",
+          "boolean"
+        ],
+        "id": "ScalarType",
+        "type": "string"
+      },
+      {
+        "description": "Represents registration data for a Telemetry scalar.",
+        "id": "ScalarData",
+        "properties": {
+          "expired": {
+            "default": false,
+            "description": "True if this scalar entry is expired. This allows recording it without error, but it will be discarded.",
+            "optional": true,
+            "type": "boolean"
+          },
+          "keyed": {
+            "default": false,
+            "description": "True if this is a keyed scalar.",
+            "optional": true,
+            "type": "boolean"
+          },
+          "kind": {
+            "$ref": "ScalarType"
+          },
+          "record_on_release": {
+            "default": false,
+            "description": "True if this data should be recorded on release.",
+            "optional": true,
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      {
+        "description": "Represents registration data for a Telemetry event.",
+        "id": "EventData",
+        "properties": {
+          "expired": {
+            "default": false,
+            "description": "True if this event entry is expired. This allows recording it without error, but it will be discarded.",
+            "optional": true,
+            "type": "boolean"
+          },
+          "extra_keys": {
+            "description": "List of allowed extra keys for this event entry.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "methods": {
+            "description": "List of methods for this event entry.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "objects": {
+            "description": "List of objects for this event entry.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "record_on_release": {
+            "default": false,
+            "description": "True if this data should be recorded on release.",
+            "optional": true,
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      }
+    ]
+  },
+  {
+    "allowedContexts": [
+      "content",
+      "devtools"
+    ],
+    "defaultContexts": [
+      "content",
+      "devtools"
+    ],
+    "description": "none",
+    "events": [
+      {
+        "description": "Used to test sending messages to extensions.",
+        "name": "onMessage",
+        "parameters": [
+          {
+            "name": "message",
+            "type": "string"
+          },
+          {
+            "name": "argument",
+            "type": "any"
+          }
+        ],
+        "type": "function"
+      }
+    ],
+    "functions": [
+      {
+        "description": "Notifies the browser process that test code running in the extension failed.  This is only used for internal unit testing.",
+        "name": "notifyFail",
+        "parameters": [
+          {
+            "name": "message",
             "type": "string"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Notifies the browser process that test code running in the extension passed.  This is only used for internal unit testing.", 
-        "name": "notifyPass", 
+        "description": "Notifies the browser process that test code running in the extension passed.  This is only used for internal unit testing.",
+        "name": "notifyPass",
         "parameters": [
           {
-            "name": "message", 
-            "optional": true, 
+            "name": "message",
+            "optional": true,
             "type": "string"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Logs a message during internal unit testing.", 
-        "name": "log", 
+        "description": "Logs a message during internal unit testing.",
+        "name": "log",
         "parameters": [
           {
-            "name": "message", 
+            "name": "message",
             "type": "string"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "allowAmbiguousOptionalArguments": true, 
-        "description": "Sends a string message to the browser process, generating a Notification that C++ test code can wait for.", 
-        "name": "sendMessage", 
+        "allowAmbiguousOptionalArguments": true,
+        "description": "Sends a string message to the browser process, generating a Notification that C++ test code can wait for.",
+        "name": "sendMessage",
         "parameters": [
           {
-            "name": "arg1", 
-            "optional": true, 
+            "name": "arg1",
+            "optional": true,
             "type": "any"
-          }, 
+          },
           {
-            "name": "arg2", 
-            "optional": true, 
+            "name": "arg2",
+            "optional": true,
             "type": "any"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "name": "fail", 
+        "name": "fail",
         "parameters": [
           {
-            "name": "message", 
-            "optional": true, 
+            "name": "message",
+            "optional": true,
             "type": "any"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "name": "succeed", 
+        "name": "succeed",
         "parameters": [
           {
-            "name": "message", 
-            "optional": true, 
+            "name": "message",
+            "optional": true,
             "type": "any"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "allowAmbiguousOptionalArguments": true, 
-        "name": "assertTrue", 
+        "allowAmbiguousOptionalArguments": true,
+        "name": "assertTrue",
         "parameters": [
           {
-            "name": "test", 
-            "optional": true, 
+            "name": "test",
+            "optional": true,
             "type": "any"
-          }, 
+          },
           {
-            "name": "message", 
-            "optional": true, 
+            "name": "message",
+            "optional": true,
             "type": "string"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "allowAmbiguousOptionalArguments": true, 
-        "name": "assertFalse", 
+        "allowAmbiguousOptionalArguments": true,
+        "name": "assertFalse",
         "parameters": [
           {
-            "name": "test", 
-            "optional": true, 
+            "name": "test",
+            "optional": true,
             "type": "any"
-          }, 
+          },
           {
-            "name": "message", 
-            "optional": true, 
+            "name": "message",
+            "optional": true,
             "type": "string"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "name": "assertBool", 
+        "name": "assertBool",
         "parameters": [
           {
             "choices": [
               {
                 "type": "string"
-              }, 
+              },
               {
                 "type": "boolean"
               }
-            ], 
+            ],
             "name": "test"
-          }, 
+          },
           {
-            "name": "expected", 
+            "name": "expected",
             "type": "boolean"
-          }, 
+          },
           {
-            "name": "message", 
-            "optional": true, 
+            "name": "message",
+            "optional": true,
             "type": "string"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
-      }, 
+      },
       {
-        "allowAmbiguousOptionalArguments": true, 
-        "name": "checkDeepEq", 
+        "allowAmbiguousOptionalArguments": true,
+        "name": "checkDeepEq",
         "parameters": [
           {
-            "name": "expected", 
+            "name": "expected",
             "type": "any"
-          }, 
+          },
           {
-            "name": "actual", 
+            "name": "actual",
             "type": "any"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
-      }, 
+      },
       {
-        "allowAmbiguousOptionalArguments": true, 
-        "name": "assertEq", 
+        "allowAmbiguousOptionalArguments": true,
+        "name": "assertEq",
         "parameters": [
           {
-            "name": "expected", 
-            "optional": true, 
+            "name": "expected",
+            "optional": true,
             "type": "any"
-          }, 
+          },
           {
-            "name": "actual", 
-            "optional": true, 
+            "name": "actual",
+            "optional": true,
             "type": "any"
-          }, 
+          },
           {
-            "name": "message", 
-            "optional": true, 
+            "name": "message",
+            "optional": true,
             "type": "string"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "name": "assertNoLastError", 
-        "parameters": [], 
-        "type": "function", 
+        "name": "assertNoLastError",
+        "parameters": [],
+        "type": "function",
         "unsupported": true
-      }, 
+      },
       {
-        "name": "assertLastError", 
+        "name": "assertLastError",
         "parameters": [
           {
-            "name": "expectedError", 
+            "name": "expectedError",
             "type": "string"
           }
-        ], 
-        "type": "function", 
+        ],
+        "type": "function",
         "unsupported": true
-      }, 
+      },
       {
-        "async": true, 
-        "name": "assertRejects", 
+        "async": true,
+        "name": "assertRejects",
         "parameters": [
           {
-            "$ref": "Promise", 
+            "$ref": "Promise",
             "name": "promise"
-          }, 
+          },
           {
-            "$ref": "ExpectedError", 
-            "name": "expectedError", 
+            "$ref": "ExpectedError",
+            "name": "expectedError",
             "optional": true
-          }, 
+          },
           {
-            "name": "message", 
-            "optional": true, 
+            "name": "message",
+            "optional": true,
             "type": "string"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "name": "assertThrows", 
+        "name": "assertThrows",
         "parameters": [
           {
-            "name": "func", 
+            "name": "func",
             "type": "function"
-          }, 
+          },
           {
-            "$ref": "ExpectedError", 
-            "name": "expectedError", 
+            "$ref": "ExpectedError",
+            "name": "expectedError",
             "optional": true
-          }, 
+          },
           {
-            "name": "message", 
-            "optional": true, 
+            "name": "message",
+            "optional": true,
             "type": "string"
           }
-        ], 
+        ],
         "type": "function"
       }
-    ], 
-    "namespace": "test", 
+    ],
+    "namespace": "test",
     "types": [
       {
         "choices": [
           {
             "type": "string"
-          }, 
+          },
           {
-            "additionalProperties": true, 
-            "isInstanceOf": "RegExp", 
+            "additionalProperties": true,
+            "isInstanceOf": "RegExp",
             "type": "object"
-          }, 
+          },
           {
             "type": "function"
           }
-        ], 
+        ],
         "id": "ExpectedError"
-      }, 
+      },
       {
         "choices": [
           {
-            "additionalProperties": true, 
+            "additionalProperties": true,
             "properties": {
               "then": {
                 "type": "function"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "additionalProperties": true, 
-            "isInstanceOf": "Promise", 
+            "additionalProperties": true,
+            "isInstanceOf": "Promise",
             "type": "object"
           }
-        ], 
+        ],
         "id": "Promise"
       }
     ]
-  }, 
+  },
   {
-    "description": "The theme API allows customizing of visual elements of the browser.", 
+    "description": "The theme API allows customizing of visual elements of the browser.",
     "events": [
       {
-        "description": "Fired when a new theme has been applied", 
-        "name": "onUpdated", 
+        "description": "Fired when a new theme has been applied",
+        "name": "onUpdated",
         "parameters": [
           {
-            "$ref": "ThemeUpdateInfo", 
-            "description": "Details of the theme update", 
+            "$ref": "ThemeUpdateInfo",
+            "description": "Details of the theme update",
             "name": "updateInfo"
           }
-        ], 
+        ],
         "type": "function"
       }
-    ], 
+    ],
     "functions": [
       {
-        "async": true, 
-        "description": "Returns the current theme for the specified window or the last focused window.", 
-        "name": "getCurrent", 
+        "async": true,
+        "description": "Returns the current theme for the specified window or the last focused window.",
+        "name": "getCurrent",
         "parameters": [
           {
-            "description": "The window for which we want the theme.", 
-            "name": "windowId", 
-            "optional": true, 
+            "description": "The window for which we want the theme.",
+            "name": "windowId",
+            "optional": true,
             "type": "integer"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": true, 
-        "description": "Make complete updates to the theme. Resolves when the update has completed.", 
-        "name": "update", 
+        "async": true,
+        "description": "Make complete updates to the theme. Resolves when the update has completed.",
+        "name": "update",
         "parameters": [
           {
-            "description": "The id of the window to update. No id updates all windows.", 
-            "name": "windowId", 
-            "optional": true, 
+            "description": "The id of the window to update. No id updates all windows.",
+            "name": "windowId",
+            "optional": true,
             "type": "integer"
-          }, 
+          },
           {
-            "$ref": "manifest.ThemeType", 
-            "description": "The properties of the theme to update.", 
+            "$ref": "manifest.ThemeType",
+            "description": "The properties of the theme to update.",
             "name": "details"
           }
-        ], 
+        ],
+        "permissions": [
+          "theme"
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": true, 
-        "description": "Removes the updates made to the theme.", 
-        "name": "reset", 
+        "async": true,
+        "description": "Removes the updates made to the theme.",
+        "name": "reset",
         "parameters": [
           {
-            "description": "The id of the window to reset. No id resets all windows.", 
-            "name": "windowId", 
-            "optional": true, 
+            "description": "The id of the window to reset. No id resets all windows.",
+            "name": "windowId",
+            "optional": true,
             "type": "integer"
           }
-        ], 
+        ],
+        "permissions": [
+          "theme"
+        ],
         "type": "function"
       }
-    ], 
-    "namespace": "theme", 
-    "permissions": [
-      "theme"
-    ], 
+    ],
+    "namespace": "theme",
     "types": [
       {
-        "description": "Info provided in the onUpdated listener.", 
-        "id": "ThemeUpdateInfo", 
+        "description": "Info provided in the onUpdated listener.",
+        "id": "ThemeUpdateInfo",
         "properties": {
           "theme": {
-            "description": "The new theme after update", 
+            "description": "The new theme after update",
             "type": "object"
-          }, 
+          },
           "windowId": {
-            "description": "The id of the window the theme has been applied to", 
-            "optional": true, 
+            "description": "The id of the window the theme has been applied to",
+            "optional": true,
             "type": "integer"
           }
-        }, 
+        },
         "type": "object"
       }
     ]
-  }, 
+  },
   {
-    "description": "Use the chrome.topSites API to access the top sites that are displayed on the new tab page. ", 
+    "description": "Use the chrome.topSites API to access the top sites that are displayed on the new tab page. ",
     "functions": [
       {
-        "async": "callback", 
-        "description": "Gets a list of top sites.", 
-        "name": "get", 
+        "async": "callback",
+        "description": "Gets a list of top sites.",
+        "name": "get",
         "parameters": [
           {
-            "name": "options", 
-            "optional": true, 
+            "default": {},
+            "name": "options",
+            "optional": true,
             "properties": {
+              "includeBlocked": {
+                "default": false,
+                "description": "Include sites that the user has blocked from appearing on the Firefox new tab.",
+                "optional": true,
+                "type": "boolean"
+              },
+              "includeFavicon": {
+                "default": false,
+                "description": "Include sites favicon if available.",
+                "optional": true,
+                "type": "boolean"
+              },
+              "includePinned": {
+                "default": false,
+                "description": "Include sites that the user has pinned on the Firefox new tab.",
+                "optional": true,
+                "type": "boolean"
+              },
+              "includeSearchShortcuts": {
+                "default": false,
+                "description": "Include search shortcuts appearing on the Firefox new tab.",
+                "optional": true,
+                "type": "boolean"
+              },
+              "limit": {
+                "default": 12,
+                "description": "The number of top sites to return, defaults to the value used by Firefox",
+                "maximum": 100,
+                "minimum": 1,
+                "optional": true,
+                "type": "integer"
+              },
+              "newtab": {
+                "default": false,
+                "description": "Return the sites that exactly appear on the user's new-tab page. When true, all other options are ignored except limit and includeFavicon.",
+                "optional": true,
+                "type": "boolean"
+              },
+              "onePerDomain": {
+                "default": true,
+                "description": "Limit the result to a single top site link per domain",
+                "optional": true,
+                "type": "boolean"
+              },
               "providers": {
-                "description": "Which providers to get top sites from. Possible values are \"places\" and \"activityStream\".", 
+                "default": [],
+                "deprecated": "Please use the other options to tune the results received from topSites.",
                 "items": {
                   "type": "string"
-                }, 
-                "optional": true, 
+                },
+                "optional": true,
                 "type": "array"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
                 "items": {
                   "$ref": "MostVisitedURL"
-                }, 
-                "name": "results", 
+                },
+                "name": "results",
                 "type": "array"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
       }
-    ], 
-    "namespace": "topSites", 
+    ],
+    "namespace": "topSites",
     "permissions": [
       "topSites"
-    ], 
+    ],
     "types": [
       {
-        "description": "An object encapsulating a most visited URL, such as the URLs on the new tab page.", 
-        "id": "MostVisitedURL", 
+        "description": "An object encapsulating a most visited URL, such as the URLs on the new tab page.",
+        "id": "MostVisitedURL",
         "properties": {
-          "title": {
-            "description": "The title of the page.", 
-            "optional": true, 
+          "favicon": {
+            "description": "Data URL for the favicon, if available.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
+          "title": {
+            "description": "The title of the page.",
+            "optional": true,
+            "type": "string"
+          },
+          "type": {
+            "default": "url",
+            "description": "The entry type, either <code>url</code> for a normal page link, or <code>search</code> for a search shortcut.",
+            "enum": [
+              "url",
+              "search"
+            ],
+            "optional": true,
+            "type": "string"
+          },
           "url": {
-            "description": "The most visited URL.", 
+            "description": "The most visited URL.",
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
       }
     ]
-  }, 
+  },
   {
-    "description": "Contains types used by other schemas.", 
-    "namespace": "types", 
+    "description": "Contains types used by other schemas.",
+    "namespace": "types",
     "types": [
       {
-        "description": "The scope of the Setting. One of<ul><li><var>regular</var>: setting for the regular profile (which is inherited by the incognito profile if not overridden elsewhere),</li><li><var>regular_only</var>: setting for the regular profile only (not inherited by the incognito profile),</li><li><var>incognito_persistent</var>: setting for the incognito profile that survives browser restarts (overrides regular preferences),</li><li><var>incognito_session_only</var>: setting for the incognito profile that can only be set during an incognito session and is deleted when the incognito session ends (overrides regular and incognito_persistent preferences).</li></ul> Only <var>regular</var> is supported by Firefox at this time.", 
+        "description": "The scope of the Setting. One of<ul><li><var>regular</var>: setting for the regular profile (which is inherited by the incognito profile if not overridden elsewhere),</li><li><var>regular_only</var>: setting for the regular profile only (not inherited by the incognito profile),</li><li><var>incognito_persistent</var>: setting for the incognito profile that survives browser restarts (overrides regular preferences),</li><li><var>incognito_session_only</var>: setting for the incognito profile that can only be set during an incognito session and is deleted when the incognito session ends (overrides regular and incognito_persistent preferences).</li></ul> Only <var>regular</var> is supported by Firefox at this time.",
         "enum": [
-          "regular", 
-          "regular_only", 
-          "incognito_persistent", 
+          "regular",
+          "regular_only",
+          "incognito_persistent",
           "incognito_session_only"
-        ], 
-        "id": "SettingScope", 
+        ],
+        "id": "SettingScope",
         "type": "string"
-      }, 
+      },
       {
-        "description": "One of<ul><li><var>not_controllable</var>: cannot be controlled by any extension</li><li><var>controlled_by_other_extensions</var>: controlled by extensions with higher precedence</li><li><var>controllable_by_this_extension</var>: can be controlled by this extension</li><li><var>controlled_by_this_extension</var>: controlled by this extension</li></ul>", 
+        "description": "One of<ul><li><var>not_controllable</var>: cannot be controlled by any extension</li><li><var>controlled_by_other_extensions</var>: controlled by extensions with higher precedence</li><li><var>controllable_by_this_extension</var>: can be controlled by this extension</li><li><var>controlled_by_this_extension</var>: controlled by this extension</li></ul>",
         "enum": [
-          "not_controllable", 
-          "controlled_by_other_extensions", 
-          "controllable_by_this_extension", 
+          "not_controllable",
+          "controlled_by_other_extensions",
+          "controllable_by_this_extension",
           "controlled_by_this_extension"
-        ], 
-        "id": "LevelOfControl", 
+        ],
+        "id": "LevelOfControl",
         "type": "string"
-      }, 
+      },
       {
         "events": [
           {
-            "description": "Fired after the setting changes.", 
-            "name": "onChange", 
+            "description": "Fired after the setting changes.",
+            "name": "onChange",
             "parameters": [
               {
-                "name": "details", 
+                "name": "details",
                 "properties": {
                   "incognitoSpecific": {
-                    "description": "Whether the value that has changed is specific to the incognito session.<br/>This property will <em>only</em> be present if the user has enabled the extension in incognito mode.", 
-                    "optional": true, 
+                    "description": "Whether the value that has changed is specific to the incognito session.<br/>This property will <em>only</em> be present if the user has enabled the extension in incognito mode.",
+                    "optional": true,
                     "type": "boolean"
-                  }, 
+                  },
                   "levelOfControl": {
-                    "$ref": "LevelOfControl", 
+                    "$ref": "types.LevelOfControl",
                     "description": "The level of control of the setting."
-                  }, 
+                  },
                   "value": {
-                    "description": "The value of the setting after the change.", 
+                    "description": "The value of the setting after the change.",
                     "type": "any"
                   }
-                }, 
+                },
                 "type": "object"
               }
-            ], 
-            "type": "function", 
+            ],
+            "type": "function",
             "unsupported": true
           }
-        ], 
+        ],
         "functions": [
           {
-            "async": "callback", 
-            "description": "Gets the value of a setting.", 
-            "name": "get", 
+            "async": "callback",
+            "description": "Gets the value of a setting.",
+            "name": "get",
             "parameters": [
               {
-                "description": "Which setting to consider.", 
-                "name": "details", 
+                "description": "Which setting to consider.",
+                "name": "details",
                 "properties": {
                   "incognito": {
-                    "description": "Whether to return the value that applies to the incognito session (default false).", 
-                    "optional": true, 
+                    "description": "Whether to return the value that applies to the incognito session (default false).",
+                    "optional": true,
                     "type": "boolean"
                   }
-                }, 
+                },
                 "type": "object"
-              }, 
+              },
               {
-                "name": "callback", 
+                "name": "callback",
                 "parameters": [
                   {
-                    "description": "Details of the currently effective value.", 
-                    "name": "details", 
+                    "description": "Details of the currently effective value.",
+                    "name": "details",
                     "properties": {
                       "incognitoSpecific": {
-                        "description": "Whether the effective value is specific to the incognito session.<br/>This property will <em>only</em> be present if the <var>incognito</var> property in the <var>details</var> parameter of <code>get()</code> was true.", 
-                        "optional": true, 
+                        "description": "Whether the effective value is specific to the incognito session.<br/>This property will <em>only</em> be present if the <var>incognito</var> property in the <var>details</var> parameter of <code>get()</code> was true.",
+                        "optional": true,
                         "type": "boolean"
-                      }, 
+                      },
                       "levelOfControl": {
-                        "$ref": "LevelOfControl", 
+                        "$ref": "types.LevelOfControl",
                         "description": "The level of control of the setting."
-                      }, 
+                      },
                       "value": {
-                        "description": "The value of the setting.", 
+                        "description": "The value of the setting.",
                         "type": "any"
                       }
-                    }, 
+                    },
                     "type": "object"
                   }
-                ], 
+                ],
                 "type": "function"
               }
-            ], 
+            ],
             "type": "function"
-          }, 
+          },
           {
-            "async": "callback", 
-            "description": "Sets the value of a setting.", 
-            "name": "set", 
+            "async": "callback",
+            "description": "Sets the value of a setting.",
+            "name": "set",
             "parameters": [
               {
-                "description": "Which setting to change.", 
-                "name": "details", 
+                "description": "Which setting to change.",
+                "name": "details",
                 "properties": {
                   "scope": {
-                    "$ref": "SettingScope", 
-                    "description": "Where to set the setting (default: regular).", 
+                    "$ref": "types.SettingScope",
+                    "description": "Where to set the setting (default: regular).",
                     "optional": true
-                  }, 
+                  },
                   "value": {
-                    "description": "The value of the setting. <br/>Note that every setting has a specific value type, which is described together with the setting. An extension should <em>not</em> set a value of a different type.", 
+                    "description": "The value of the setting. <br/>Note that every setting has a specific value type, which is described together with the setting. An extension should <em>not</em> set a value of a different type.",
                     "type": "any"
                   }
-                }, 
+                },
                 "type": "object"
-              }, 
+              },
               {
-                "description": "Called at the completion of the set operation.", 
-                "name": "callback", 
-                "optional": true, 
-                "parameters": [], 
+                "description": "Called at the completion of the set operation.",
+                "name": "callback",
+                "optional": true,
+                "parameters": [],
                 "type": "function"
               }
-            ], 
+            ],
             "type": "function"
-          }, 
+          },
           {
-            "async": "callback", 
-            "description": "Clears the setting, restoring any default value.", 
-            "name": "clear", 
+            "async": "callback",
+            "description": "Clears the setting, restoring any default value.",
+            "name": "clear",
             "parameters": [
               {
-                "description": "Which setting to clear.", 
-                "name": "details", 
+                "description": "Which setting to clear.",
+                "name": "details",
                 "properties": {
                   "scope": {
-                    "$ref": "SettingScope", 
-                    "description": "Where to clear the setting (default: regular).", 
+                    "$ref": "types.SettingScope",
+                    "description": "Where to clear the setting (default: regular).",
                     "optional": true
                   }
-                }, 
+                },
                 "type": "object"
-              }, 
+              },
               {
-                "description": "Called at the completion of the clear operation.", 
-                "name": "callback", 
-                "optional": true, 
-                "parameters": [], 
+                "description": "Called at the completion of the clear operation.",
+                "name": "callback",
+                "optional": true,
+                "parameters": [],
                 "type": "function"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
-        "id": "Setting", 
+        ],
+        "id": "Setting",
         "type": "object"
       }
     ]
-  }, 
+  },
   {
-    "description": "Use the <code>browser.webNavigation</code> API to receive notifications about the status of navigation requests in-flight.", 
+    "description": "Use the <code>browser.urlbar</code> API to experiment with new features in the URLBar. Restricted to Mozilla privileged WebExtensions.",
     "events": [
       {
-        "description": "Fired when a navigation is about to occur.", 
+        "description": "Before a query starts, this event is fired for the given provider. Its purpose is to request the provider's behavior for the query. The listener should return a behavior in response. By default, providers are inactive, so if your provider should always be inactive, you don't need to listen for this event.",
         "extraParameters": [
           {
-            "$ref": "EventUrlFilters", 
-            "description": "Conditions that the URL being navigated to must satisfy. The 'schemes' and 'ports' fields of UrlFilter are ignored for this event.", 
-            "name": "filters", 
-            "optional": true
+            "description": "The name of the provider whose behavior the listener returns.",
+            "name": "providerName",
+            "pattern": "^[a-zA-Z0-9_-]+$",
+            "type": "string"
           }
-        ], 
-        "name": "onBeforeNavigate", 
+        ],
+        "name": "onBehaviorRequested",
         "parameters": [
           {
-            "name": "details", 
-            "properties": {
-              "frameId": {
-                "description": "0 indicates the navigation happens in the tab content window; a positive value indicates navigation in a subframe. Frame IDs are unique for a given tab and process.", 
-                "type": "integer"
-              }, 
-              "parentFrameId": {
-                "description": "ID of frame that wraps the frame. Set to -1 of no parent frame exists.", 
-                "type": "integer"
-              }, 
-              "processId": {
-                "description": "The ID of the process runs the renderer for this tab.", 
-                "type": "integer", 
-                "unsupported": true
-              }, 
-              "tabId": {
-                "description": "The ID of the tab in which the navigation is about to occur.", 
-                "type": "integer"
-              }, 
-              "timeStamp": {
-                "description": "The time when the browser was about to start the navigation, in milliseconds since the epoch.", 
-                "type": "number"
-              }, 
-              "url": {
-                "type": "string"
-              }
-            }, 
-            "type": "object"
+            "$ref": "Query",
+            "description": "The query for which the behavior is requested.",
+            "name": "query"
           }
-        ], 
+        ],
+        "returns": {
+          "description": "The behavior of the provider for the query.",
+          "enum": [
+            "active",
+            "inactive",
+            "restricting"
+          ],
+          "type": "string"
+        },
         "type": "function"
-      }, 
+      },
       {
-        "description": "Fired when a navigation is committed. The document (and the resources it refers to, such as images and subframes) might still be downloading, but at least part of the document has been received from the server and the browser has decided to switch to the new document.", 
+        "description": "This event is fired for the given provider when a query is canceled. The listener should stop any ongoing fetch or creation of results and clean up its resources.",
         "extraParameters": [
           {
-            "$ref": "EventUrlFilters", 
-            "description": "Conditions that the URL being navigated to must satisfy. The 'schemes' and 'ports' fields of UrlFilter are ignored for this event.", 
-            "name": "filters", 
-            "optional": true
+            "description": "The name of the provider that is creating results for the query.",
+            "name": "providerName",
+            "pattern": "^[a-zA-Z0-9_-]+$",
+            "type": "string"
           }
-        ], 
-        "name": "onCommitted", 
+        ],
+        "name": "onQueryCanceled",
         "parameters": [
           {
-            "name": "details", 
-            "properties": {
-              "frameId": {
-                "description": "0 indicates the navigation happens in the tab content window; a positive value indicates navigation in a subframe. Frame IDs are unique within a tab.", 
-                "type": "integer"
-              }, 
-              "processId": {
-                "description": "The ID of the process runs the renderer for this tab.", 
-                "type": "integer", 
-                "unsupported": true
-              }, 
-              "tabId": {
-                "description": "The ID of the tab in which the navigation occurs.", 
-                "type": "integer"
-              }, 
-              "timeStamp": {
-                "description": "The time when the navigation was committed, in milliseconds since the epoch.", 
-                "type": "number"
-              }, 
-              "transitionQualifiers": {
-                "description": "A list of transition qualifiers.", 
-                "items": {
-                  "$ref": "TransitionQualifier"
-                }, 
-                "type": "array", 
-                "unsupported": true
-              }, 
-              "transitionType": {
-                "$ref": "TransitionType", 
-                "description": "Cause of the navigation.", 
-                "unsupported": true
-              }, 
-              "url": {
-                "type": "string"
-              }
-            }, 
-            "type": "object"
+            "$ref": "Query",
+            "description": "The query that was canceled.",
+            "name": "query"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Fired when the page's DOM is fully constructed, but the referenced resources may not finish loading.", 
+        "description": "When a query starts, this event is fired for the given provider if the provider is active for the query and there are no other providers that are restricting. Its purpose is to request the provider's results for the query. The listener should return a list of results in response.",
         "extraParameters": [
           {
-            "$ref": "EventUrlFilters", 
-            "description": "Conditions that the URL being navigated to must satisfy. The 'schemes' and 'ports' fields of UrlFilter are ignored for this event.", 
-            "name": "filters", 
-            "optional": true
+            "description": "The name of the provider whose results the listener returns.",
+            "name": "providerName",
+            "pattern": "^[a-zA-Z0-9_-]+$",
+            "type": "string"
           }
-        ], 
-        "name": "onDOMContentLoaded", 
+        ],
+        "name": "onResultsRequested",
         "parameters": [
           {
-            "name": "details", 
-            "properties": {
-              "frameId": {
-                "description": "0 indicates the navigation happens in the tab content window; a positive value indicates navigation in a subframe. Frame IDs are unique within a tab.", 
-                "type": "integer"
-              }, 
-              "processId": {
-                "description": "The ID of the process runs the renderer for this tab.", 
-                "type": "integer", 
-                "unsupported": true
-              }, 
-              "tabId": {
-                "description": "The ID of the tab in which the navigation occurs.", 
-                "type": "integer"
-              }, 
-              "timeStamp": {
-                "description": "The time when the page's DOM was fully constructed, in milliseconds since the epoch.", 
-                "type": "number"
-              }, 
-              "url": {
-                "type": "string"
-              }
-            }, 
-            "type": "object"
+            "$ref": "Query",
+            "description": "The query for which results are requested.",
+            "name": "query"
           }
-        ], 
-        "type": "function"
-      }, 
-      {
-        "description": "Fired when a document, including the resources it refers to, is completely loaded and initialized.", 
-        "extraParameters": [
-          {
-            "$ref": "EventUrlFilters", 
-            "description": "Conditions that the URL being navigated to must satisfy. The 'schemes' and 'ports' fields of UrlFilter are ignored for this event.", 
-            "name": "filters", 
-            "optional": true
-          }
-        ], 
-        "name": "onCompleted", 
-        "parameters": [
-          {
-            "name": "details", 
-            "properties": {
-              "frameId": {
-                "description": "0 indicates the navigation happens in the tab content window; a positive value indicates navigation in a subframe. Frame IDs are unique within a tab.", 
-                "type": "integer"
-              }, 
-              "processId": {
-                "description": "The ID of the process runs the renderer for this tab.", 
-                "type": "integer", 
-                "unsupported": true
-              }, 
-              "tabId": {
-                "description": "The ID of the tab in which the navigation occurs.", 
-                "type": "integer"
-              }, 
-              "timeStamp": {
-                "description": "The time when the document finished loading, in milliseconds since the epoch.", 
-                "type": "number"
-              }, 
-              "url": {
-                "type": "string"
-              }
-            }, 
-            "type": "object"
-          }
-        ], 
-        "type": "function"
-      }, 
-      {
-        "description": "Fired when an error occurs and the navigation is aborted. This can happen if either a network error occurred, or the user aborted the navigation.", 
-        "extraParameters": [
-          {
-            "$ref": "EventUrlFilters", 
-            "description": "Conditions that the URL being navigated to must satisfy. The 'schemes' and 'ports' fields of UrlFilter are ignored for this event.", 
-            "name": "filters", 
-            "optional": true
-          }
-        ], 
-        "name": "onErrorOccurred", 
-        "parameters": [
-          {
-            "name": "details", 
-            "properties": {
-              "error": {
-                "description": "The error description.", 
-                "type": "string", 
-                "unsupported": true
-              }, 
-              "frameId": {
-                "description": "0 indicates the navigation happens in the tab content window; a positive value indicates navigation in a subframe. Frame IDs are unique within a tab.", 
-                "type": "integer"
-              }, 
-              "processId": {
-                "description": "The ID of the process runs the renderer for this tab.", 
-                "type": "integer", 
-                "unsupported": true
-              }, 
-              "tabId": {
-                "description": "The ID of the tab in which the navigation occurs.", 
-                "type": "integer"
-              }, 
-              "timeStamp": {
-                "description": "The time when the error occurred, in milliseconds since the epoch.", 
-                "type": "number"
-              }, 
-              "url": {
-                "type": "string"
-              }
-            }, 
-            "type": "object"
-          }
-        ], 
-        "type": "function"
-      }, 
-      {
-        "description": "Fired when a new window, or a new tab in an existing window, is created to host a navigation.", 
-        "extraParameters": [
-          {
-            "$ref": "EventUrlFilters", 
-            "description": "Conditions that the URL being navigated to must satisfy. The 'schemes' and 'ports' fields of UrlFilter are ignored for this event.", 
-            "name": "filters", 
-            "optional": true
-          }
-        ], 
-        "name": "onCreatedNavigationTarget", 
-        "parameters": [
-          {
-            "name": "details", 
-            "properties": {
-              "sourceFrameId": {
-                "description": "The ID of the frame with sourceTabId in which the navigation is triggered. 0 indicates the main frame.", 
-                "type": "integer"
-              }, 
-              "sourceProcessId": {
-                "description": "The ID of the process runs the renderer for the source tab.", 
-                "type": "integer"
-              }, 
-              "sourceTabId": {
-                "description": "The ID of the tab in which the navigation is triggered.", 
-                "type": "integer"
-              }, 
-              "tabId": {
-                "description": "The ID of the tab in which the url is opened", 
-                "type": "integer"
-              }, 
-              "timeStamp": {
-                "description": "The time when the browser was about to create a new view, in milliseconds since the epoch.", 
-                "type": "number"
-              }, 
-              "url": {
-                "description": "The URL to be opened in the new window.", 
-                "type": "string"
-              }
-            }, 
-            "type": "object"
-          }
-        ], 
-        "type": "function"
-      }, 
-      {
-        "description": "Fired when the reference fragment of a frame was updated. All future events for that frame will use the updated URL.", 
-        "extraParameters": [
-          {
-            "$ref": "EventUrlFilters", 
-            "description": "Conditions that the URL being navigated to must satisfy. The 'schemes' and 'ports' fields of UrlFilter are ignored for this event.", 
-            "name": "filters", 
-            "optional": true
-          }
-        ], 
-        "name": "onReferenceFragmentUpdated", 
-        "parameters": [
-          {
-            "name": "details", 
-            "properties": {
-              "frameId": {
-                "description": "0 indicates the navigation happens in the tab content window; a positive value indicates navigation in a subframe. Frame IDs are unique within a tab.", 
-                "type": "integer"
-              }, 
-              "processId": {
-                "description": "The ID of the process runs the renderer for this tab.", 
-                "type": "integer", 
-                "unsupported": true
-              }, 
-              "tabId": {
-                "description": "The ID of the tab in which the navigation occurs.", 
-                "type": "integer"
-              }, 
-              "timeStamp": {
-                "description": "The time when the navigation was committed, in milliseconds since the epoch.", 
-                "type": "number"
-              }, 
-              "transitionQualifiers": {
-                "description": "A list of transition qualifiers.", 
-                "items": {
-                  "$ref": "TransitionQualifier"
-                }, 
-                "type": "array", 
-                "unsupported": true
-              }, 
-              "transitionType": {
-                "$ref": "TransitionType", 
-                "description": "Cause of the navigation.", 
-                "unsupported": true
-              }, 
-              "url": {
-                "type": "string"
-              }
-            }, 
-            "type": "object"
-          }
-        ], 
-        "type": "function"
-      }, 
-      {
-        "description": "Fired when the contents of the tab is replaced by a different (usually previously pre-rendered) tab.", 
-        "name": "onTabReplaced", 
-        "parameters": [
-          {
-            "name": "details", 
-            "properties": {
-              "replacedTabId": {
-                "description": "The ID of the tab that was replaced.", 
-                "type": "integer"
-              }, 
-              "tabId": {
-                "description": "The ID of the tab that replaced the old tab.", 
-                "type": "integer"
-              }, 
-              "timeStamp": {
-                "description": "The time when the replacement happened, in milliseconds since the epoch.", 
-                "type": "number"
-              }
-            }, 
-            "type": "object"
-          }
-        ], 
-        "type": "function"
-      }, 
-      {
-        "description": "Fired when the frame's history was updated to a new URL. All future events for that frame will use the updated URL.", 
-        "extraParameters": [
-          {
-            "$ref": "EventUrlFilters", 
-            "description": "Conditions that the URL being navigated to must satisfy. The 'schemes' and 'ports' fields of UrlFilter are ignored for this event.", 
-            "name": "filters", 
-            "optional": true
-          }
-        ], 
-        "name": "onHistoryStateUpdated", 
-        "parameters": [
-          {
-            "name": "details", 
-            "properties": {
-              "frameId": {
-                "description": "0 indicates the navigation happens in the tab content window; a positive value indicates navigation in a subframe. Frame IDs are unique within a tab.", 
-                "type": "integer"
-              }, 
-              "processId": {
-                "description": "The ID of the process runs the renderer for this tab.", 
-                "type": "integer", 
-                "unsupported": true
-              }, 
-              "tabId": {
-                "description": "The ID of the tab in which the navigation occurs.", 
-                "type": "integer"
-              }, 
-              "timeStamp": {
-                "description": "The time when the navigation was committed, in milliseconds since the epoch.", 
-                "type": "number"
-              }, 
-              "transitionQualifiers": {
-                "description": "A list of transition qualifiers.", 
-                "items": {
-                  "$ref": "TransitionQualifier"
-                }, 
-                "type": "array", 
-                "unsupported": true
-              }, 
-              "transitionType": {
-                "$ref": "TransitionType", 
-                "description": "Cause of the navigation.", 
-                "unsupported": true
-              }, 
-              "url": {
-                "type": "string"
-              }
-            }, 
-            "type": "object"
-          }
-        ], 
+        ],
+        "returns": {
+          "description": "The results that the provider fetched for the query.",
+          "items": {
+            "$ref": "Result"
+          },
+          "type": "array"
+        },
         "type": "function"
       }
-    ], 
+    ],
+    "namespace": "urlbar",
+    "permissions": [
+      "urlbar"
+    ],
+    "properties": {
+      "engagementTelemetry": {
+        "$ref": "types.Setting",
+        "description": "Enables or disables the engagement telemetry."
+      },
+      "openViewOnFocus": {
+        "$ref": "types.Setting",
+        "description": "Enables or disables the open-view-on-focus mode."
+      }
+    },
+    "types": [
+      {
+        "description": "A query performed in the urlbar.",
+        "id": "Query",
+        "properties": {
+          "acceptableSources": {
+            "description": "List of acceptable source types to return.",
+            "items": {
+              "$ref": "SourceType"
+            },
+            "type": "array"
+          },
+          "isPrivate": {
+            "description": "Whether the query's browser context is private.",
+            "type": "boolean"
+          },
+          "maxResults": {
+            "description": "The maximum number of results shown to the user.",
+            "type": "integer"
+          },
+          "searchString": {
+            "description": "The query's search string.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      {
+        "description": "A result of a query. Queries can have many results. Each result is created by a provider.",
+        "id": "Result",
+        "properties": {
+          "payload": {
+            "description": "An object with arbitrary properties depending on the result's type.",
+            "type": "object"
+          },
+          "source": {
+            "$ref": "SourceType",
+            "description": "The result's source."
+          },
+          "type": {
+            "$ref": "ResultType",
+            "description": "The result's type."
+          }
+        },
+        "type": "object"
+      },
+      {
+        "description": "Possible types of results. <code>remote_tab</code>: A synced tab from another device. <code>search</code>: A search suggestion from a search engine. <code>tab</code>: An open tab in the browser. <code>url</code>: A URL that's not one of the other types.",
+        "enum": [
+          "remote_tab",
+          "search",
+          "tab",
+          "url"
+        ],
+        "id": "ResultType",
+        "type": "string"
+      },
+      {
+        "description": "Possible sources of results. <code>bookmarks</code>: The result comes from the user's bookmarks. <code>history</code>: The result comes from the user's history. <code>search</code>: The result comes from a search engine. <code>tabs</code>: The result is an open tab in the browser or a synced tab from another device. ",
+        "enum": [
+          "bookmarks",
+          "history",
+          "search",
+          "tabs",
+          "local",
+          "network"
+        ],
+        "id": "SourceType",
+        "type": "string"
+      }
+    ]
+  },
+  {
     "functions": [
       {
-        "async": "callback", 
-        "description": "Retrieves information about the given frame. A frame refers to an &lt;iframe&gt; or a &lt;frame&gt; of a web page and is identified by a tab ID and a frame ID.", 
-        "name": "getFrame", 
+        "async": true,
+        "description": "Register a user script programmatically given its $(ref:userScripts.UserScriptOptions), and resolves to a $(ref:userScripts.RegisteredUserScript) instance",
+        "name": "register",
         "parameters": [
           {
-            "description": "Information about the frame to retrieve information about.", 
-            "name": "details", 
-            "properties": {
-              "frameId": {
-                "description": "The ID of the frame in the given tab.", 
-                "minimum": 0, 
-                "type": "integer"
-              }, 
-              "processId": {
-                "description": "The ID of the process runs the renderer for this tab.", 
-                "optional": true, 
-                "type": "integer"
-              }, 
-              "tabId": {
-                "description": "The ID of the tab in which the frame is.", 
-                "minimum": 0, 
-                "type": "integer"
-              }
-            }, 
-            "type": "object"
-          }, 
+            "$ref": "UserScriptOptions",
+            "name": "userScriptOptions"
+          }
+        ],
+        "type": "function"
+      }
+    ],
+    "namespace": "userScripts",
+    "permissions": [
+      "manifest:user_scripts"
+    ],
+    "types": [
+      {
+        "description": "Details of a user script",
+        "id": "UserScriptOptions",
+        "properties": {
+          "allFrames": {
+            "default": false,
+            "description": "If allFrames is <code>true</code>, implies that the JavaScript should be injected into all frames of current page. By default, it's <code>false</code> and is only injected into the top frame.",
+            "optional": true,
+            "type": "boolean"
+          },
+          "excludeGlobs": {
+            "items": {
+              "type": "string"
+            },
+            "optional": true,
+            "type": "array"
+          },
+          "excludeMatches": {
+            "items": {
+              "$ref": "manifest.MatchPattern"
+            },
+            "minItems": 1,
+            "optional": true,
+            "type": "array"
+          },
+          "includeGlobs": {
+            "items": {
+              "type": "string"
+            },
+            "optional": true,
+            "type": "array"
+          },
+          "js": {
+            "description": "The list of JS files to inject",
+            "items": {
+              "$ref": "extensionTypes.ExtensionFileOrCode"
+            },
+            "minItems": 1,
+            "optional": true,
+            "type": "array"
+          },
+          "matchAboutBlank": {
+            "default": false,
+            "description": "If matchAboutBlank is true, then the code is also injected in about:blank and about:srcdoc frames if your extension has access to its parent document. Code cannot be inserted in top-level about:-frames. By default it is <code>false</code>.",
+            "optional": true,
+            "type": "boolean"
+          },
+          "matches": {
+            "items": {
+              "$ref": "manifest.MatchPattern"
+            },
+            "minItems": 1,
+            "optional": false,
+            "type": "array"
+          },
+          "runAt": {
+            "$ref": "extensionTypes.RunAt",
+            "default": "document_idle",
+            "description": "The soonest that the JavaScript will be injected into the tab. Defaults to \"document_idle\".",
+            "optional": true
+          },
+          "scriptMetadata": {
+            "$ref": "extensionTypes.PlainJSONValue",
+            "description": "An opaque user script metadata value",
+            "optional": true
+          }
+        },
+        "type": "object"
+      },
+      {
+        "description": "An object that represents a user script registered programmatically",
+        "functions": [
           {
-            "name": "callback", 
-            "parameters": [
-              {
-                "description": "Information about the requested frame, null if the specified frame ID and/or tab ID are invalid.", 
-                "name": "details", 
-                "optional": true, 
-                "properties": {
-                  "errorOccurred": {
-                    "description": "True if the last navigation in this frame was interrupted by an error, i.e. the onErrorOccurred event fired.", 
-                    "optional": true, 
-                    "type": "boolean"
-                  }, 
-                  "frameId": {
-                    "description": "The ID of the frame. 0 indicates that this is the main frame; a positive value indicates the ID of a subframe.", 
-                    "type": "integer"
-                  }, 
-                  "parentFrameId": {
-                    "description": "ID of frame that wraps the frame. Set to -1 of no parent frame exists.", 
-                    "type": "integer"
-                  }, 
-                  "tabId": {
-                    "description": "The ID of the tab in which the frame is.", 
-                    "type": "integer"
-                  }, 
-                  "url": {
-                    "description": "The URL currently associated with this frame, if the frame identified by the frameId existed at one point in the given tab. The fact that an URL is associated with a given frameId does not imply that the corresponding frame still exists.", 
-                    "type": "string"
-                  }
-                }, 
-                "type": "object"
-              }
-            ], 
+            "async": true,
+            "description": "Unregister a user script registered programmatically",
+            "name": "unregister",
+            "parameters": [],
             "type": "function"
           }
-        ], 
-        "type": "function"
-      }, 
+        ],
+        "id": "RegisteredUserScript",
+        "type": "object"
+      }
+    ]
+  },
+  {
+    "allowedContexts": [
+      "content"
+    ],
+    "events": [
       {
-        "async": "callback", 
-        "description": "Retrieves information about all frames of a given tab.", 
-        "name": "getAllFrames", 
+        "allowedContexts": [
+          "content",
+          "content_only"
+        ],
+        "description": "Event called when a new userScript global has been created",
+        "name": "onBeforeScript",
         "parameters": [
           {
-            "description": "Information about the tab to retrieve all frames from.", 
-            "name": "details", 
+            "name": "userScript",
             "properties": {
+              "defineGlobals": {
+                "description": "Exports all the properties of a given plain object as userScript globals",
+                "parameters": [
+                  {
+                    "description": "A plain object whose properties are exported as userScript globals",
+                    "name": "sourceObject",
+                    "type": "object"
+                  }
+                ],
+                "type": "function"
+              },
+              "export": {
+                "description": "Convert a given value to make it accessible to the userScript code",
+                "parameters": [
+                  {
+                    "description": "A value to convert into an object accessible to the userScript",
+                    "name": "value",
+                    "type": "any"
+                  }
+                ],
+                "returns": {
+                  "type": "any"
+                },
+                "type": "function"
+              },
+              "global": {
+                "description": "The userScript global",
+                "type": "any"
+              },
+              "metadata": {
+                "description": "The userScript metadata (as set in userScripts.register)",
+                "type": "any"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "permissions": [
+          "manifest:user_scripts.api_script"
+        ],
+        "type": "function"
+      }
+    ],
+    "namespace": "userScripts",
+    "permissions": [
+      "manifest:user_scripts"
+    ]
+  },
+  {
+    "description": "Use the <code>browser.webNavigation</code> API to receive notifications about the status of navigation requests in-flight.",
+    "events": [
+      {
+        "description": "Fired when a navigation is about to occur.",
+        "extraParameters": [
+          {
+            "$ref": "EventUrlFilters",
+            "description": "Conditions that the URL being navigated to must satisfy. The 'schemes' and 'ports' fields of UrlFilter are ignored for this event.",
+            "name": "filters",
+            "optional": true
+          }
+        ],
+        "name": "onBeforeNavigate",
+        "parameters": [
+          {
+            "name": "details",
+            "properties": {
+              "frameId": {
+                "description": "0 indicates the navigation happens in the tab content window; a positive value indicates navigation in a subframe. Frame IDs are unique for a given tab and process.",
+                "type": "integer"
+              },
+              "parentFrameId": {
+                "description": "ID of frame that wraps the frame. Set to -1 of no parent frame exists.",
+                "type": "integer"
+              },
+              "processId": {
+                "description": "The ID of the process runs the renderer for this tab.",
+                "type": "integer",
+                "unsupported": true
+              },
               "tabId": {
-                "description": "The ID of the tab.", 
-                "minimum": 0, 
+                "description": "The ID of the tab in which the navigation is about to occur.",
+                "type": "integer"
+              },
+              "timeStamp": {
+                "description": "The time when the browser was about to start the navigation, in milliseconds since the epoch.",
+                "type": "number"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "description": "Fired when a navigation is committed. The document (and the resources it refers to, such as images and subframes) might still be downloading, but at least part of the document has been received from the server and the browser has decided to switch to the new document.",
+        "extraParameters": [
+          {
+            "$ref": "EventUrlFilters",
+            "description": "Conditions that the URL being navigated to must satisfy. The 'schemes' and 'ports' fields of UrlFilter are ignored for this event.",
+            "name": "filters",
+            "optional": true
+          }
+        ],
+        "name": "onCommitted",
+        "parameters": [
+          {
+            "name": "details",
+            "properties": {
+              "frameId": {
+                "description": "0 indicates the navigation happens in the tab content window; a positive value indicates navigation in a subframe. Frame IDs are unique within a tab.",
+                "type": "integer"
+              },
+              "processId": {
+                "description": "The ID of the process runs the renderer for this tab.",
+                "type": "integer",
+                "unsupported": true
+              },
+              "tabId": {
+                "description": "The ID of the tab in which the navigation occurs.",
+                "type": "integer"
+              },
+              "timeStamp": {
+                "description": "The time when the navigation was committed, in milliseconds since the epoch.",
+                "type": "number"
+              },
+              "transitionQualifiers": {
+                "description": "A list of transition qualifiers.",
+                "items": {
+                  "$ref": "TransitionQualifier"
+                },
+                "type": "array",
+                "unsupported": true
+              },
+              "transitionType": {
+                "$ref": "TransitionType",
+                "description": "Cause of the navigation.",
+                "unsupported": true
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "description": "Fired when the page's DOM is fully constructed, but the referenced resources may not finish loading.",
+        "extraParameters": [
+          {
+            "$ref": "EventUrlFilters",
+            "description": "Conditions that the URL being navigated to must satisfy. The 'schemes' and 'ports' fields of UrlFilter are ignored for this event.",
+            "name": "filters",
+            "optional": true
+          }
+        ],
+        "name": "onDOMContentLoaded",
+        "parameters": [
+          {
+            "name": "details",
+            "properties": {
+              "frameId": {
+                "description": "0 indicates the navigation happens in the tab content window; a positive value indicates navigation in a subframe. Frame IDs are unique within a tab.",
+                "type": "integer"
+              },
+              "processId": {
+                "description": "The ID of the process runs the renderer for this tab.",
+                "type": "integer",
+                "unsupported": true
+              },
+              "tabId": {
+                "description": "The ID of the tab in which the navigation occurs.",
+                "type": "integer"
+              },
+              "timeStamp": {
+                "description": "The time when the page's DOM was fully constructed, in milliseconds since the epoch.",
+                "type": "number"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "description": "Fired when a document, including the resources it refers to, is completely loaded and initialized.",
+        "extraParameters": [
+          {
+            "$ref": "EventUrlFilters",
+            "description": "Conditions that the URL being navigated to must satisfy. The 'schemes' and 'ports' fields of UrlFilter are ignored for this event.",
+            "name": "filters",
+            "optional": true
+          }
+        ],
+        "name": "onCompleted",
+        "parameters": [
+          {
+            "name": "details",
+            "properties": {
+              "frameId": {
+                "description": "0 indicates the navigation happens in the tab content window; a positive value indicates navigation in a subframe. Frame IDs are unique within a tab.",
+                "type": "integer"
+              },
+              "processId": {
+                "description": "The ID of the process runs the renderer for this tab.",
+                "type": "integer",
+                "unsupported": true
+              },
+              "tabId": {
+                "description": "The ID of the tab in which the navigation occurs.",
+                "type": "integer"
+              },
+              "timeStamp": {
+                "description": "The time when the document finished loading, in milliseconds since the epoch.",
+                "type": "number"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "description": "Fired when an error occurs and the navigation is aborted. This can happen if either a network error occurred, or the user aborted the navigation.",
+        "extraParameters": [
+          {
+            "$ref": "EventUrlFilters",
+            "description": "Conditions that the URL being navigated to must satisfy. The 'schemes' and 'ports' fields of UrlFilter are ignored for this event.",
+            "name": "filters",
+            "optional": true
+          }
+        ],
+        "name": "onErrorOccurred",
+        "parameters": [
+          {
+            "name": "details",
+            "properties": {
+              "error": {
+                "description": "The error description.",
+                "type": "string",
+                "unsupported": true
+              },
+              "frameId": {
+                "description": "0 indicates the navigation happens in the tab content window; a positive value indicates navigation in a subframe. Frame IDs are unique within a tab.",
+                "type": "integer"
+              },
+              "processId": {
+                "description": "The ID of the process runs the renderer for this tab.",
+                "type": "integer",
+                "unsupported": true
+              },
+              "tabId": {
+                "description": "The ID of the tab in which the navigation occurs.",
+                "type": "integer"
+              },
+              "timeStamp": {
+                "description": "The time when the error occurred, in milliseconds since the epoch.",
+                "type": "number"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "description": "Fired when a new window, or a new tab in an existing window, is created to host a navigation.",
+        "extraParameters": [
+          {
+            "$ref": "EventUrlFilters",
+            "description": "Conditions that the URL being navigated to must satisfy. The 'schemes' and 'ports' fields of UrlFilter are ignored for this event.",
+            "name": "filters",
+            "optional": true
+          }
+        ],
+        "name": "onCreatedNavigationTarget",
+        "parameters": [
+          {
+            "name": "details",
+            "properties": {
+              "sourceFrameId": {
+                "description": "The ID of the frame with sourceTabId in which the navigation is triggered. 0 indicates the main frame.",
+                "type": "integer"
+              },
+              "sourceProcessId": {
+                "description": "The ID of the process runs the renderer for the source tab.",
+                "type": "integer"
+              },
+              "sourceTabId": {
+                "description": "The ID of the tab in which the navigation is triggered.",
+                "type": "integer"
+              },
+              "tabId": {
+                "description": "The ID of the tab in which the url is opened",
+                "type": "integer"
+              },
+              "timeStamp": {
+                "description": "The time when the browser was about to create a new view, in milliseconds since the epoch.",
+                "type": "number"
+              },
+              "url": {
+                "description": "The URL to be opened in the new window.",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "description": "Fired when the reference fragment of a frame was updated. All future events for that frame will use the updated URL.",
+        "extraParameters": [
+          {
+            "$ref": "EventUrlFilters",
+            "description": "Conditions that the URL being navigated to must satisfy. The 'schemes' and 'ports' fields of UrlFilter are ignored for this event.",
+            "name": "filters",
+            "optional": true
+          }
+        ],
+        "name": "onReferenceFragmentUpdated",
+        "parameters": [
+          {
+            "name": "details",
+            "properties": {
+              "frameId": {
+                "description": "0 indicates the navigation happens in the tab content window; a positive value indicates navigation in a subframe. Frame IDs are unique within a tab.",
+                "type": "integer"
+              },
+              "processId": {
+                "description": "The ID of the process runs the renderer for this tab.",
+                "type": "integer",
+                "unsupported": true
+              },
+              "tabId": {
+                "description": "The ID of the tab in which the navigation occurs.",
+                "type": "integer"
+              },
+              "timeStamp": {
+                "description": "The time when the navigation was committed, in milliseconds since the epoch.",
+                "type": "number"
+              },
+              "transitionQualifiers": {
+                "description": "A list of transition qualifiers.",
+                "items": {
+                  "$ref": "TransitionQualifier"
+                },
+                "type": "array",
+                "unsupported": true
+              },
+              "transitionType": {
+                "$ref": "TransitionType",
+                "description": "Cause of the navigation.",
+                "unsupported": true
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "description": "Fired when the contents of the tab is replaced by a different (usually previously pre-rendered) tab.",
+        "name": "onTabReplaced",
+        "parameters": [
+          {
+            "name": "details",
+            "properties": {
+              "replacedTabId": {
+                "description": "The ID of the tab that was replaced.",
+                "type": "integer"
+              },
+              "tabId": {
+                "description": "The ID of the tab that replaced the old tab.",
+                "type": "integer"
+              },
+              "timeStamp": {
+                "description": "The time when the replacement happened, in milliseconds since the epoch.",
+                "type": "number"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "description": "Fired when the frame's history was updated to a new URL. All future events for that frame will use the updated URL.",
+        "extraParameters": [
+          {
+            "$ref": "EventUrlFilters",
+            "description": "Conditions that the URL being navigated to must satisfy. The 'schemes' and 'ports' fields of UrlFilter are ignored for this event.",
+            "name": "filters",
+            "optional": true
+          }
+        ],
+        "name": "onHistoryStateUpdated",
+        "parameters": [
+          {
+            "name": "details",
+            "properties": {
+              "frameId": {
+                "description": "0 indicates the navigation happens in the tab content window; a positive value indicates navigation in a subframe. Frame IDs are unique within a tab.",
+                "type": "integer"
+              },
+              "processId": {
+                "description": "The ID of the process runs the renderer for this tab.",
+                "type": "integer",
+                "unsupported": true
+              },
+              "tabId": {
+                "description": "The ID of the tab in which the navigation occurs.",
+                "type": "integer"
+              },
+              "timeStamp": {
+                "description": "The time when the navigation was committed, in milliseconds since the epoch.",
+                "type": "number"
+              },
+              "transitionQualifiers": {
+                "description": "A list of transition qualifiers.",
+                "items": {
+                  "$ref": "TransitionQualifier"
+                },
+                "type": "array",
+                "unsupported": true
+              },
+              "transitionType": {
+                "$ref": "TransitionType",
+                "description": "Cause of the navigation.",
+                "unsupported": true
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "type": "function"
+      }
+    ],
+    "functions": [
+      {
+        "async": "callback",
+        "description": "Retrieves information about the given frame. A frame refers to an &lt;iframe&gt; or a &lt;frame&gt; of a web page and is identified by a tab ID and a frame ID.",
+        "name": "getFrame",
+        "parameters": [
+          {
+            "description": "Information about the frame to retrieve information about.",
+            "name": "details",
+            "properties": {
+              "frameId": {
+                "description": "The ID of the frame in the given tab.",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "processId": {
+                "description": "The ID of the process runs the renderer for this tab.",
+                "optional": true,
+                "type": "integer"
+              },
+              "tabId": {
+                "description": "The ID of the tab in which the frame is.",
+                "minimum": 0,
                 "type": "integer"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
-                "description": "A list of frames in the given tab, null if the specified tab ID is invalid.", 
+                "description": "Information about the requested frame, null if the specified frame ID and/or tab ID are invalid.",
+                "name": "details",
+                "optional": true,
+                "properties": {
+                  "errorOccurred": {
+                    "description": "True if the last navigation in this frame was interrupted by an error, i.e. the onErrorOccurred event fired.",
+                    "optional": true,
+                    "type": "boolean"
+                  },
+                  "frameId": {
+                    "description": "The ID of the frame. 0 indicates that this is the main frame; a positive value indicates the ID of a subframe.",
+                    "type": "integer"
+                  },
+                  "parentFrameId": {
+                    "description": "ID of frame that wraps the frame. Set to -1 of no parent frame exists.",
+                    "type": "integer"
+                  },
+                  "tabId": {
+                    "description": "The ID of the tab in which the frame is.",
+                    "type": "integer"
+                  },
+                  "url": {
+                    "description": "The URL currently associated with this frame, if the frame identified by the frameId existed at one point in the given tab. The fact that an URL is associated with a given frameId does not imply that the corresponding frame still exists.",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            ],
+            "type": "function"
+          }
+        ],
+        "type": "function"
+      },
+      {
+        "async": "callback",
+        "description": "Retrieves information about all frames of a given tab.",
+        "name": "getAllFrames",
+        "parameters": [
+          {
+            "description": "Information about the tab to retrieve all frames from.",
+            "name": "details",
+            "properties": {
+              "tabId": {
+                "description": "The ID of the tab.",
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "type": "object"
+          },
+          {
+            "name": "callback",
+            "parameters": [
+              {
+                "description": "A list of frames in the given tab, null if the specified tab ID is invalid.",
                 "items": {
                   "properties": {
                     "errorOccurred": {
-                      "description": "True if the last navigation in this frame was interrupted by an error, i.e. the onErrorOccurred event fired.", 
-                      "optional": true, 
+                      "description": "True if the last navigation in this frame was interrupted by an error, i.e. the onErrorOccurred event fired.",
+                      "optional": true,
                       "type": "boolean"
-                    }, 
+                    },
                     "frameId": {
-                      "description": "The ID of the frame. 0 indicates that this is the main frame; a positive value indicates the ID of a subframe.", 
+                      "description": "The ID of the frame. 0 indicates that this is the main frame; a positive value indicates the ID of a subframe.",
                       "type": "integer"
-                    }, 
+                    },
                     "parentFrameId": {
-                      "description": "ID of frame that wraps the frame. Set to -1 of no parent frame exists.", 
+                      "description": "ID of frame that wraps the frame. Set to -1 of no parent frame exists.",
                       "type": "integer"
-                    }, 
+                    },
                     "processId": {
-                      "description": "The ID of the process runs the renderer for this tab.", 
-                      "type": "integer", 
+                      "description": "The ID of the process runs the renderer for this tab.",
+                      "type": "integer",
                       "unsupported": true
-                    }, 
+                    },
                     "tabId": {
-                      "description": "The ID of the tab in which the frame is.", 
+                      "description": "The ID of the tab in which the frame is.",
                       "type": "integer"
-                    }, 
+                    },
                     "url": {
-                      "description": "The URL currently associated with this frame.", 
+                      "description": "The URL currently associated with this frame.",
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
-                }, 
-                "name": "details", 
-                "optional": true, 
+                },
+                "name": "details",
+                "optional": true,
                 "type": "array"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
       }
-    ], 
-    "namespace": "webNavigation", 
+    ],
+    "namespace": "webNavigation",
     "permissions": [
       "webNavigation"
-    ], 
+    ],
     "types": [
       {
-        "description": "Cause of the navigation. The same transition types as defined in the history API are used. These are the same transition types as defined in the $(topic:transition_types)[history API] except with <code>\"start_page\"</code> in place of <code>\"auto_toplevel\"</code> (for backwards compatibility).", 
+        "description": "Cause of the navigation. The same transition types as defined in the history API are used. These are the same transition types as defined in the $(topic:transition_types)[history API] except with <code>\"start_page\"</code> in place of <code>\"auto_toplevel\"</code> (for backwards compatibility).",
         "enum": [
-          "link", 
-          "typed", 
-          "auto_bookmark", 
-          "auto_subframe", 
-          "manual_subframe", 
-          "generated", 
-          "start_page", 
-          "form_submit", 
-          "reload", 
-          "keyword", 
+          "link",
+          "typed",
+          "auto_bookmark",
+          "auto_subframe",
+          "manual_subframe",
+          "generated",
+          "start_page",
+          "form_submit",
+          "reload",
+          "keyword",
           "keyword_generated"
-        ], 
-        "id": "TransitionType", 
+        ],
+        "id": "TransitionType",
         "type": "string"
-      }, 
+      },
       {
         "enum": [
-          "client_redirect", 
-          "server_redirect", 
-          "forward_back", 
+          "client_redirect",
+          "server_redirect",
+          "forward_back",
           "from_address_bar"
-        ], 
-        "id": "TransitionQualifier", 
+        ],
+        "id": "TransitionQualifier",
         "type": "string"
-      }, 
+      },
       {
-        "id": "EventUrlFilters", 
+        "id": "EventUrlFilters",
         "properties": {
           "url": {
             "items": {
               "$ref": "events.UrlFilter"
-            }, 
-            "minItems": 1, 
+            },
+            "minItems": 1,
             "type": "array"
           }
-        }, 
+        },
         "type": "object"
       }
     ]
-  }, 
+  },
   {
-    "description": "Use the <code>browser.webRequest</code> API to observe and analyze traffic and to intercept, block, or modify requests in-flight.", 
+    "description": "Use the <code>browser.webRequest</code> API to observe and analyze traffic and to intercept, block, or modify requests in-flight.",
     "events": [
       {
-        "description": "Fired when a request is about to occur.", 
+        "description": "Fired when a request is about to occur.",
         "extraParameters": [
           {
-            "$ref": "RequestFilter", 
-            "description": "A set of filters that restricts the events that will be sent to this listener.", 
+            "$ref": "RequestFilter",
+            "description": "A set of filters that restricts the events that will be sent to this listener.",
             "name": "filter"
-          }, 
+          },
           {
-            "description": "Array of extra information that should be passed to the listener function.", 
+            "description": "Array of extra information that should be passed to the listener function.",
             "items": {
               "$ref": "OnBeforeRequestOptions"
-            }, 
-            "name": "extraInfoSpec", 
-            "optional": true, 
+            },
+            "name": "extraInfoSpec",
+            "optional": true,
             "type": "array"
           }
-        ], 
-        "name": "onBeforeRequest", 
+        ],
+        "name": "onBeforeRequest",
         "parameters": [
           {
-            "name": "details", 
+            "name": "details",
             "properties": {
+              "cookieStoreId": {
+                "description": "The cookie store ID of the contextual identity.",
+                "optional": true,
+                "type": "string"
+              },
               "documentUrl": {
-                "description": "URL of the page into which the requested resource will be loaded.", 
-                "optional": true, 
+                "description": "URL of the page into which the requested resource will be loaded.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "frameId": {
-                "description": "The value 0 indicates that the request happens in the main frame; a positive value indicates the ID of a subframe in which the request happens. If the document of a (sub-)frame is loaded (<code>type</code> is <code>main_frame</code> or <code>sub_frame</code>), <code>frameId</code> indicates the ID of this frame, not the ID of the outer frame. Frame IDs are unique within a tab.", 
+                "description": "The value 0 indicates that the request happens in the main frame; a positive value indicates the ID of a subframe in which the request happens. If the document of a (sub-)frame is loaded (<code>type</code> is <code>main_frame</code> or <code>sub_frame</code>), <code>frameId</code> indicates the ID of this frame, not the ID of the outer frame. Frame IDs are unique within a tab.",
                 "type": "integer"
-              }, 
+              },
+              "incognito": {
+                "description": "True for private browsing requests.",
+                "optional": true,
+                "type": "boolean"
+              },
               "method": {
-                "description": "Standard HTTP method.", 
+                "description": "Standard HTTP method.",
                 "type": "string"
-              }, 
+              },
               "originUrl": {
-                "description": "URL of the resource that triggered this request.", 
-                "optional": true, 
+                "description": "URL of the resource that triggered this request.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "parentFrameId": {
-                "description": "ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists.", 
+                "description": "ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists.",
                 "type": "integer"
-              }, 
+              },
               "requestBody": {
-                "description": "Contains the HTTP request body data. Only provided if extraInfoSpec contains 'requestBody'.", 
-                "optional": true, 
+                "description": "Contains the HTTP request body data. Only provided if extraInfoSpec contains 'requestBody'.",
+                "optional": true,
                 "properties": {
                   "error": {
-                    "description": "Errors when obtaining request body data.", 
-                    "optional": true, 
+                    "description": "Errors when obtaining request body data.",
+                    "optional": true,
                     "type": "string"
-                  }, 
+                  },
                   "formData": {
                     "additionalProperties": {
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
-                    "description": "If the request method is POST and the body is a sequence of key-value pairs encoded in UTF8, encoded as either multipart/form-data, or application/x-www-form-urlencoded, this dictionary is present and for each key contains the list of all values for that key. If the data is of another media type, or if it is malformed, the dictionary is not present. An example value of this dictionary is {'key': ['value1', 'value2']}.", 
-                    "optional": true, 
-                    "properties": {}, 
+                    },
+                    "description": "If the request method is POST and the body is a sequence of key-value pairs encoded in UTF8, encoded as either multipart/form-data, or application/x-www-form-urlencoded, this dictionary is present and for each key contains the list of all values for that key. If the data is of another media type, or if it is malformed, the dictionary is not present. An example value of this dictionary is {'key': ['value1', 'value2']}.",
+                    "optional": true,
+                    "properties": {},
                     "type": "object"
-                  }, 
+                  },
                   "raw": {
-                    "description": "If the request method is PUT or POST, and the body is not already parsed in formData, then the unparsed request body elements are contained in this array.", 
+                    "description": "If the request method is PUT or POST, and the body is not already parsed in formData, then the unparsed request body elements are contained in this array.",
                     "items": {
                       "$ref": "UploadData"
-                    }, 
-                    "optional": true, 
+                    },
+                    "optional": true,
                     "type": "array"
                   }
-                }, 
+                },
                 "type": "object"
-              }, 
+              },
               "requestId": {
-                "description": "The ID of the request. Request IDs are unique within a browser session. As a result, they could be used to relate different events of the same request.", 
+                "description": "The ID of the request. Request IDs are unique within a browser session. As a result, they could be used to relate different events of the same request.",
                 "type": "string"
-              }, 
+              },
               "tabId": {
-                "description": "The ID of the tab in which the request takes place. Set to -1 if the request isn't related to a tab.", 
+                "description": "The ID of the tab in which the request takes place. Set to -1 if the request isn't related to a tab.",
                 "type": "integer"
-              }, 
+              },
               "timeStamp": {
-                "description": "The time when this signal is triggered, in milliseconds since the epoch.", 
+                "description": "The time when this signal is triggered, in milliseconds since the epoch.",
                 "type": "number"
-              }, 
+              },
               "type": {
-                "$ref": "ResourceType", 
+                "$ref": "ResourceType",
                 "description": "How the requested resource will be used."
-              }, 
+              },
               "url": {
                 "type": "string"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "returns": {
-          "$ref": "BlockingResponse", 
-          "description": "If \"blocking\" is specified in the \"extraInfoSpec\" parameter, the event listener should return an object of this type.", 
+          "$ref": "BlockingResponse",
+          "description": "If \"blocking\" is specified in the \"extraInfoSpec\" parameter, the event listener should return an object of this type.",
           "optional": true
-        }, 
+        },
         "type": "function"
-      }, 
+      },
       {
-        "description": "Fired before sending an HTTP request, once the request headers are available. This may occur after a TCP connection is made to the server, but before any HTTP data is sent. ", 
+        "description": "Fired before sending an HTTP request, once the request headers are available. This may occur after a TCP connection is made to the server, but before any HTTP data is sent. ",
         "extraParameters": [
           {
-            "$ref": "RequestFilter", 
-            "description": "A set of filters that restricts the events that will be sent to this listener.", 
+            "$ref": "RequestFilter",
+            "description": "A set of filters that restricts the events that will be sent to this listener.",
             "name": "filter"
-          }, 
+          },
           {
-            "description": "Array of extra information that should be passed to the listener function.", 
+            "description": "Array of extra information that should be passed to the listener function.",
             "items": {
               "$ref": "OnBeforeSendHeadersOptions"
-            }, 
-            "name": "extraInfoSpec", 
-            "optional": true, 
+            },
+            "name": "extraInfoSpec",
+            "optional": true,
             "type": "array"
           }
-        ], 
-        "name": "onBeforeSendHeaders", 
+        ],
+        "name": "onBeforeSendHeaders",
         "parameters": [
           {
-            "name": "details", 
+            "name": "details",
             "properties": {
+              "cookieStoreId": {
+                "description": "The cookie store ID of the contextual identity.",
+                "optional": true,
+                "type": "string"
+              },
               "documentUrl": {
-                "description": "URL of the page into which the requested resource will be loaded.", 
-                "optional": true, 
+                "description": "URL of the page into which the requested resource will be loaded.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "frameId": {
-                "description": "The value 0 indicates that the request happens in the main frame; a positive value indicates the ID of a subframe in which the request happens. If the document of a (sub-)frame is loaded (<code>type</code> is <code>main_frame</code> or <code>sub_frame</code>), <code>frameId</code> indicates the ID of this frame, not the ID of the outer frame. Frame IDs are unique within a tab.", 
+                "description": "The value 0 indicates that the request happens in the main frame; a positive value indicates the ID of a subframe in which the request happens. If the document of a (sub-)frame is loaded (<code>type</code> is <code>main_frame</code> or <code>sub_frame</code>), <code>frameId</code> indicates the ID of this frame, not the ID of the outer frame. Frame IDs are unique within a tab.",
                 "type": "integer"
-              }, 
+              },
+              "incognito": {
+                "description": "True for private browsing requests.",
+                "optional": true,
+                "type": "boolean"
+              },
               "method": {
-                "description": "Standard HTTP method.", 
+                "description": "Standard HTTP method.",
                 "type": "string"
-              }, 
+              },
               "originUrl": {
-                "description": "URL of the resource that triggered this request.", 
-                "optional": true, 
+                "description": "URL of the resource that triggered this request.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "parentFrameId": {
-                "description": "ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists.", 
+                "description": "ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists.",
                 "type": "integer"
-              }, 
+              },
               "requestHeaders": {
-                "$ref": "HttpHeaders", 
-                "description": "The HTTP request headers that are going to be sent out with this request.", 
+                "$ref": "HttpHeaders",
+                "description": "The HTTP request headers that are going to be sent out with this request.",
                 "optional": true
-              }, 
+              },
               "requestId": {
-                "description": "The ID of the request. Request IDs are unique within a browser session. As a result, they could be used to relate different events of the same request.", 
+                "description": "The ID of the request. Request IDs are unique within a browser session. As a result, they could be used to relate different events of the same request.",
                 "type": "string"
-              }, 
+              },
               "tabId": {
-                "description": "The ID of the tab in which the request takes place. Set to -1 if the request isn't related to a tab.", 
+                "description": "The ID of the tab in which the request takes place. Set to -1 if the request isn't related to a tab.",
                 "type": "integer"
-              }, 
+              },
               "timeStamp": {
-                "description": "The time when this signal is triggered, in milliseconds since the epoch.", 
+                "description": "The time when this signal is triggered, in milliseconds since the epoch.",
                 "type": "number"
-              }, 
+              },
               "type": {
-                "$ref": "ResourceType", 
+                "$ref": "ResourceType",
                 "description": "How the requested resource will be used."
-              }, 
+              },
               "url": {
                 "type": "string"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "returns": {
-          "$ref": "BlockingResponse", 
-          "description": "If \"blocking\" is specified in the \"extraInfoSpec\" parameter, the event listener should return an object of this type.", 
+          "$ref": "BlockingResponse",
+          "description": "If \"blocking\" is specified in the \"extraInfoSpec\" parameter, the event listener should return an object of this type.",
           "optional": true
-        }, 
+        },
         "type": "function"
-      }, 
+      },
       {
-        "description": "Fired just before a request is going to be sent to the server (modifications of previous onBeforeSendHeaders callbacks are visible by the time onSendHeaders is fired).", 
+        "description": "Fired just before a request is going to be sent to the server (modifications of previous onBeforeSendHeaders callbacks are visible by the time onSendHeaders is fired).",
         "extraParameters": [
           {
-            "$ref": "RequestFilter", 
-            "description": "A set of filters that restricts the events that will be sent to this listener.", 
+            "$ref": "RequestFilter",
+            "description": "A set of filters that restricts the events that will be sent to this listener.",
             "name": "filter"
-          }, 
+          },
           {
-            "description": "Array of extra information that should be passed to the listener function.", 
+            "description": "Array of extra information that should be passed to the listener function.",
             "items": {
               "$ref": "OnSendHeadersOptions"
-            }, 
-            "name": "extraInfoSpec", 
-            "optional": true, 
+            },
+            "name": "extraInfoSpec",
+            "optional": true,
             "type": "array"
           }
-        ], 
-        "name": "onSendHeaders", 
+        ],
+        "name": "onSendHeaders",
         "parameters": [
           {
-            "name": "details", 
+            "name": "details",
             "properties": {
+              "cookieStoreId": {
+                "description": "The cookie store ID of the contextual identity.",
+                "optional": true,
+                "type": "string"
+              },
               "documentUrl": {
-                "description": "URL of the page into which the requested resource will be loaded.", 
-                "optional": true, 
+                "description": "URL of the page into which the requested resource will be loaded.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "frameId": {
-                "description": "The value 0 indicates that the request happens in the main frame; a positive value indicates the ID of a subframe in which the request happens. If the document of a (sub-)frame is loaded (<code>type</code> is <code>main_frame</code> or <code>sub_frame</code>), <code>frameId</code> indicates the ID of this frame, not the ID of the outer frame. Frame IDs are unique within a tab.", 
+                "description": "The value 0 indicates that the request happens in the main frame; a positive value indicates the ID of a subframe in which the request happens. If the document of a (sub-)frame is loaded (<code>type</code> is <code>main_frame</code> or <code>sub_frame</code>), <code>frameId</code> indicates the ID of this frame, not the ID of the outer frame. Frame IDs are unique within a tab.",
                 "type": "integer"
-              }, 
+              },
+              "incognito": {
+                "description": "True for private browsing requests.",
+                "optional": true,
+                "type": "boolean"
+              },
               "method": {
-                "description": "Standard HTTP method.", 
+                "description": "Standard HTTP method.",
                 "type": "string"
-              }, 
+              },
               "originUrl": {
-                "description": "URL of the resource that triggered this request.", 
-                "optional": true, 
+                "description": "URL of the resource that triggered this request.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "parentFrameId": {
-                "description": "ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists.", 
+                "description": "ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists.",
                 "type": "integer"
-              }, 
+              },
               "requestHeaders": {
-                "$ref": "HttpHeaders", 
-                "description": "The HTTP request headers that have been sent out with this request.", 
+                "$ref": "HttpHeaders",
+                "description": "The HTTP request headers that have been sent out with this request.",
                 "optional": true
-              }, 
+              },
               "requestId": {
-                "description": "The ID of the request. Request IDs are unique within a browser session. As a result, they could be used to relate different events of the same request.", 
+                "description": "The ID of the request. Request IDs are unique within a browser session. As a result, they could be used to relate different events of the same request.",
                 "type": "string"
-              }, 
+              },
               "tabId": {
-                "description": "The ID of the tab in which the request takes place. Set to -1 if the request isn't related to a tab.", 
+                "description": "The ID of the tab in which the request takes place. Set to -1 if the request isn't related to a tab.",
                 "type": "integer"
-              }, 
+              },
               "timeStamp": {
-                "description": "The time when this signal is triggered, in milliseconds since the epoch.", 
+                "description": "The time when this signal is triggered, in milliseconds since the epoch.",
                 "type": "number"
-              }, 
+              },
               "type": {
-                "$ref": "ResourceType", 
+                "$ref": "ResourceType",
                 "description": "How the requested resource will be used."
-              }, 
+              },
               "url": {
                 "type": "string"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Fired when HTTP response headers of a request have been received.", 
+        "description": "Fired when HTTP response headers of a request have been received.",
         "extraParameters": [
           {
-            "$ref": "RequestFilter", 
-            "description": "A set of filters that restricts the events that will be sent to this listener.", 
+            "$ref": "RequestFilter",
+            "description": "A set of filters that restricts the events that will be sent to this listener.",
             "name": "filter"
-          }, 
+          },
           {
-            "description": "Array of extra information that should be passed to the listener function.", 
+            "description": "Array of extra information that should be passed to the listener function.",
             "items": {
               "$ref": "OnHeadersReceivedOptions"
-            }, 
-            "name": "extraInfoSpec", 
-            "optional": true, 
+            },
+            "name": "extraInfoSpec",
+            "optional": true,
             "type": "array"
           }
-        ], 
-        "name": "onHeadersReceived", 
+        ],
+        "name": "onHeadersReceived",
         "parameters": [
           {
-            "name": "details", 
+            "name": "details",
             "properties": {
+              "cookieStoreId": {
+                "description": "The cookie store ID of the contextual identity.",
+                "optional": true,
+                "type": "string"
+              },
               "documentUrl": {
-                "description": "URL of the page into which the requested resource will be loaded.", 
-                "optional": true, 
+                "description": "URL of the page into which the requested resource will be loaded.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "frameId": {
-                "description": "The value 0 indicates that the request happens in the main frame; a positive value indicates the ID of a subframe in which the request happens. If the document of a (sub-)frame is loaded (<code>type</code> is <code>main_frame</code> or <code>sub_frame</code>), <code>frameId</code> indicates the ID of this frame, not the ID of the outer frame. Frame IDs are unique within a tab.", 
+                "description": "The value 0 indicates that the request happens in the main frame; a positive value indicates the ID of a subframe in which the request happens. If the document of a (sub-)frame is loaded (<code>type</code> is <code>main_frame</code> or <code>sub_frame</code>), <code>frameId</code> indicates the ID of this frame, not the ID of the outer frame. Frame IDs are unique within a tab.",
                 "type": "integer"
-              }, 
+              },
+              "incognito": {
+                "description": "True for private browsing requests.",
+                "optional": true,
+                "type": "boolean"
+              },
               "method": {
-                "description": "Standard HTTP method.", 
+                "description": "Standard HTTP method.",
                 "type": "string"
-              }, 
+              },
               "originUrl": {
-                "description": "URL of the resource that triggered this request.", 
-                "optional": true, 
+                "description": "URL of the resource that triggered this request.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "parentFrameId": {
-                "description": "ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists.", 
+                "description": "ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists.",
                 "type": "integer"
-              }, 
+              },
               "requestId": {
-                "description": "The ID of the request. Request IDs are unique within a browser session. As a result, they could be used to relate different events of the same request.", 
+                "description": "The ID of the request. Request IDs are unique within a browser session. As a result, they could be used to relate different events of the same request.",
                 "type": "string"
-              }, 
+              },
               "responseHeaders": {
-                "$ref": "HttpHeaders", 
-                "description": "The HTTP response headers that have been received with this response.", 
+                "$ref": "HttpHeaders",
+                "description": "The HTTP response headers that have been received with this response.",
                 "optional": true
-              }, 
+              },
               "statusCode": {
-                "description": "Standard HTTP status code returned by the server.", 
+                "description": "Standard HTTP status code returned by the server.",
                 "type": "integer"
-              }, 
+              },
               "statusLine": {
-                "description": "HTTP status line of the response or the 'HTTP/0.9 200 OK' string for HTTP/0.9 responses (i.e., responses that lack a status line).", 
+                "description": "HTTP status line of the response or the 'HTTP/0.9 200 OK' string for HTTP/0.9 responses (i.e., responses that lack a status line).",
                 "type": "string"
-              }, 
+              },
               "tabId": {
-                "description": "The ID of the tab in which the request takes place. Set to -1 if the request isn't related to a tab.", 
+                "description": "The ID of the tab in which the request takes place. Set to -1 if the request isn't related to a tab.",
                 "type": "integer"
-              }, 
+              },
               "timeStamp": {
-                "description": "The time when this signal is triggered, in milliseconds since the epoch.", 
+                "description": "The time when this signal is triggered, in milliseconds since the epoch.",
                 "type": "number"
-              }, 
+              },
               "type": {
-                "$ref": "ResourceType", 
+                "$ref": "ResourceType",
                 "description": "How the requested resource will be used."
-              }, 
+              },
               "url": {
                 "type": "string"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "returns": {
-          "$ref": "BlockingResponse", 
-          "description": "If \"blocking\" is specified in the \"extraInfoSpec\" parameter, the event listener should return an object of this type.", 
+          "$ref": "BlockingResponse",
+          "description": "If \"blocking\" is specified in the \"extraInfoSpec\" parameter, the event listener should return an object of this type.",
           "optional": true
-        }, 
+        },
         "type": "function"
-      }, 
+      },
       {
-        "description": "Fired when an authentication failure is received. The listener has three options: it can provide authentication credentials, it can cancel the request and display the error page, or it can take no action on the challenge. If bad user credentials are provided, this may be called multiple times for the same request.", 
+        "description": "Fired when an authentication failure is received. The listener has three options: it can provide authentication credentials, it can cancel the request and display the error page, or it can take no action on the challenge. If bad user credentials are provided, this may be called multiple times for the same request.",
         "extraParameters": [
           {
-            "$ref": "RequestFilter", 
-            "description": "A set of filters that restricts the events that will be sent to this listener.", 
+            "$ref": "RequestFilter",
+            "description": "A set of filters that restricts the events that will be sent to this listener.",
             "name": "filter"
-          }, 
+          },
           {
-            "description": "Array of extra information that should be passed to the listener function.", 
+            "description": "Array of extra information that should be passed to the listener function.",
             "items": {
               "$ref": "OnAuthRequiredOptions"
-            }, 
-            "name": "extraInfoSpec", 
-            "optional": true, 
+            },
+            "name": "extraInfoSpec",
+            "optional": true,
             "type": "array"
           }
-        ], 
-        "name": "onAuthRequired", 
+        ],
+        "name": "onAuthRequired",
         "parameters": [
           {
-            "name": "details", 
+            "name": "details",
             "properties": {
               "challenger": {
-                "description": "The server requesting authentication.", 
+                "description": "The server requesting authentication.",
                 "properties": {
                   "host": {
                     "type": "string"
-                  }, 
+                  },
                   "port": {
                     "type": "integer"
                   }
-                }, 
+                },
                 "type": "object"
-              }, 
+              },
+              "cookieStoreId": {
+                "description": "The cookie store ID of the contextual identity.",
+                "optional": true,
+                "type": "string"
+              },
               "documentUrl": {
-                "description": "URL of the page into which the requested resource will be loaded.", 
-                "optional": true, 
+                "description": "URL of the page into which the requested resource will be loaded.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "frameId": {
-                "description": "The value 0 indicates that the request happens in the main frame; a positive value indicates the ID of a subframe in which the request happens. If the document of a (sub-)frame is loaded (<code>type</code> is <code>main_frame</code> or <code>sub_frame</code>), <code>frameId</code> indicates the ID of this frame, not the ID of the outer frame. Frame IDs are unique within a tab.", 
+                "description": "The value 0 indicates that the request happens in the main frame; a positive value indicates the ID of a subframe in which the request happens. If the document of a (sub-)frame is loaded (<code>type</code> is <code>main_frame</code> or <code>sub_frame</code>), <code>frameId</code> indicates the ID of this frame, not the ID of the outer frame. Frame IDs are unique within a tab.",
                 "type": "integer"
-              }, 
-              "isProxy": {
-                "description": "True for Proxy-Authenticate, false for WWW-Authenticate.", 
+              },
+              "incognito": {
+                "description": "True for private browsing requests.",
+                "optional": true,
                 "type": "boolean"
-              }, 
+              },
+              "isProxy": {
+                "description": "True for Proxy-Authenticate, false for WWW-Authenticate.",
+                "type": "boolean"
+              },
               "method": {
-                "description": "Standard HTTP method.", 
+                "description": "Standard HTTP method.",
                 "type": "string"
-              }, 
+              },
               "originUrl": {
-                "description": "URL of the resource that triggered this request.", 
-                "optional": true, 
+                "description": "URL of the resource that triggered this request.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "parentFrameId": {
-                "description": "ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists.", 
+                "description": "ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists.",
                 "type": "integer"
-              }, 
+              },
               "realm": {
-                "description": "The authentication realm provided by the server, if there is one.", 
-                "optional": true, 
+                "description": "The authentication realm provided by the server, if there is one.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "requestId": {
-                "description": "The ID of the request. Request IDs are unique within a browser session. As a result, they could be used to relate different events of the same request.", 
+                "description": "The ID of the request. Request IDs are unique within a browser session. As a result, they could be used to relate different events of the same request.",
                 "type": "string"
-              }, 
+              },
               "responseHeaders": {
-                "$ref": "HttpHeaders", 
-                "description": "The HTTP response headers that were received along with this response.", 
+                "$ref": "HttpHeaders",
+                "description": "The HTTP response headers that were received along with this response.",
                 "optional": true
-              }, 
+              },
               "scheme": {
-                "description": "The authentication scheme, e.g. Basic or Digest.", 
+                "description": "The authentication scheme, e.g. Basic or Digest.",
                 "type": "string"
-              }, 
+              },
               "statusCode": {
-                "description": "Standard HTTP status code returned by the server.", 
+                "description": "Standard HTTP status code returned by the server.",
                 "type": "integer"
-              }, 
+              },
               "statusLine": {
-                "description": "HTTP status line of the response or the 'HTTP/0.9 200 OK' string for HTTP/0.9 responses (i.e., responses that lack a status line) or an empty string if there are no headers.", 
+                "description": "HTTP status line of the response or the 'HTTP/0.9 200 OK' string for HTTP/0.9 responses (i.e., responses that lack a status line) or an empty string if there are no headers.",
                 "type": "string"
-              }, 
+              },
               "tabId": {
-                "description": "The ID of the tab in which the request takes place. Set to -1 if the request isn't related to a tab.", 
+                "description": "The ID of the tab in which the request takes place. Set to -1 if the request isn't related to a tab.",
                 "type": "integer"
-              }, 
+              },
               "timeStamp": {
-                "description": "The time when this signal is triggered, in milliseconds since the epoch.", 
+                "description": "The time when this signal is triggered, in milliseconds since the epoch.",
                 "type": "number"
-              }, 
+              },
               "type": {
-                "$ref": "ResourceType", 
+                "$ref": "ResourceType",
                 "description": "How the requested resource will be used."
-              }, 
+              },
               "url": {
                 "type": "string"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
+            "name": "callback",
+            "optional": true,
             "parameters": [
               {
-                "$ref": "BlockingResponse", 
+                "$ref": "BlockingResponse",
                 "name": "response"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "returns": {
-          "$ref": "BlockingResponse", 
-          "description": "If \"blocking\" is specified in the \"extraInfoSpec\" parameter, the event listener should return an object of this type.", 
+          "$ref": "BlockingResponse",
+          "description": "If \"blocking\" is specified in the \"extraInfoSpec\" parameter, the event listener should return an object of this type.",
           "optional": true
-        }, 
+        },
         "type": "function"
-      }, 
+      },
       {
-        "description": "Fired when the first byte of the response body is received. For HTTP requests, this means that the status line and response headers are available.", 
+        "description": "Fired when the first byte of the response body is received. For HTTP requests, this means that the status line and response headers are available.",
         "extraParameters": [
           {
-            "$ref": "RequestFilter", 
-            "description": "A set of filters that restricts the events that will be sent to this listener.", 
+            "$ref": "RequestFilter",
+            "description": "A set of filters that restricts the events that will be sent to this listener.",
             "name": "filter"
-          }, 
+          },
           {
-            "description": "Array of extra information that should be passed to the listener function.", 
+            "description": "Array of extra information that should be passed to the listener function.",
             "items": {
               "$ref": "OnResponseStartedOptions"
-            }, 
-            "name": "extraInfoSpec", 
-            "optional": true, 
+            },
+            "name": "extraInfoSpec",
+            "optional": true,
             "type": "array"
           }
-        ], 
-        "name": "onResponseStarted", 
+        ],
+        "name": "onResponseStarted",
         "parameters": [
           {
-            "name": "details", 
+            "name": "details",
             "properties": {
+              "cookieStoreId": {
+                "description": "The cookie store ID of the contextual identity.",
+                "optional": true,
+                "type": "string"
+              },
               "documentUrl": {
-                "description": "URL of the page into which the requested resource will be loaded.", 
-                "optional": true, 
+                "description": "URL of the page into which the requested resource will be loaded.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "frameId": {
-                "description": "The value 0 indicates that the request happens in the main frame; a positive value indicates the ID of a subframe in which the request happens. If the document of a (sub-)frame is loaded (<code>type</code> is <code>main_frame</code> or <code>sub_frame</code>), <code>frameId</code> indicates the ID of this frame, not the ID of the outer frame. Frame IDs are unique within a tab.", 
+                "description": "The value 0 indicates that the request happens in the main frame; a positive value indicates the ID of a subframe in which the request happens. If the document of a (sub-)frame is loaded (<code>type</code> is <code>main_frame</code> or <code>sub_frame</code>), <code>frameId</code> indicates the ID of this frame, not the ID of the outer frame. Frame IDs are unique within a tab.",
                 "type": "integer"
-              }, 
+              },
               "fromCache": {
-                "description": "Indicates if this response was fetched from disk cache.", 
+                "description": "Indicates if this response was fetched from disk cache.",
                 "type": "boolean"
-              }, 
+              },
+              "incognito": {
+                "description": "True for private browsing requests.",
+                "optional": true,
+                "type": "boolean"
+              },
               "ip": {
-                "description": "The server IP address that the request was actually sent to. Note that it may be a literal IPv6 address.", 
-                "optional": true, 
+                "description": "The server IP address that the request was actually sent to. Note that it may be a literal IPv6 address.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "method": {
-                "description": "Standard HTTP method.", 
+                "description": "Standard HTTP method.",
                 "type": "string"
-              }, 
+              },
               "originUrl": {
-                "description": "URL of the resource that triggered this request.", 
-                "optional": true, 
+                "description": "URL of the resource that triggered this request.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "parentFrameId": {
-                "description": "ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists.", 
+                "description": "ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists.",
                 "type": "integer"
-              }, 
+              },
               "requestId": {
-                "description": "The ID of the request. Request IDs are unique within a browser session. As a result, they could be used to relate different events of the same request.", 
+                "description": "The ID of the request. Request IDs are unique within a browser session. As a result, they could be used to relate different events of the same request.",
                 "type": "string"
-              }, 
+              },
               "responseHeaders": {
-                "$ref": "HttpHeaders", 
-                "description": "The HTTP response headers that were received along with this response.", 
+                "$ref": "HttpHeaders",
+                "description": "The HTTP response headers that were received along with this response.",
                 "optional": true
-              }, 
+              },
               "statusCode": {
-                "description": "Standard HTTP status code returned by the server.", 
+                "description": "Standard HTTP status code returned by the server.",
                 "type": "integer"
-              }, 
+              },
               "statusLine": {
-                "description": "HTTP status line of the response or the 'HTTP/0.9 200 OK' string for HTTP/0.9 responses (i.e., responses that lack a status line) or an empty string if there are no headers.", 
+                "description": "HTTP status line of the response or the 'HTTP/0.9 200 OK' string for HTTP/0.9 responses (i.e., responses that lack a status line) or an empty string if there are no headers.",
                 "type": "string"
-              }, 
+              },
               "tabId": {
-                "description": "The ID of the tab in which the request takes place. Set to -1 if the request isn't related to a tab.", 
+                "description": "The ID of the tab in which the request takes place. Set to -1 if the request isn't related to a tab.",
                 "type": "integer"
-              }, 
+              },
               "timeStamp": {
-                "description": "The time when this signal is triggered, in milliseconds since the epoch.", 
+                "description": "The time when this signal is triggered, in milliseconds since the epoch.",
                 "type": "number"
-              }, 
+              },
               "type": {
-                "$ref": "ResourceType", 
+                "$ref": "ResourceType",
                 "description": "How the requested resource will be used."
-              }, 
+              },
               "url": {
                 "type": "string"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Fired when a server-initiated redirect is about to occur.", 
+        "description": "Fired when a server-initiated redirect is about to occur.",
         "extraParameters": [
           {
-            "$ref": "RequestFilter", 
-            "description": "A set of filters that restricts the events that will be sent to this listener.", 
+            "$ref": "RequestFilter",
+            "description": "A set of filters that restricts the events that will be sent to this listener.",
             "name": "filter"
-          }, 
+          },
           {
-            "description": "Array of extra information that should be passed to the listener function.", 
+            "description": "Array of extra information that should be passed to the listener function.",
             "items": {
               "$ref": "OnBeforeRedirectOptions"
-            }, 
-            "name": "extraInfoSpec", 
-            "optional": true, 
+            },
+            "name": "extraInfoSpec",
+            "optional": true,
             "type": "array"
           }
-        ], 
-        "name": "onBeforeRedirect", 
+        ],
+        "name": "onBeforeRedirect",
         "parameters": [
           {
-            "name": "details", 
+            "name": "details",
             "properties": {
+              "cookieStoreId": {
+                "description": "The cookie store ID of the contextual identity.",
+                "optional": true,
+                "type": "string"
+              },
               "documentUrl": {
-                "description": "URL of the page into which the requested resource will be loaded.", 
-                "optional": true, 
+                "description": "URL of the page into which the requested resource will be loaded.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "frameId": {
-                "description": "The value 0 indicates that the request happens in the main frame; a positive value indicates the ID of a subframe in which the request happens. If the document of a (sub-)frame is loaded (<code>type</code> is <code>main_frame</code> or <code>sub_frame</code>), <code>frameId</code> indicates the ID of this frame, not the ID of the outer frame. Frame IDs are unique within a tab.", 
+                "description": "The value 0 indicates that the request happens in the main frame; a positive value indicates the ID of a subframe in which the request happens. If the document of a (sub-)frame is loaded (<code>type</code> is <code>main_frame</code> or <code>sub_frame</code>), <code>frameId</code> indicates the ID of this frame, not the ID of the outer frame. Frame IDs are unique within a tab.",
                 "type": "integer"
-              }, 
+              },
               "fromCache": {
-                "description": "Indicates if this response was fetched from disk cache.", 
+                "description": "Indicates if this response was fetched from disk cache.",
                 "type": "boolean"
-              }, 
+              },
+              "incognito": {
+                "description": "True for private browsing requests.",
+                "optional": true,
+                "type": "boolean"
+              },
               "ip": {
-                "description": "The server IP address that the request was actually sent to. Note that it may be a literal IPv6 address.", 
-                "optional": true, 
+                "description": "The server IP address that the request was actually sent to. Note that it may be a literal IPv6 address.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "method": {
-                "description": "Standard HTTP method.", 
+                "description": "Standard HTTP method.",
                 "type": "string"
-              }, 
+              },
               "originUrl": {
-                "description": "URL of the resource that triggered this request.", 
-                "optional": true, 
+                "description": "URL of the resource that triggered this request.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "parentFrameId": {
-                "description": "ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists.", 
+                "description": "ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists.",
                 "type": "integer"
-              }, 
+              },
               "redirectUrl": {
-                "description": "The new URL.", 
+                "description": "The new URL.",
                 "type": "string"
-              }, 
+              },
               "requestId": {
-                "description": "The ID of the request. Request IDs are unique within a browser session. As a result, they could be used to relate different events of the same request.", 
+                "description": "The ID of the request. Request IDs are unique within a browser session. As a result, they could be used to relate different events of the same request.",
                 "type": "string"
-              }, 
+              },
               "responseHeaders": {
-                "$ref": "HttpHeaders", 
-                "description": "The HTTP response headers that were received along with this redirect.", 
+                "$ref": "HttpHeaders",
+                "description": "The HTTP response headers that were received along with this redirect.",
                 "optional": true
-              }, 
+              },
               "statusCode": {
-                "description": "Standard HTTP status code returned by the server.", 
+                "description": "Standard HTTP status code returned by the server.",
                 "type": "integer"
-              }, 
+              },
               "statusLine": {
-                "description": "HTTP status line of the response or the 'HTTP/0.9 200 OK' string for HTTP/0.9 responses (i.e., responses that lack a status line) or an empty string if there are no headers.", 
+                "description": "HTTP status line of the response or the 'HTTP/0.9 200 OK' string for HTTP/0.9 responses (i.e., responses that lack a status line) or an empty string if there are no headers.",
                 "type": "string"
-              }, 
+              },
               "tabId": {
-                "description": "The ID of the tab in which the request takes place. Set to -1 if the request isn't related to a tab.", 
+                "description": "The ID of the tab in which the request takes place. Set to -1 if the request isn't related to a tab.",
                 "type": "integer"
-              }, 
+              },
               "timeStamp": {
-                "description": "The time when this signal is triggered, in milliseconds since the epoch.", 
+                "description": "The time when this signal is triggered, in milliseconds since the epoch.",
                 "type": "number"
-              }, 
+              },
               "type": {
-                "$ref": "ResourceType", 
+                "$ref": "ResourceType",
                 "description": "How the requested resource will be used."
-              }, 
+              },
               "url": {
                 "type": "string"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Fired when a request is completed.", 
+        "description": "Fired when a request is completed.",
         "extraParameters": [
           {
-            "$ref": "RequestFilter", 
-            "description": "A set of filters that restricts the events that will be sent to this listener.", 
+            "$ref": "RequestFilter",
+            "description": "A set of filters that restricts the events that will be sent to this listener.",
             "name": "filter"
-          }, 
+          },
           {
-            "description": "Array of extra information that should be passed to the listener function.", 
+            "description": "Array of extra information that should be passed to the listener function.",
             "items": {
               "$ref": "OnCompletedOptions"
-            }, 
-            "name": "extraInfoSpec", 
-            "optional": true, 
+            },
+            "name": "extraInfoSpec",
+            "optional": true,
             "type": "array"
           }
-        ], 
-        "name": "onCompleted", 
+        ],
+        "name": "onCompleted",
         "parameters": [
           {
-            "name": "details", 
+            "name": "details",
             "properties": {
+              "cookieStoreId": {
+                "description": "The cookie store ID of the contextual identity.",
+                "optional": true,
+                "type": "string"
+              },
               "documentUrl": {
-                "description": "URL of the page into which the requested resource will be loaded.", 
-                "optional": true, 
+                "description": "URL of the page into which the requested resource will be loaded.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "frameId": {
-                "description": "The value 0 indicates that the request happens in the main frame; a positive value indicates the ID of a subframe in which the request happens. If the document of a (sub-)frame is loaded (<code>type</code> is <code>main_frame</code> or <code>sub_frame</code>), <code>frameId</code> indicates the ID of this frame, not the ID of the outer frame. Frame IDs are unique within a tab.", 
+                "description": "The value 0 indicates that the request happens in the main frame; a positive value indicates the ID of a subframe in which the request happens. If the document of a (sub-)frame is loaded (<code>type</code> is <code>main_frame</code> or <code>sub_frame</code>), <code>frameId</code> indicates the ID of this frame, not the ID of the outer frame. Frame IDs are unique within a tab.",
                 "type": "integer"
-              }, 
+              },
               "fromCache": {
-                "description": "Indicates if this response was fetched from disk cache.", 
+                "description": "Indicates if this response was fetched from disk cache.",
                 "type": "boolean"
-              }, 
+              },
+              "incognito": {
+                "description": "True for private browsing requests.",
+                "optional": true,
+                "type": "boolean"
+              },
               "ip": {
-                "description": "The server IP address that the request was actually sent to. Note that it may be a literal IPv6 address.", 
-                "optional": true, 
+                "description": "The server IP address that the request was actually sent to. Note that it may be a literal IPv6 address.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "method": {
-                "description": "Standard HTTP method.", 
+                "description": "Standard HTTP method.",
                 "type": "string"
-              }, 
+              },
               "originUrl": {
-                "description": "URL of the resource that triggered this request.", 
-                "optional": true, 
+                "description": "URL of the resource that triggered this request.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "parentFrameId": {
-                "description": "ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists.", 
+                "description": "ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists.",
                 "type": "integer"
-              }, 
+              },
               "requestId": {
-                "description": "The ID of the request. Request IDs are unique within a browser session. As a result, they could be used to relate different events of the same request.", 
+                "description": "The ID of the request. Request IDs are unique within a browser session. As a result, they could be used to relate different events of the same request.",
                 "type": "string"
-              }, 
+              },
               "responseHeaders": {
-                "$ref": "HttpHeaders", 
-                "description": "The HTTP response headers that were received along with this response.", 
+                "$ref": "HttpHeaders",
+                "description": "The HTTP response headers that were received along with this response.",
                 "optional": true
-              }, 
+              },
               "statusCode": {
-                "description": "Standard HTTP status code returned by the server.", 
+                "description": "Standard HTTP status code returned by the server.",
                 "type": "integer"
-              }, 
+              },
               "statusLine": {
-                "description": "HTTP status line of the response or the 'HTTP/0.9 200 OK' string for HTTP/0.9 responses (i.e., responses that lack a status line) or an empty string if there are no headers.", 
+                "description": "HTTP status line of the response or the 'HTTP/0.9 200 OK' string for HTTP/0.9 responses (i.e., responses that lack a status line) or an empty string if there are no headers.",
                 "type": "string"
-              }, 
+              },
               "tabId": {
-                "description": "The ID of the tab in which the request takes place. Set to -1 if the request isn't related to a tab.", 
+                "description": "The ID of the tab in which the request takes place. Set to -1 if the request isn't related to a tab.",
                 "type": "integer"
-              }, 
+              },
               "timeStamp": {
-                "description": "The time when this signal is triggered, in milliseconds since the epoch.", 
+                "description": "The time when this signal is triggered, in milliseconds since the epoch.",
                 "type": "number"
-              }, 
+              },
               "type": {
-                "$ref": "ResourceType", 
+                "$ref": "ResourceType",
                 "description": "How the requested resource will be used."
-              }, 
+              },
               "url": {
                 "type": "string"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Fired when an error occurs.", 
+        "description": "Fired when an error occurs.",
         "extraParameters": [
           {
-            "$ref": "RequestFilter", 
-            "description": "A set of filters that restricts the events that will be sent to this listener.", 
+            "$ref": "RequestFilter",
+            "description": "A set of filters that restricts the events that will be sent to this listener.",
             "name": "filter"
           }
-        ], 
-        "name": "onErrorOccurred", 
+        ],
+        "name": "onErrorOccurred",
         "parameters": [
           {
-            "name": "details", 
+            "name": "details",
             "properties": {
+              "cookieStoreId": {
+                "description": "The cookie store ID of the contextual identity.",
+                "optional": true,
+                "type": "string"
+              },
               "documentUrl": {
-                "description": "URL of the page into which the requested resource will be loaded.", 
-                "optional": true, 
+                "description": "URL of the page into which the requested resource will be loaded.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "error": {
-                "description": "The error description. This string is <em>not</em> guaranteed to remain backwards compatible between releases. You must not parse and act based upon its content.", 
+                "description": "The error description. This string is <em>not</em> guaranteed to remain backwards compatible between releases. You must not parse and act based upon its content.",
                 "type": "string"
-              }, 
+              },
               "frameId": {
-                "description": "The value 0 indicates that the request happens in the main frame; a positive value indicates the ID of a subframe in which the request happens. If the document of a (sub-)frame is loaded (<code>type</code> is <code>main_frame</code> or <code>sub_frame</code>), <code>frameId</code> indicates the ID of this frame, not the ID of the outer frame. Frame IDs are unique within a tab.", 
+                "description": "The value 0 indicates that the request happens in the main frame; a positive value indicates the ID of a subframe in which the request happens. If the document of a (sub-)frame is loaded (<code>type</code> is <code>main_frame</code> or <code>sub_frame</code>), <code>frameId</code> indicates the ID of this frame, not the ID of the outer frame. Frame IDs are unique within a tab.",
                 "type": "integer"
-              }, 
+              },
               "fromCache": {
-                "description": "Indicates if this response was fetched from disk cache.", 
+                "description": "Indicates if this response was fetched from disk cache.",
                 "type": "boolean"
-              }, 
+              },
+              "incognito": {
+                "description": "True for private browsing requests.",
+                "optional": true,
+                "type": "boolean"
+              },
               "ip": {
-                "description": "The server IP address that the request was actually sent to. Note that it may be a literal IPv6 address.", 
-                "optional": true, 
+                "description": "The server IP address that the request was actually sent to. Note that it may be a literal IPv6 address.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "method": {
-                "description": "Standard HTTP method.", 
+                "description": "Standard HTTP method.",
                 "type": "string"
-              }, 
+              },
               "originUrl": {
-                "description": "URL of the resource that triggered this request.", 
-                "optional": true, 
+                "description": "URL of the resource that triggered this request.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "parentFrameId": {
-                "description": "ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists.", 
+                "description": "ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists.",
                 "type": "integer"
-              }, 
+              },
               "requestId": {
-                "description": "The ID of the request. Request IDs are unique within a browser session. As a result, they could be used to relate different events of the same request.", 
+                "description": "The ID of the request. Request IDs are unique within a browser session. As a result, they could be used to relate different events of the same request.",
                 "type": "string"
-              }, 
+              },
               "tabId": {
-                "description": "The ID of the tab in which the request takes place. Set to -1 if the request isn't related to a tab.", 
+                "description": "The ID of the tab in which the request takes place. Set to -1 if the request isn't related to a tab.",
                 "type": "integer"
-              }, 
+              },
               "timeStamp": {
-                "description": "The time when this signal is triggered, in milliseconds since the epoch.", 
+                "description": "The time when this signal is triggered, in milliseconds since the epoch.",
                 "type": "number"
-              }, 
+              },
               "type": {
-                "$ref": "ResourceType", 
+                "$ref": "ResourceType",
                 "description": "How the requested resource will be used."
-              }, 
+              },
               "url": {
                 "type": "string"
               }
-            }, 
+            },
             "type": "object"
           }
-        ], 
+        ],
         "type": "function"
       }
-    ], 
+    ],
     "functions": [
       {
-        "async": "callback", 
-        "description": "Needs to be called when the behavior of the webRequest handlers has changed to prevent incorrect handling due to caching. This function call is expensive. Don't call it often.", 
-        "name": "handlerBehaviorChanged", 
+        "async": "callback",
+        "description": "Needs to be called when the behavior of the webRequest handlers has changed to prevent incorrect handling due to caching. This function call is expensive. Don't call it often.",
+        "name": "handlerBehaviorChanged",
         "parameters": [
           {
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "...", 
-        "name": "filterResponseData", 
+        "description": "...",
+        "name": "filterResponseData",
         "parameters": [
           {
-            "name": "requestId", 
+            "name": "requestId",
             "type": "string"
           }
-        ], 
+        ],
         "permissions": [
           "webRequestBlocking"
-        ], 
+        ],
         "returns": {
           "additionalProperties": {
             "type": "any"
-          }, 
-          "isInstanceOf": "StreamFilter", 
+          },
+          "isInstanceOf": "StreamFilter",
           "type": "object"
-        }, 
+        },
+        "type": "function"
+      },
+      {
+        "async": true,
+        "description": "Retrieves the security information for the request.  Returns a promise that will resolve to a SecurityInfo object.",
+        "name": "getSecurityInfo",
+        "parameters": [
+          {
+            "name": "requestId",
+            "type": "string"
+          },
+          {
+            "name": "options",
+            "optional": true,
+            "properties": {
+              "certificateChain": {
+                "description": "Include the entire certificate chain.",
+                "optional": true,
+                "type": "boolean"
+              },
+              "rawDER": {
+                "description": "Include raw certificate data for processing by the extension.",
+                "optional": true,
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          }
+        ],
         "type": "function"
       }
-    ], 
-    "namespace": "webRequest", 
+    ],
+    "namespace": "webRequest",
     "permissions": [
       "webRequest"
-    ], 
+    ],
     "properties": {
       "MAX_HANDLER_BEHAVIOR_CHANGED_CALLS_PER_10_MINUTES": {
-        "description": "The maximum number of times that <code>handlerBehaviorChanged</code> can be called per 10 minute sustained interval. <code>handlerBehaviorChanged</code> is an expensive function call that shouldn't be called often.", 
+        "description": "The maximum number of times that <code>handlerBehaviorChanged</code> can be called per 10 minute sustained interval. <code>handlerBehaviorChanged</code> is an expensive function call that shouldn't be called often.",
         "value": 20
       }
-    }, 
+    },
     "types": [
       {
         "enum": [
-          "main_frame", 
-          "sub_frame", 
-          "stylesheet", 
-          "script", 
-          "image", 
-          "object", 
-          "object_subrequest", 
-          "xmlhttprequest", 
-          "xbl", 
-          "xslt", 
-          "ping", 
-          "beacon", 
-          "xml_dtd", 
-          "font", 
-          "media", 
-          "websocket", 
-          "csp_report", 
-          "imageset", 
-          "web_manifest", 
+          "main_frame",
+          "sub_frame",
+          "stylesheet",
+          "script",
+          "image",
+          "object",
+          "object_subrequest",
+          "xmlhttprequest",
+          "xbl",
+          "xslt",
+          "ping",
+          "beacon",
+          "xml_dtd",
+          "font",
+          "media",
+          "websocket",
+          "csp_report",
+          "imageset",
+          "web_manifest",
+          "speculative",
           "other"
-        ], 
-        "id": "ResourceType", 
+        ],
+        "id": "ResourceType",
         "type": "string"
-      }, 
+      },
       {
         "enum": [
-          "blocking", 
+          "blocking",
           "requestBody"
-        ], 
-        "id": "OnBeforeRequestOptions", 
+        ],
+        "id": "OnBeforeRequestOptions",
+        "postprocess": "webRequestBlockingPermissionRequired",
         "type": "string"
-      }, 
+      },
       {
         "enum": [
-          "requestHeaders", 
+          "requestHeaders",
           "blocking"
-        ], 
-        "id": "OnBeforeSendHeadersOptions", 
+        ],
+        "id": "OnBeforeSendHeadersOptions",
+        "postprocess": "webRequestBlockingPermissionRequired",
         "type": "string"
-      }, 
+      },
       {
         "enum": [
           "requestHeaders"
-        ], 
-        "id": "OnSendHeadersOptions", 
+        ],
+        "id": "OnSendHeadersOptions",
         "type": "string"
-      }, 
+      },
       {
         "enum": [
-          "blocking", 
+          "blocking",
           "responseHeaders"
-        ], 
-        "id": "OnHeadersReceivedOptions", 
+        ],
+        "id": "OnHeadersReceivedOptions",
+        "postprocess": "webRequestBlockingPermissionRequired",
         "type": "string"
-      }, 
+      },
       {
         "enum": [
-          "responseHeaders", 
-          "blocking", 
+          "responseHeaders",
+          "blocking",
           "asyncBlocking"
-        ], 
-        "id": "OnAuthRequiredOptions", 
+        ],
+        "id": "OnAuthRequiredOptions",
+        "postprocess": "webRequestBlockingPermissionRequired",
         "type": "string"
-      }, 
+      },
       {
         "enum": [
           "responseHeaders"
-        ], 
-        "id": "OnResponseStartedOptions", 
+        ],
+        "id": "OnResponseStartedOptions",
         "type": "string"
-      }, 
+      },
       {
         "enum": [
           "responseHeaders"
-        ], 
-        "id": "OnBeforeRedirectOptions", 
+        ],
+        "id": "OnBeforeRedirectOptions",
         "type": "string"
-      }, 
+      },
       {
         "enum": [
           "responseHeaders"
-        ], 
-        "id": "OnCompletedOptions", 
+        ],
+        "id": "OnCompletedOptions",
         "type": "string"
-      }, 
+      },
       {
-        "description": "An object describing filters to apply to webRequest events.", 
-        "id": "RequestFilter", 
+        "description": "An object describing filters to apply to webRequest events.",
+        "id": "RequestFilter",
         "properties": {
+          "incognito": {
+            "description": "If provided, requests that do not match the incognito state will be filtered out.",
+            "optional": true,
+            "type": "boolean"
+          },
           "tabId": {
-            "optional": true, 
+            "optional": true,
             "type": "integer"
-          }, 
+          },
           "types": {
-            "description": "A list of request types. Requests that cannot match any of the types will be filtered out.", 
+            "description": "A list of request types. Requests that cannot match any of the types will be filtered out.",
             "items": {
               "$ref": "ResourceType"
-            }, 
-            "minItems": 1, 
-            "optional": true, 
+            },
+            "minItems": 1,
+            "optional": true,
             "type": "array"
-          }, 
+          },
           "urls": {
-            "description": "A list of URLs or URL patterns. Requests that cannot match any of the URLs will be filtered out.", 
+            "description": "A list of URLs or URL patterns. Requests that cannot match any of the URLs will be filtered out.",
             "items": {
               "type": "string"
-            }, 
-            "minItems": 1, 
+            },
+            "minItems": 1,
             "type": "array"
-          }, 
+          },
           "windowId": {
-            "optional": true, 
+            "optional": true,
             "type": "integer"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       {
-        "description": "An array of HTTP headers. Each header is represented as a dictionary containing the keys <code>name</code> and either <code>value</code> or <code>binaryValue</code>.", 
-        "id": "HttpHeaders", 
+        "description": "An array of HTTP headers. Each header is represented as a dictionary containing the keys <code>name</code> and either <code>value</code> or <code>binaryValue</code>.",
+        "id": "HttpHeaders",
         "items": {
           "properties": {
             "binaryValue": {
-              "description": "Value of the HTTP header if it cannot be represented by UTF-8, stored as individual byte values (0..255).", 
+              "description": "Value of the HTTP header if it cannot be represented by UTF-8, stored as individual byte values (0..255).",
               "items": {
                 "type": "integer"
-              }, 
-              "optional": true, 
+              },
+              "optional": true,
               "type": "array"
-            }, 
+            },
             "name": {
-              "description": "Name of the HTTP header.", 
+              "description": "Name of the HTTP header.",
               "type": "string"
-            }, 
+            },
             "value": {
-              "description": "Value of the HTTP header if it can be represented by UTF-8.", 
-              "optional": true, 
+              "description": "Value of the HTTP header if it can be represented by UTF-8.",
+              "optional": true,
               "type": "string"
             }
-          }, 
+          },
           "type": "object"
-        }, 
+        },
         "type": "array"
-      }, 
+      },
       {
-        "description": "Returns value for event handlers that have the 'blocking' extraInfoSpec applied. Allows the event handler to modify network requests.", 
-        "id": "BlockingResponse", 
+        "description": "Returns value for event handlers that have the 'blocking' extraInfoSpec applied. Allows the event handler to modify network requests.",
+        "id": "BlockingResponse",
         "properties": {
           "authCredentials": {
-            "description": "Only used as a response to the onAuthRequired event. If set, the request is made using the supplied credentials.", 
-            "optional": true, 
+            "description": "Only used as a response to the onAuthRequired event. If set, the request is made using the supplied credentials.",
+            "optional": true,
             "properties": {
               "password": {
                 "type": "string"
-              }, 
+              },
               "username": {
                 "type": "string"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           "cancel": {
-            "description": "If true, the request is cancelled. Used in onBeforeRequest, this prevents the request from being sent.", 
-            "optional": true, 
+            "description": "If true, the request is cancelled. Used in onBeforeRequest, this prevents the request from being sent.",
+            "optional": true,
             "type": "boolean"
-          }, 
+          },
           "redirectUrl": {
-            "description": "Only used as a response to the onBeforeRequest and onHeadersReceived events. If set, the original request is prevented from being sent/completed and is instead redirected to the given URL. Redirections to non-HTTP schemes such as data: are allowed. Redirects initiated by a redirect action use the original request method for the redirect, with one exception: If the redirect is initiated at the onHeadersReceived stage, then the redirect will be issued using the GET method.", 
-            "optional": true, 
+            "description": "Only used as a response to the onBeforeRequest and onHeadersReceived events. If set, the original request is prevented from being sent/completed and is instead redirected to the given URL. Redirections to non-HTTP schemes such as data: are allowed. Redirects initiated by a redirect action use the original request method for the redirect, with one exception: If the redirect is initiated at the onHeadersReceived stage, then the redirect will be issued using the GET method.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "requestHeaders": {
-            "$ref": "HttpHeaders", 
-            "description": "Only used as a response to the onBeforeSendHeaders event. If set, the request is made with these request headers instead.", 
+            "$ref": "HttpHeaders",
+            "description": "Only used as a response to the onBeforeSendHeaders event. If set, the request is made with these request headers instead.",
             "optional": true
-          }, 
+          },
           "responseHeaders": {
-            "$ref": "HttpHeaders", 
-            "description": "Only used as a response to the onHeadersReceived event. If set, the server is assumed to have responded with these response headers instead. Only return <code>responseHeaders</code> if you really want to modify the headers in order to limit the number of conflicts (only one extension may modify <code>responseHeaders</code> for each request).", 
+            "$ref": "HttpHeaders",
+            "description": "Only used as a response to the onHeadersReceived event. If set, the server is assumed to have responded with these response headers instead. Only return <code>responseHeaders</code> if you really want to modify the headers in order to limit the number of conflicts (only one extension may modify <code>responseHeaders</code> for each request).",
             "optional": true
+          },
+          "upgradeToSecure": {
+            "description": "Only used as a response to the onBeforeRequest event. If set, the original request is prevented from being sent/completed and is instead upgraded to a secure request.  If any extension returns <code>redirectUrl</code> during onBeforeRequest, <code>upgradeToSecure</code> will have no affect.",
+            "optional": true,
+            "type": "boolean"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       {
-        "description": "Contains data uploaded in a URL request.", 
-        "id": "UploadData", 
+        "description": "Contains the certificate properties of the request if it is a secure request.",
+        "id": "CertificateInfo",
+        "properties": {
+          "fingerprint": {
+            "properties": {
+              "sha1": {
+                "type": "string"
+              },
+              "sha256": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "isBuiltInRoot": {
+            "type": "boolean"
+          },
+          "issuer": {
+            "type": "string"
+          },
+          "rawDER": {
+            "items": {
+              "type": "integer"
+            },
+            "optional": true,
+            "type": "array"
+          },
+          "serialNumber": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "subjectPublicKeyInfoDigest": {
+            "properties": {
+              "sha256": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "validity": {
+            "description": "Contains start and end timestamps.",
+            "properties": {
+              "end": {
+                "type": "integer"
+              },
+              "start": {
+                "type": "integer"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      {
+        "enum": [
+          "not_applicable",
+          "policy_compliant",
+          "policy_not_enough_scts",
+          "policy_not_diverse_scts"
+        ],
+        "id": "CertificateTransparencyStatus",
+        "type": "string"
+      },
+      {
+        "enum": [
+          "cipher"
+        ],
+        "id": "TransportWeaknessReasons",
+        "type": "string"
+      },
+      {
+        "description": "Contains the security properties of the request (ie. SSL/TLS information).",
+        "id": "SecurityInfo",
+        "properties": {
+          "certificateTransparencyStatus": {
+            "$ref": "CertificateTransparencyStatus",
+            "description": "Certificate transparency compliance per RFC 6962.  See <code>https://www.certificate-transparency.org/what-is-ct</code> for more information.",
+            "optional": true
+          },
+          "certificates": {
+            "description": "Certificate data if state is \"secure\".  Will only contain one entry unless <code>certificateChain</code> is passed as an option.",
+            "items": {
+              "$ref": "CertificateInfo"
+            },
+            "type": "array"
+          },
+          "cipherSuite": {
+            "description": "The cipher suite used in this request if state is \"secure\".",
+            "optional": true,
+            "type": "string"
+          },
+          "errorMessage": {
+            "description": "Error message if state is \"broken\"",
+            "optional": true,
+            "type": "string"
+          },
+          "hpkp": {
+            "description": "True if host uses Public Key Pinning and state is \"secure\".",
+            "optional": true,
+            "type": "string"
+          },
+          "hsts": {
+            "description": "True if host uses Strict Transport Security and state is \"secure\".",
+            "optional": true,
+            "type": "boolean"
+          },
+          "isDomainMismatch": {
+            "description": "The domain name does not match the certificate domain.",
+            "optional": true,
+            "type": "boolean"
+          },
+          "isExtendedValidation": {
+            "optional": true,
+            "type": "boolean"
+          },
+          "isNotValidAtThisTime": {
+            "description": "The certificate is either expired or is not yet valid.  See <code>CertificateInfo.validity</code> for start and end dates.",
+            "optional": true,
+            "type": "boolean"
+          },
+          "isUntrusted": {
+            "optional": true,
+            "type": "boolean"
+          },
+          "keaGroupName": {
+            "description": "The key exchange algorithm used in this request if state is \"secure\".",
+            "optional": true,
+            "type": "string"
+          },
+          "protocolVersion": {
+            "description": "Protocol version if state is \"secure\"",
+            "enum": [
+              "TLSv1",
+              "TLSv1.1",
+              "TLSv1.2",
+              "TLSv1.3",
+              "unknown"
+            ],
+            "optional": true,
+            "type": "string"
+          },
+          "signatureSchemeName": {
+            "description": "The signature scheme used in this request if state is \"secure\".",
+            "optional": true,
+            "type": "string"
+          },
+          "state": {
+            "enum": [
+              "insecure",
+              "weak",
+              "broken",
+              "secure"
+            ],
+            "type": "string"
+          },
+          "weaknessReasons": {
+            "description": "list of reasons that cause the request to be considered weak, if state is \"weak\"",
+            "items": {
+              "$ref": "TransportWeaknessReasons"
+            },
+            "optional": true,
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      {
+        "description": "Contains data uploaded in a URL request.",
+        "id": "UploadData",
         "properties": {
           "bytes": {
-            "description": "An ArrayBuffer with a copy of the data.", 
-            "optional": true, 
+            "description": "An ArrayBuffer with a copy of the data.",
+            "optional": true,
             "type": "any"
-          }, 
+          },
           "file": {
-            "description": "A string with the file's path and name.", 
-            "optional": true, 
+            "description": "A string with the file's path and name.",
+            "optional": true,
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
       }
     ]
-  }, 
+  },
   {
-    "description": "Use the <code>browser.windows</code> API to interact with browser windows. You can use this API to create, modify, and rearrange windows in the browser.", 
+    "description": "Use the <code>browser.windows</code> API to interact with browser windows. You can use this API to create, modify, and rearrange windows in the browser.",
     "events": [
       {
-        "description": "Fired when a window is created.", 
+        "description": "Fired when a window is created.",
         "filters": [
           {
-            "description": "Conditions that the window's type being created must satisfy. By default it will satisfy <code>['app', 'normal', 'panel', 'popup']</code>, with <code>'app'</code> and <code>'panel'</code> window types limited to the extension's own windows.", 
+            "description": "Conditions that the window's type being created must satisfy. By default it will satisfy <code>['app', 'normal', 'panel', 'popup']</code>, with <code>'app'</code> and <code>'panel'</code> window types limited to the extension's own windows.",
             "items": {
               "$ref": "WindowType"
-            }, 
-            "name": "windowTypes", 
+            },
+            "name": "windowTypes",
             "type": "array"
           }
-        ], 
-        "name": "onCreated", 
+        ],
+        "name": "onCreated",
         "parameters": [
           {
-            "$ref": "Window", 
-            "description": "Details of the window that was created.", 
+            "$ref": "Window",
+            "description": "Details of the window that was created.",
             "name": "window"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Fired when a window is removed (closed).", 
+        "description": "Fired when a window is removed (closed).",
         "filters": [
           {
-            "description": "Conditions that the window's type being removed must satisfy. By default it will satisfy <code>['app', 'normal', 'panel', 'popup']</code>, with <code>'app'</code> and <code>'panel'</code> window types limited to the extension's own windows.", 
+            "description": "Conditions that the window's type being removed must satisfy. By default it will satisfy <code>['app', 'normal', 'panel', 'popup']</code>, with <code>'app'</code> and <code>'panel'</code> window types limited to the extension's own windows.",
             "items": {
               "$ref": "WindowType"
-            }, 
-            "name": "windowTypes", 
+            },
+            "name": "windowTypes",
             "type": "array"
           }
-        ], 
-        "name": "onRemoved", 
+        ],
+        "name": "onRemoved",
         "parameters": [
           {
-            "description": "ID of the removed window.", 
-            "minimum": 0, 
-            "name": "windowId", 
+            "description": "ID of the removed window.",
+            "minimum": 0,
+            "name": "windowId",
             "type": "integer"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "description": "Fired when the currently focused window changes. Will be $(ref:windows.WINDOW_ID_NONE) if all browser windows have lost focus. Note: On some Linux window managers, WINDOW_ID_NONE will always be sent immediately preceding a switch from one browser window to another.", 
+        "description": "Fired when the currently focused window changes. Will be $(ref:windows.WINDOW_ID_NONE) if all browser windows have lost focus. Note: On some Linux window managers, WINDOW_ID_NONE will always be sent immediately preceding a switch from one browser window to another.",
         "filters": [
           {
-            "description": "Conditions that the window's type being removed must satisfy. By default it will satisfy <code>['app', 'normal', 'panel', 'popup']</code>, with <code>'app'</code> and <code>'panel'</code> window types limited to the extension's own windows.", 
+            "description": "Conditions that the window's type being removed must satisfy. By default it will satisfy <code>['app', 'normal', 'panel', 'popup']</code>, with <code>'app'</code> and <code>'panel'</code> window types limited to the extension's own windows.",
             "items": {
               "$ref": "WindowType"
-            }, 
-            "name": "windowTypes", 
+            },
+            "name": "windowTypes",
             "type": "array"
           }
-        ], 
-        "name": "onFocusChanged", 
+        ],
+        "name": "onFocusChanged",
         "parameters": [
           {
-            "description": "ID of the newly focused window.", 
-            "minimum": -1, 
-            "name": "windowId", 
+            "description": "ID of the newly focused window.",
+            "minimum": -1,
+            "name": "windowId",
             "type": "integer"
           }
-        ], 
+        ],
         "type": "function"
       }
-    ], 
+    ],
     "functions": [
       {
-        "async": "callback", 
-        "description": "Gets details about a window.", 
-        "name": "get", 
+        "async": "callback",
+        "description": "Gets details about a window.",
+        "name": "get",
         "parameters": [
           {
-            "minimum": -2, 
-            "name": "windowId", 
+            "minimum": -2,
+            "name": "windowId",
             "type": "integer"
-          }, 
+          },
           {
-            "description": "", 
-            "name": "getInfo", 
-            "optional": true, 
-            "properties": {
-              "populate": {
-                "description": "If true, the $(ref:windows.Window) object will have a <var>tabs</var> property that contains a list of the $(ref:tabs.Tab) objects. The <code>Tab</code> objects only contain the <code>url</code>, <code>title</code> and <code>favIconUrl</code> properties if the extension's manifest file includes the <code>\"tabs\"</code> permission.", 
-                "optional": true, 
-                "type": "boolean"
-              }, 
-              "windowTypes": {
-                "description": "If set, the $(ref:windows.Window) returned will be filtered based on its type. If unset the default filter is set to <code>['app', 'normal', 'panel', 'popup']</code>, with <code>'app'</code> and <code>'panel'</code> window types limited to the extension's own windows.", 
-                "items": {
-                  "$ref": "WindowType"
-                }, 
-                "optional": true, 
-                "type": "array"
-              }
-            }, 
-            "type": "object"
-          }, 
+            "$ref": "GetInfo",
+            "name": "getInfo",
+            "optional": true
+          },
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
-                "$ref": "Window", 
+                "$ref": "Window",
                 "name": "window"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Gets the $(topic:current-window)[current window].", 
-        "name": "getCurrent", 
+        "async": "callback",
+        "description": "Gets the $(topic:current-window)[current window].",
+        "name": "getCurrent",
         "parameters": [
           {
-            "description": "", 
-            "name": "getInfo", 
-            "optional": true, 
-            "properties": {
-              "populate": {
-                "description": "If true, the $(ref:windows.Window) object will have a <var>tabs</var> property that contains a list of the $(ref:tabs.Tab) objects. The <code>Tab</code> objects only contain the <code>url</code>, <code>title</code> and <code>favIconUrl</code> properties if the extension's manifest file includes the <code>\"tabs\"</code> permission.", 
-                "optional": true, 
-                "type": "boolean"
-              }, 
-              "windowTypes": {
-                "description": "If set, the $(ref:windows.Window) returned will be filtered based on its type. If unset the default filter is set to <code>['app', 'normal', 'panel', 'popup']</code>, with <code>'app'</code> and <code>'panel'</code> window types limited to the extension's own windows.", 
-                "items": {
-                  "$ref": "WindowType"
-                }, 
-                "optional": true, 
-                "type": "array"
-              }
-            }, 
-            "type": "object"
-          }, 
+            "$ref": "GetInfo",
+            "name": "getInfo",
+            "optional": true
+          },
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
-                "$ref": "Window", 
+                "$ref": "Window",
                 "name": "window"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Gets the window that was most recently focused &mdash; typically the window 'on top'.", 
-        "name": "getLastFocused", 
+        "async": "callback",
+        "description": "Gets the window that was most recently focused &mdash; typically the window 'on top'.",
+        "name": "getLastFocused",
         "parameters": [
           {
-            "description": "", 
-            "name": "getInfo", 
-            "optional": true, 
-            "properties": {
-              "populate": {
-                "description": "If true, the $(ref:windows.Window) object will have a <var>tabs</var> property that contains a list of the $(ref:tabs.Tab) objects. The <code>Tab</code> objects only contain the <code>url</code>, <code>title</code> and <code>favIconUrl</code> properties if the extension's manifest file includes the <code>\"tabs\"</code> permission.", 
-                "optional": true, 
-                "type": "boolean"
-              }, 
-              "windowTypes": {
-                "description": "If set, the $(ref:windows.Window) returned will be filtered based on its type. If unset the default filter is set to <code>['app', 'normal', 'panel', 'popup']</code>, with <code>'app'</code> and <code>'panel'</code> window types limited to the extension's own windows.", 
-                "items": {
-                  "$ref": "WindowType"
-                }, 
-                "optional": true, 
-                "type": "array"
-              }
-            }, 
-            "type": "object"
-          }, 
+            "$ref": "GetInfo",
+            "name": "getInfo",
+            "optional": true
+          },
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
-                "$ref": "Window", 
+                "$ref": "Window",
                 "name": "window"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Gets all windows.", 
-        "name": "getAll", 
+        "async": "callback",
+        "description": "Gets all windows.",
+        "name": "getAll",
         "parameters": [
           {
-            "description": "", 
-            "name": "getInfo", 
-            "optional": true, 
+            "$import": "GetInfo",
+            "description": "Specifies properties used to filter the $(ref:windows.Window) returned and to determine whether they should contain a list of the $(ref:tabs.Tab) objects.",
+            "name": "getInfo",
+            "optional": true,
             "properties": {
-              "populate": {
-                "description": "If true, each $(ref:windows.Window) object will have a <var>tabs</var> property that contains a list of the $(ref:tabs.Tab) objects for that window. The <code>Tab</code> objects only contain the <code>url</code>, <code>title</code> and <code>favIconUrl</code> properties if the extension's manifest file includes the <code>\"tabs\"</code> permission.", 
-                "optional": true, 
-                "type": "boolean"
-              }, 
               "windowTypes": {
-                "description": "If set, the $(ref:windows.Window) returned will be filtered based on its type. If unset the default filter is set to <code>['app', 'normal', 'panel', 'popup']</code>, with <code>'app'</code> and <code>'panel'</code> window types limited to the extension's own windows.", 
+                "description": "If set, the $(ref:windows.Window) returned will be filtered based on its type. If unset the default filter is set to <code>['app', 'normal', 'panel', 'popup']</code>, with <code>'app'</code> and <code>'panel'</code> window types limited to the extension's own windows.",
                 "items": {
                   "$ref": "WindowType"
-                }, 
-                "optional": true, 
+                },
+                "optional": true,
                 "type": "array"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "name": "callback", 
+            "name": "callback",
             "parameters": [
               {
                 "items": {
                   "$ref": "Window"
-                }, 
-                "name": "windows", 
+                },
+                "name": "windows",
                 "type": "array"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Creates (opens) a new browser with any optional sizing, position or default URL provided.", 
-        "name": "create", 
+        "async": "callback",
+        "description": "Creates (opens) a new browser with any optional sizing, position or default URL provided.",
+        "name": "create",
         "parameters": [
           {
-            "default": {}, 
-            "name": "createData", 
-            "optional": true, 
+            "default": {},
+            "name": "createData",
+            "optional": true,
             "properties": {
               "allowScriptsToClose": {
-                "description": "Allow scripts to close the window.", 
-                "optional": true, 
+                "description": "Allow scripts to close the window.",
+                "optional": true,
                 "type": "boolean"
-              }, 
-              "focused": {
-                "description": "If true, opens an active window. If false, opens an inactive window.", 
-                "optional": true, 
-                "type": "boolean", 
-                "unsupported": true
-              }, 
-              "height": {
-                "description": "The height in pixels of the new window, including the frame. If not specified defaults to a natural height.", 
-                "minimum": 0, 
-                "optional": true, 
-                "type": "integer"
-              }, 
-              "incognito": {
-                "description": "Whether the new window should be an incognito window.", 
-                "optional": true, 
-                "type": "boolean"
-              }, 
-              "left": {
-                "description": "The number of pixels to position the new window from the left edge of the screen. If not specified, the new window is offset naturally from the last focused window. This value is ignored for panels.", 
-                "optional": true, 
-                "type": "integer"
-              }, 
-              "state": {
-                "$ref": "WindowState", 
-                "description": "The initial state of the window. The 'minimized', 'maximized' and 'fullscreen' states cannot be combined with 'left', 'top', 'width' or 'height'.", 
-                "optional": true
-              }, 
-              "tabId": {
-                "description": "The id of the tab for which you want to adopt to the new window.", 
-                "minimum": 0, 
-                "optional": true, 
-                "type": "integer"
-              }, 
-              "titlePreface": {
-                "description": "A string to add to the beginning of the window title.", 
-                "optional": true, 
+              },
+              "cookieStoreId": {
+                "description": "The CookieStoreId to use for all tabs that were created when the window is opened.",
+                "optional": true,
                 "type": "string"
-              }, 
-              "top": {
-                "description": "The number of pixels to position the new window from the top edge of the screen. If not specified, the new window is offset naturally from the last focused window. This value is ignored for panels.", 
-                "optional": true, 
+              },
+              "focused": {
+                "description": "If true, opens an active window. If false, opens an inactive window.",
+                "optional": true,
+                "type": "boolean",
+                "unsupported": true
+              },
+              "height": {
+                "description": "The height in pixels of the new window, including the frame. If not specified defaults to a natural height.",
+                "minimum": 0,
+                "optional": true,
                 "type": "integer"
-              }, 
-              "type": {
-                "$ref": "CreateType", 
-                "description": "Specifies what type of browser window to create. The 'panel' and 'detached_panel' types create a popup unless the '--enable-panels' flag is set.", 
+              },
+              "incognito": {
+                "description": "Whether the new window should be an incognito window.",
+                "optional": true,
+                "type": "boolean"
+              },
+              "left": {
+                "description": "The number of pixels to position the new window from the left edge of the screen. If not specified, the new window is offset naturally from the last focused window. This value is ignored for panels.",
+                "optional": true,
+                "type": "integer"
+              },
+              "state": {
+                "$ref": "WindowState",
+                "description": "The initial state of the window. The 'minimized', 'maximized' and 'fullscreen' states cannot be combined with 'left', 'top', 'width' or 'height'.",
                 "optional": true
-              }, 
+              },
+              "tabId": {
+                "description": "The id of the tab for which you want to adopt to the new window.",
+                "minimum": 0,
+                "optional": true,
+                "type": "integer"
+              },
+              "titlePreface": {
+                "description": "A string to add to the beginning of the window title.",
+                "optional": true,
+                "type": "string"
+              },
+              "top": {
+                "description": "The number of pixels to position the new window from the top edge of the screen. If not specified, the new window is offset naturally from the last focused window. This value is ignored for panels.",
+                "optional": true,
+                "type": "integer"
+              },
+              "type": {
+                "$ref": "CreateType",
+                "description": "Specifies what type of browser window to create. The 'panel' and 'detached_panel' types create a popup unless the '--enable-panels' flag is set.",
+                "optional": true
+              },
               "url": {
                 "choices": [
                   {
-                    "format": "relativeUrl", 
+                    "format": "relativeUrl",
                     "type": "string"
-                  }, 
+                  },
                   {
                     "items": {
-                      "format": "relativeUrl", 
+                      "format": "relativeUrl",
                       "type": "string"
-                    }, 
+                    },
                     "type": "array"
                   }
-                ], 
-                "description": "A URL or array of URLs to open as tabs in the window. Fully-qualified URLs must include a scheme (i.e. 'http://www.google.com', not 'www.google.com'). Relative URLs will be relative to the current page within the extension. Defaults to the New Tab Page.", 
+                ],
+                "description": "A URL or array of URLs to open as tabs in the window. Fully-qualified URLs must include a scheme (i.e. 'http://www.google.com', not 'www.google.com'). Relative URLs will be relative to the current page within the extension. Defaults to the New Tab Page.",
                 "optional": true
-              }, 
+              },
               "width": {
-                "description": "The width in pixels of the new window, including the frame. If not specified defaults to a natural width.", 
-                "minimum": 0, 
-                "optional": true, 
+                "description": "The width in pixels of the new window, including the frame. If not specified defaults to a natural width.",
+                "minimum": 0,
+                "optional": true,
                 "type": "integer"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
+            "name": "callback",
+            "optional": true,
             "parameters": [
               {
-                "$ref": "Window", 
-                "description": "Contains details about the created window.", 
-                "name": "window", 
+                "$ref": "Window",
+                "description": "Contains details about the created window.",
+                "name": "window",
                 "optional": true
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Updates the properties of a window. Specify only the properties that you want to change; unspecified properties will be left unchanged.", 
-        "name": "update", 
+        "async": "callback",
+        "description": "Updates the properties of a window. Specify only the properties that you want to change; unspecified properties will be left unchanged.",
+        "name": "update",
         "parameters": [
           {
-            "minimum": -2, 
-            "name": "windowId", 
+            "minimum": -2,
+            "name": "windowId",
             "type": "integer"
-          }, 
+          },
           {
-            "name": "updateInfo", 
+            "name": "updateInfo",
             "properties": {
               "drawAttention": {
-                "description": "If true, causes the window to be displayed in a manner that draws the user's attention to the window, without changing the focused window. The effect lasts until the user changes focus to the window. This option has no effect if the window already has focus. Set to false to cancel a previous draw attention request.", 
-                "optional": true, 
+                "description": "If true, causes the window to be displayed in a manner that draws the user's attention to the window, without changing the focused window. The effect lasts until the user changes focus to the window. This option has no effect if the window already has focus. Set to false to cancel a previous draw attention request.",
+                "optional": true,
                 "type": "boolean"
-              }, 
+              },
               "focused": {
-                "description": "If true, brings the window to the front. If false, brings the next window in the z-order to the front.", 
-                "optional": true, 
+                "description": "If true, brings the window to the front. If false, brings the next window in the z-order to the front.",
+                "optional": true,
                 "type": "boolean"
-              }, 
+              },
               "height": {
-                "description": "The height to resize the window to in pixels. This value is ignored for panels.", 
-                "minimum": 0, 
-                "optional": true, 
+                "description": "The height to resize the window to in pixels. This value is ignored for panels.",
+                "minimum": 0,
+                "optional": true,
                 "type": "integer"
-              }, 
+              },
               "left": {
-                "description": "The offset from the left edge of the screen to move the window to in pixels. This value is ignored for panels.", 
-                "optional": true, 
+                "description": "The offset from the left edge of the screen to move the window to in pixels. This value is ignored for panels.",
+                "optional": true,
                 "type": "integer"
-              }, 
+              },
               "state": {
-                "$ref": "WindowState", 
-                "description": "The new state of the window. The 'minimized', 'maximized' and 'fullscreen' states cannot be combined with 'left', 'top', 'width' or 'height'.", 
+                "$ref": "WindowState",
+                "description": "The new state of the window. The 'minimized', 'maximized' and 'fullscreen' states cannot be combined with 'left', 'top', 'width' or 'height'.",
                 "optional": true
-              }, 
+              },
               "titlePreface": {
-                "description": "A string to add to the beginning of the window title.", 
-                "optional": true, 
+                "description": "A string to add to the beginning of the window title.",
+                "optional": true,
                 "type": "string"
-              }, 
+              },
               "top": {
-                "description": "The offset from the top edge of the screen to move the window to in pixels. This value is ignored for panels.", 
-                "optional": true, 
+                "description": "The offset from the top edge of the screen to move the window to in pixels. This value is ignored for panels.",
+                "optional": true,
                 "type": "integer"
-              }, 
+              },
               "width": {
-                "description": "The width to resize the window to in pixels. This value is ignored for panels.", 
-                "minimum": 0, 
-                "optional": true, 
+                "description": "The width to resize the window to in pixels. This value is ignored for panels.",
+                "minimum": 0,
+                "optional": true,
                 "type": "integer"
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
+            "name": "callback",
+            "optional": true,
             "parameters": [
               {
-                "$ref": "Window", 
+                "$ref": "Window",
                 "name": "window"
               }
-            ], 
+            ],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
-      }, 
+      },
       {
-        "async": "callback", 
-        "description": "Removes (closes) a window, and all the tabs inside it.", 
-        "name": "remove", 
+        "async": "callback",
+        "description": "Removes (closes) a window, and all the tabs inside it.",
+        "name": "remove",
         "parameters": [
           {
-            "minimum": 0, 
-            "name": "windowId", 
+            "minimum": -2,
+            "name": "windowId",
             "type": "integer"
-          }, 
+          },
           {
-            "name": "callback", 
-            "optional": true, 
-            "parameters": [], 
+            "name": "callback",
+            "optional": true,
+            "parameters": [],
             "type": "function"
           }
-        ], 
+        ],
         "type": "function"
       }
-    ], 
-    "namespace": "windows", 
+    ],
+    "namespace": "windows",
     "properties": {
       "WINDOW_ID_CURRENT": {
-        "description": "The windowId value that represents the $(topic:current-window)[current window].", 
+        "description": "The windowId value that represents the $(topic:current-window)[current window].",
         "value": -2
-      }, 
+      },
       "WINDOW_ID_NONE": {
-        "description": "The windowId value that represents the absence of a browser window.", 
+        "description": "The windowId value that represents the absence of a browser window.",
         "value": -1
       }
-    }, 
+    },
     "types": [
       {
-        "description": "The type of browser window this is. Under some circumstances a Window may not be assigned type property, for example when querying closed windows from the $(ref:sessions) API.", 
+        "description": "The type of browser window this is. Under some circumstances a Window may not be assigned type property, for example when querying closed windows from the $(ref:sessions) API.",
         "enum": [
-          "normal", 
-          "popup", 
-          "panel", 
-          "app", 
+          "normal",
+          "popup",
+          "panel",
+          "app",
           "devtools"
-        ], 
-        "id": "WindowType", 
+        ],
+        "id": "WindowType",
         "type": "string"
-      }, 
+      },
       {
-        "description": "The state of this browser window. Under some circumstances a Window may not be assigned state property, for example when querying closed windows from the $(ref:sessions) API.", 
+        "description": "The state of this browser window. Under some circumstances a Window may not be assigned state property, for example when querying closed windows from the $(ref:sessions) API.",
         "enum": [
-          "normal", 
-          "minimized", 
-          "maximized", 
-          "fullscreen", 
+          "normal",
+          "minimized",
+          "maximized",
+          "fullscreen",
           "docked"
-        ], 
-        "id": "WindowState", 
+        ],
+        "id": "WindowState",
         "type": "string"
-      }, 
+      },
       {
-        "id": "Window", 
+        "id": "Window",
         "properties": {
           "alwaysOnTop": {
-            "description": "Whether the window is set to be always on top.", 
+            "description": "Whether the window is set to be always on top.",
             "type": "boolean"
-          }, 
+          },
           "focused": {
-            "description": "Whether the window is currently the focused window.", 
+            "description": "Whether the window is currently the focused window.",
             "type": "boolean"
-          }, 
+          },
           "height": {
-            "description": "The height of the window, including the frame, in pixels. Under some circumstances a Window may not be assigned height property, for example when querying closed windows from the $(ref:sessions) API.", 
-            "optional": true, 
+            "description": "The height of the window, including the frame, in pixels. Under some circumstances a Window may not be assigned height property, for example when querying closed windows from the $(ref:sessions) API.",
+            "optional": true,
             "type": "integer"
-          }, 
+          },
           "id": {
-            "description": "The ID of the window. Window IDs are unique within a browser session. Under some circumstances a Window may not be assigned an ID, for example when querying windows using the $(ref:sessions) API, in which case a session ID may be present.", 
-            "minimum": 0, 
-            "optional": true, 
+            "description": "The ID of the window. Window IDs are unique within a browser session. Under some circumstances a Window may not be assigned an ID, for example when querying windows using the $(ref:sessions) API, in which case a session ID may be present.",
+            "minimum": 0,
+            "optional": true,
             "type": "integer"
-          }, 
+          },
           "incognito": {
-            "description": "Whether the window is incognito.", 
+            "description": "Whether the window is incognito.",
             "type": "boolean"
-          }, 
+          },
           "left": {
-            "description": "The offset of the window from the left edge of the screen in pixels. Under some circumstances a Window may not be assigned left property, for example when querying closed windows from the $(ref:sessions) API.", 
-            "optional": true, 
+            "description": "The offset of the window from the left edge of the screen in pixels. Under some circumstances a Window may not be assigned left property, for example when querying closed windows from the $(ref:sessions) API.",
+            "optional": true,
             "type": "integer"
-          }, 
+          },
           "sessionId": {
-            "description": "The session ID used to uniquely identify a Window obtained from the $(ref:sessions) API.", 
-            "optional": true, 
+            "description": "The session ID used to uniquely identify a Window obtained from the $(ref:sessions) API.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "state": {
-            "$ref": "WindowState", 
-            "description": "The state of this browser window.", 
+            "$ref": "WindowState",
+            "description": "The state of this browser window.",
             "optional": true
-          }, 
+          },
           "tabs": {
-            "description": "Array of $(ref:tabs.Tab) objects representing the current tabs in the window.", 
+            "description": "Array of $(ref:tabs.Tab) objects representing the current tabs in the window.",
             "items": {
               "$ref": "tabs.Tab"
-            }, 
-            "optional": true, 
+            },
+            "optional": true,
             "type": "array"
-          }, 
+          },
           "title": {
-            "description": "The title of the window. Read-only.", 
-            "optional": true, 
+            "description": "The title of the window. Read-only.",
+            "optional": true,
             "type": "string"
-          }, 
+          },
           "top": {
-            "description": "The offset of the window from the top edge of the screen in pixels. Under some circumstances a Window may not be assigned top property, for example when querying closed windows from the $(ref:sessions) API.", 
-            "optional": true, 
+            "description": "The offset of the window from the top edge of the screen in pixels. Under some circumstances a Window may not be assigned top property, for example when querying closed windows from the $(ref:sessions) API.",
+            "optional": true,
             "type": "integer"
-          }, 
+          },
           "type": {
-            "$ref": "WindowType", 
-            "description": "The type of browser window this is.", 
+            "$ref": "WindowType",
+            "description": "The type of browser window this is.",
             "optional": true
-          }, 
+          },
           "width": {
-            "description": "The width of the window, including the frame, in pixels. Under some circumstances a Window may not be assigned width property, for example when querying closed windows from the $(ref:sessions) API.", 
-            "optional": true, 
+            "description": "The width of the window, including the frame, in pixels. Under some circumstances a Window may not be assigned width property, for example when querying closed windows from the $(ref:sessions) API.",
+            "optional": true,
             "type": "integer"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       {
-        "description": "Specifies what type of browser window to create. The 'panel' and 'detached_panel' types create a popup unless the '--enable-panels' flag is set.", 
+        "description": "Specifies what type of browser window to create. The 'panel' and 'detached_panel' types create a popup unless the '--enable-panels' flag is set.",
         "enum": [
-          "normal", 
-          "popup", 
-          "panel", 
+          "normal",
+          "popup",
+          "panel",
           "detached_panel"
-        ], 
-        "id": "CreateType", 
+        ],
+        "id": "CreateType",
         "type": "string"
+      },
+      {
+        "description": "Specifies whether the $(ref:windows.Window) returned should contain a list of the $(ref:tabs.Tab) objects.",
+        "id": "GetInfo",
+        "properties": {
+          "populate": {
+            "description": "If true, the $(ref:windows.Window) returned will have a <var>tabs</var> property that contains a list of the $(ref:tabs.Tab) objects. The <code>Tab</code> objects only contain the <code>url</code>, <code>title</code> and <code>favIconUrl</code> properties if the extension's manifest file includes the <code>\"tabs\"</code> permission.",
+            "optional": true,
+            "type": "boolean"
+          },
+          "windowTypes": {
+            "deprecated": true,
+            "description": "<code>windowTypes</code> is deprecated and ignored on Firefox.",
+            "items": {
+              "$ref": "WindowType"
+            },
+            "optional": true,
+            "type": "array"
+          }
+        },
+        "type": "object"
       }
     ]
   }


### PR DESCRIPTION
Fix #63
Fix #87 
Fix #89 

I took the script at #73 and converted it to Python 3.

Right now I have 18 tests failed with two different types of failures, but I don’t know how to fix them:

```
  1) webextensions webextensions browser.menus webextensions browser.menus.create should be defined:
     AssertionError: expected false to be truthy
      at Function.assert.isOk (node_modules/chai/lib/chai/interface/assert.js:85:32)                                                                                                                                                   
      at Context.<anonymous> (test/specs/chrome.methods.test.js:36:20)                                                                                                                                                                 
      at processImmediate (internal/timers.js:439:21)                                                                                                                                                                                  

  2) webextensions webextensions browser.menus webextensions browser.menus.create should have stub sync behaviour:
     TypeError: Cannot read property 'resetHistory' of undefined
      at Context.<anonymous> (test/specs/chrome.methods.test.js:42:18)                                                                                                                                                                 
      at processImmediate (internal/timers.js:439:21)                                 
```

This may be related to the fact that there is three times `webextensions` in the test name, because they are apparently the only tests to have that.