### PR TITLE
Bump urijs to 1.19.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "lodash": "^4.16.3",
     "sinon": "^7.2.3",
-    "urijs": "^1.18.2"
+    "urijs": "^1.19.6"
   },
   "devDependencies": {
     "babel-cli": "^6.16.0",


### PR DESCRIPTION
Fixes vulnerability CVE-2021-27516
also see https://github.com/medialize/URI.js/releases/tag/v1.19.6

Note: there is no package-lock.json committed to the repo. Is there a reason for this?